### PR TITLE
tooltip optimisation: evaluate content only on hover

### DIFF
--- a/src/DashboardV2.js
+++ b/src/DashboardV2.js
@@ -280,26 +280,28 @@ export default function DashboardV2() {
     const weightText = `${formatAmount(currentWeightBps, 2, 2, false)}% / ${formatAmount(targetWeightBps, 2, 2, false)}%`
 
     return (
-      <Tooltip handle={weightText} position="right-bottom">
-        Current Weight: {formatAmount(currentWeightBps, 2, 2, false)}%<br/>
-        Target Weight: {formatAmount(targetWeightBps, 2, 2, false)}%<br/>
-        <br/>
-        {currentWeightBps.lt(targetWeightBps) && <div>
-          {tokenInfo.symbol} is below its target weight.<br/>
+      <Tooltip handle={weightText} position="right-bottom" renderContent={() => {
+        return <>
+          Current Weight: {formatAmount(currentWeightBps, 2, 2, false)}%<br/>
+          Target Weight: {formatAmount(targetWeightBps, 2, 2, false)}%<br/>
           <br/>
-          Get lower fees to <Link to="/buy_glp" target="_blank" rel="noopener noreferrer">buy GLP</Link> with {tokenInfo.symbol},&nbsp;
-          and to <Link to="/trade" target="_blank" rel="noopener noreferrer">swap</Link> {tokenInfo.symbol} for other tokens.
-        </div>}
-        {currentWeightBps.gt(targetWeightBps) && <div>
-          {tokenInfo.symbol} is above its target weight.<br/>
+          {currentWeightBps.lt(targetWeightBps) && <div>
+            {tokenInfo.symbol} is below its target weight.<br/>
+            <br/>
+            Get lower fees to <Link to="/buy_glp" target="_blank" rel="noopener noreferrer">buy GLP</Link> with {tokenInfo.symbol},&nbsp;
+            and to <Link to="/trade" target="_blank" rel="noopener noreferrer">swap</Link> {tokenInfo.symbol} for other tokens.
+          </div>}
+          {currentWeightBps.gt(targetWeightBps) && <div>
+            {tokenInfo.symbol} is above its target weight.<br/>
+            <br/>
+            Get lower fees to <Link to="/trade" target="_blank" rel="noopener noreferrer">swap</Link> tokens for {tokenInfo.symbol}.
+          </div>}
           <br/>
-          Get lower fees to <Link to="/trade" target="_blank" rel="noopener noreferrer">swap</Link> tokens for {tokenInfo.symbol}.
-        </div>}
-        <br/>
-        <div>
-          <a href="https://gmxio.gitbook.io/gmx/glp" target="_blank" rel="noopener noreferrer">More Info</a>
-        </div>
-      </Tooltip>
+          <div>
+            <a href="https://gmxio.gitbook.io/gmx/glp" target="_blank" rel="noopener noreferrer">More Info</a>
+          </div>
+        </>
+      }} />
     )
   }
 
@@ -349,17 +351,13 @@ export default function DashboardV2() {
               <div className="App-card-row">
                 <div className="label">AUM</div>
                 <div>
-                  <Tooltip handle={`$${formatAmount(tvl, USD_DECIMALS, 0, true)}`} position="right-bottom">
-                    Assets Under Management: GLP pool + GMX staked
-                  </Tooltip>
+                  <Tooltip handle={`$${formatAmount(tvl, USD_DECIMALS, 0, true)}`} position="right-bottom" renderContent={() => "Assets Under Management: GLP pool + GMX staked"} />
                 </div>
               </div>
               <div className="App-card-row">
                 <div className="label">GLP Pool</div>
                 <div>
-                  <Tooltip handle={`$${formatAmount(aum, USD_DECIMALS, 0, true)}`} position="right-bottom">
-                    Total value of tokens in GLP pool
-                  </Tooltip>
+                  <Tooltip handle={`$${formatAmount(aum, USD_DECIMALS, 0, true)}`} position="right-bottom" renderContent={() => "Total value of tokens in GLP pool"} />
                 </div>
               </div>
               <div className="App-card-row">
@@ -505,11 +503,13 @@ export default function DashboardV2() {
                   <div className="App-card-row">
                     <div className="label">Pool</div>
                     <div>
-                      <Tooltip handle={`$${formatKeyAmount(tokenInfo, "managedUsd", USD_DECIMALS, 0, true)}`} position="right-bottom">
-                        Pool Amount: {formatKeyAmount(tokenInfo, "managedAmount", token.decimals, 2, true)} {token.symbol}<br/>
-                        <br/>
-                        Max {tokenInfo.symbol} Capacity: ${formatAmount(maxUsdgAmount, 18, 0, true)}
-                      </Tooltip>
+                      <Tooltip handle={`$${formatKeyAmount(tokenInfo, "managedUsd", USD_DECIMALS, 0, true)}`} position="right-bottom" renderContent={() => {
+                        return <>
+                          Pool Amount: {formatKeyAmount(tokenInfo, "managedAmount", token.decimals, 2, true)} {token.symbol}<br/>
+                          <br/>
+                          Max {tokenInfo.symbol} Capacity: ${formatAmount(maxUsdgAmount, 18, 0, true)}
+                        </>
+                      }} />
                     </div>
                   </div>
                   <div className="App-card-row">

--- a/src/StakeV2.js
+++ b/src/StakeV2.js
@@ -527,22 +527,35 @@ function VesterDepositModal(props) {
           <div className="Exchange-info-row">
             <div className="Exchange-info-label">Vault Capacity</div>
             <div className="align-right">
-              <Tooltip handle={`${formatAmount(nextDepositAmount, 18, 2, true)} / ${formatAmount(maxVestableAmount, 18, 2, true)}`} position="right-bottom">
-                Vault Capacity for your Account<br/>
-                <br/>
-                Deposited: {formatAmount(escrowedBalance, 18, 2, true)} esGMX<br/>
-                Max Capacity: {formatAmount(maxVestableAmount, 18, 2, true)} esGMX<br/>
-              </Tooltip>
+              <Tooltip
+                handle={`${formatAmount(nextDepositAmount, 18, 2, true)} / ${formatAmount(maxVestableAmount, 18, 2, true)}`}
+                position="right-bottom"
+                renderContent={() => {
+                  return <>
+                    Vault Capacity for your Account<br/>
+                    <br/>
+                    Deposited: {formatAmount(escrowedBalance, 18, 2, true)} esGMX<br/>
+                    Max Capacity: {formatAmount(maxVestableAmount, 18, 2, true)} esGMX<br/>
+                  </>
+                }}
+              />
             </div>
           </div>
           <div className="Exchange-info-row">
             <div className="Exchange-info-label">Reserve Amount</div>
             <div className="align-right">
-              <Tooltip handle={`${formatAmount(nextReserveAmount, 18, 2, true)} / ${formatAmount(maxReserveAmount, 18, 2, true)}`} position="right-bottom">
-                Current Reserved: {formatAmount(reserveAmount, 18, 2, true)}<br/>
-                Reserve Required: {formatAmount(additionalReserveAmount, 18, 2, true)}<br/>
-                {(amount && nextReserveAmount.gt(maxReserveAmount)) && <div><br/>You need a total of at least {formatAmount(nextReserveAmount, 18, 2, true)} {stakeTokenLabel} to vest {formatAmount(amount, 18, 2, true)} esGMX.</div>}
-              </Tooltip>
+              <Tooltip
+                handle={`${formatAmount(nextReserveAmount, 18, 2, true)} / ${formatAmount(maxReserveAmount, 18, 2, true)}`}
+                position="right-bottom"
+                renderContent={() => {
+                  return <>
+                    Current Reserved: {formatAmount(reserveAmount, 18, 2, true)}<br/>
+                    Reserve Required: {formatAmount(additionalReserveAmount, 18, 2, true)}<br/>
+                    {(amount && nextReserveAmount.gt(maxReserveAmount)) && <div><br/>You need a total of at least {formatAmount(nextReserveAmount, 18, 2, true)} {stakeTokenLabel} to vest {formatAmount(amount, 18, 2, true)} esGMX.</div>}
+                    }}
+                  </>
+                }}
+              />
             </div>
           </div>
         </div>
@@ -1175,10 +1188,13 @@ export default function StakeV2({ setPendingTxns }) {
 
   const renderMultiplierPointsValue = useCallback(() => {
     return (
-      <Tooltip handle={`100.00%`} position="right-bottom">
-        Boost your rewards with Multiplier Points.&nbsp;
-        <a href="https://gmxio.gitbook.io/gmx/rewards#multiplier-points" rel="noreferrer" target="_blank">More info</a>.
-      </Tooltip>
+      <Tooltip handle={`100.00%`} position="right-bottom" renderContent={() => {
+        return <>
+          Boost your rewards with Multiplier Points.&nbsp;
+          <a href="https://gmxio.gitbook.io/gmx/rewards#multiplier-points" rel="noreferrer" target="_blank">More info</a>.
+        </>
+        }}
+      />
     )
   }, [])
 
@@ -1350,31 +1366,43 @@ export default function StakeV2({ setPendingTxns }) {
               <div className="App-card-row">
                 <div className="label">APR</div>
                 <div>
-                  <Tooltip handle={`${formatKeyAmount(processedData, "gmxAprTotal", 2, 2, true)}%`} position="right-bottom">
-                    <div className="Tooltip-row">
-                      <span className="label">ETH (WETH) APR</span>
-                      <span>{formatKeyAmount(processedData, "gmxAprForETH", 2, 2, true)}%</span>
-                    </div>
-                    <div className="Tooltip-row">
-                      <span className="label">Escrowed GMX APR</span>
-                      <span>{formatKeyAmount(processedData, "gmxAprForEsGmx", 2, 2, true)}%</span>
-                    </div>
-                  </Tooltip>
+                  <Tooltip
+                    handle={`${formatKeyAmount(processedData, "gmxAprTotal", 2, 2, true)}%`}
+                    position="right-bottom"
+                    renderContent={() => {
+                      return <>
+                        <div className="Tooltip-row">
+                          <span className="label">ETH (WETH) APR</span>
+                          <span>{formatKeyAmount(processedData, "gmxAprForETH", 2, 2, true)}%</span>
+                        </div>
+                        <div className="Tooltip-row">
+                          <span className="label">Escrowed GMX APR</span>
+                          <span>{formatKeyAmount(processedData, "gmxAprForEsGmx", 2, 2, true)}%</span>
+                        </div>
+                      </>
+                    }}
+                  />
                 </div>
               </div>
               <div className="App-card-row">
                 <div className="label">Rewards</div>
                 <div>
-                  <Tooltip handle={`$${formatKeyAmount(processedData, "totalGmxRewardsUsd", USD_DECIMALS, 2, true)}`} position="right-bottom">
-                    <div className="Tooltip-row">
-                      <span className="label">ETH (WETH)</span>
-                      <span>{formatKeyAmount(processedData, "feeGmxTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "feeGmxTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
-                    </div>
-                    <div className="Tooltip-row">
-                      <span className="label">Escrowed GMX</span>
-                      <span>{formatKeyAmount(processedData, "stakedGmxTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "stakedGmxTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
-                    </div>
-                  </Tooltip>
+                  <Tooltip
+                    handle={`$${formatKeyAmount(processedData, "totalGmxRewardsUsd", USD_DECIMALS, 2, true)}`}
+                    position="right-bottom"
+                    renderContent={() => {
+                      return <>
+                        <div className="Tooltip-row">
+                          <span className="label">ETH (WETH)</span>
+                          <span>{formatKeyAmount(processedData, "feeGmxTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "feeGmxTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
+                        </div>
+                        <div className="Tooltip-row">
+                          <span className="label">Escrowed GMX</span>
+                          <span>{formatKeyAmount(processedData, "stakedGmxTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "stakedGmxTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
+                        </div>
+                      </>
+                    }}
+                  />
                 </div>
               </div>
               <div className="App-card-row">
@@ -1390,11 +1418,17 @@ export default function StakeV2({ setPendingTxns }) {
                   Boost Percentage
                 </div>
                 <div>
-                  <Tooltip handle={`${formatAmount(boostBasisPoints, 2, 2, false)}%`} position="right-bottom">
-                    You are earning {formatAmount(boostBasisPoints, 2, 2, false)}% more ETH rewards using {formatAmount(processedData.bnGmxInFeeGmx, 18, 4, 2, true)} Staked Multiplier Points.<br/>
-                    <br/>
-                    Use the "Compound" button to stake your Multiplier Points.
-                  </Tooltip>
+                  <Tooltip
+                    handle={`${formatAmount(boostBasisPoints, 2, 2, false)}%`}
+                    position="right-bottom"
+                    renderContent={() => {
+                      return <>
+                        You are earning {formatAmount(boostBasisPoints, 2, 2, false)}% more ETH rewards using {formatAmount(processedData.bnGmxInFeeGmx, 18, 4, 2, true)} Staked Multiplier Points.<br/>
+                        <br/>
+                        Use the "Compound" button to stake your Multiplier Points.
+                      </>
+                    }}
+                  />
                 </div>
               </div>
               <div className="App-card-divider"></div>
@@ -1503,31 +1537,43 @@ export default function StakeV2({ setPendingTxns }) {
               <div className="App-card-row">
                 <div className="label">APR</div>
                 <div>
-                  <Tooltip handle={`${formatKeyAmount(processedData, "glpAprTotal", 2, 2, true)}%`} position="right-bottom">
-                    <div className="Tooltip-row">
-                      <span className="label">ETH (WETH) APR</span>
-                      <span>{formatKeyAmount(processedData, "glpAprForETH", 2, 2, true)}%</span>
-                    </div>
-                    <div className="Tooltip-row">
-                      <span className="label">Escrowed GMX APR</span>
-                      <span>{formatKeyAmount(processedData, "glpAprForEsGmx", 2, 2, true)}%</span>
-                    </div>
-                  </Tooltip>
+                  <Tooltip
+                    handle={`${formatKeyAmount(processedData, "glpAprTotal", 2, 2, true)}%`}
+                    position="right-bottom"
+                    renderContent={() => {
+                      return <>
+                        <div className="Tooltip-row">
+                          <span className="label">ETH (WETH) APR</span>
+                          <span>{formatKeyAmount(processedData, "glpAprForETH", 2, 2, true)}%</span>
+                        </div>
+                        <div className="Tooltip-row">
+                          <span className="label">Escrowed GMX APR</span>
+                          <span>{formatKeyAmount(processedData, "glpAprForEsGmx", 2, 2, true)}%</span>
+                        </div>
+                      </>
+                    }}
+                  />
                 </div>
               </div>
               <div className="App-card-row">
                 <div className="label">Rewards</div>
                 <div>
-                  <Tooltip handle={`$${formatKeyAmount(processedData, "totalGlpRewardsUsd", USD_DECIMALS, 2, true)}`} position="right-bottom">
-                    <div className="Tooltip-row">
-                      <span className="label">ETH (WETH)</span>
-                      <span>{formatKeyAmount(processedData, "feeGlpTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "feeGlpTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
-                    </div>
-                    <div className="Tooltip-row">
-                      <span className="label">Escrowed GMX</span>
-                      <span>{formatKeyAmount(processedData, "stakedGlpTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "stakedGlpTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
-                    </div>
-                  </Tooltip>
+                  <Tooltip
+                    handle={`$${formatKeyAmount(processedData, "totalGlpRewardsUsd", USD_DECIMALS, 2, true)}`}
+                    position="right-bottom"
+                    renderContent={() => {
+                      return <>
+                        <div className="Tooltip-row">
+                          <span className="label">ETH (WETH)</span>
+                          <span>{formatKeyAmount(processedData, "feeGlpTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "feeGlpTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
+                        </div>
+                        <div className="Tooltip-row">
+                          <span className="label">Escrowed GMX</span>
+                          <span>{formatKeyAmount(processedData, "stakedGlpTrackerRewards", 18, 4)} (${formatKeyAmount(processedData, "stakedGlpTrackerRewardsUsd", USD_DECIMALS, 2, true)})</span>
+                        </div>
+                      </>
+                    }}
+                  />
                 </div>
               </div>
               <div className="App-card-divider"></div>
@@ -1577,16 +1623,22 @@ export default function StakeV2({ setPendingTxns }) {
                 <div className="label">APR</div>
                 <div>
                   <div>
-                    <Tooltip handle={`${formatKeyAmount(processedData, "gmxAprTotal", 2, 2, true)}%`} position="right-bottom">
-                      <div className="Tooltip-row">
-                        <span className="label">ETH (WETH) APR</span>
-                        <span>{formatKeyAmount(processedData, "gmxAprForETH", 2, 2, true)}%</span>
-                      </div>
-                      <div className="Tooltip-row">
-                        <span className="label">Escrowed GMX APR</span>
-                        <span>{formatKeyAmount(processedData, "gmxAprForEsGmx", 2, 2, true)}%</span>
-                      </div>
-                    </Tooltip>
+                    <Tooltip
+                      handle={`${formatKeyAmount(processedData, "gmxAprTotal", 2, 2, true)}%`}
+                      position="right-bottom"
+                      renderContent={() => {
+                        return <>
+                          <div className="Tooltip-row">
+                            <span className="label">ETH (WETH) APR</span>
+                            <span>{formatKeyAmount(processedData, "gmxAprForETH", 2, 2, true)}%</span>
+                          </div>
+                          <div className="Tooltip-row">
+                            <span className="label">Escrowed GMX APR</span>
+                            <span>{formatKeyAmount(processedData, "gmxAprForEsGmx", 2, 2, true)}%</span>
+                          </div>
+                        </>
+                      }}
+                    />
                   </div>
                 </div>
               </div>
@@ -1639,11 +1691,13 @@ export default function StakeV2({ setPendingTxns }) {
               <div className="App-card-row">
                 <div className="label">Staked Tokens</div>
                 <div>
-                  <Tooltip handle={formatAmount(totalRewardTokens, 18, 2, true)} position="right-bottom">
-                    {formatAmount(processedData.gmxInStakedGmx, 18, 2, true)} GMX<br/>
-                    {formatAmount(processedData.esGmxInStakedGmx, 18, 2, true)} esGMX<br/>
-                    {formatAmount(processedData.bnGmxInFeeGmx, 18, 2, true)} Multiplier Points
-                  </Tooltip>
+                  <Tooltip handle={formatAmount(totalRewardTokens, 18, 2, true)} position="right-bottom" renderContent={() => {
+                    return <>
+                      {formatAmount(processedData.gmxInStakedGmx, 18, 2, true)} GMX<br/>
+                      {formatAmount(processedData.esGmxInStakedGmx, 18, 2, true)} esGMX<br/>
+                      {formatAmount(processedData.bnGmxInFeeGmx, 18, 2, true)} Multiplier Points
+                    </>
+                  }} />
                 </div>
               </div>
               <div className="App-card-row">
@@ -1655,18 +1709,26 @@ export default function StakeV2({ setPendingTxns }) {
               <div className="App-card-row">
                 <div className="label">Vesting Status</div>
                 <div>
-                  <Tooltip handle={`${formatKeyAmount(vestingData, "gmxVesterClaimSum", 18, 4, true)} / ${formatKeyAmount(vestingData, "gmxVesterVestedAmount", 18, 4, true)}`} position="right-bottom">
-                    {formatKeyAmount(vestingData, "gmxVesterClaimSum", 18, 4, true)} tokens have been converted to GMX from the&nbsp;
-                    {formatKeyAmount(vestingData, "gmxVesterVestedAmount", 18, 4, true)} esGMX deposited for vesting.
-                  </Tooltip>
+                  <Tooltip
+                    handle={`${formatKeyAmount(vestingData, "gmxVesterClaimSum", 18, 4, true)} / ${formatKeyAmount(vestingData, "gmxVesterVestedAmount", 18, 4, true)}`}
+                    position="right-bottom"
+                    renderContent={() => {
+                      return <>
+                        {formatKeyAmount(vestingData, "gmxVesterClaimSum", 18, 4, true)} tokens have been converted to GMX from the&nbsp;
+                        {formatKeyAmount(vestingData, "gmxVesterVestedAmount", 18, 4, true)} esGMX deposited for vesting.
+                      </>
+                    }}
+                  />
                 </div>
               </div>
               <div className="App-card-row">
                 <div className="label">Claimable</div>
                 <div>
-                  <Tooltip handle={`${formatKeyAmount(vestingData, "gmxVesterClaimable", 18, 4, true)} GMX`} position="right-bottom">
-                    {formatKeyAmount(vestingData, "gmxVesterClaimable", 18, 4, true)} GMX tokens can be claimed, use the options under the Total Rewards section to claim them.
-                  </Tooltip>
+                  <Tooltip
+                    handle={`${formatKeyAmount(vestingData, "gmxVesterClaimable", 18, 4, true)} GMX`}
+                    position="right-bottom"
+                    renderContent={() => `${formatKeyAmount(vestingData, "gmxVesterClaimable", 18, 4, true)} GMX tokens can be claimed, use the options under the Total Rewards section to claim them.`}
+                  />
                 </div>
               </div>
               <div className="App-card-divider"></div>
@@ -1696,17 +1758,26 @@ export default function StakeV2({ setPendingTxns }) {
               <div className="App-card-row">
                 <div className="label">Vesting Status</div>
                 <div>
-                  <Tooltip handle={`${formatKeyAmount(vestingData, "glpVesterClaimSum", 18, 4, true)} / ${formatKeyAmount(vestingData, "glpVesterVestedAmount", 18, 4, true)}`} position="right-bottom">
-                    {formatKeyAmount(vestingData, "glpVesterClaimSum", 18, 4, true)} tokens have been converted to GMX from the&nbsp;
-                    {formatKeyAmount(vestingData, "glpVesterVestedAmount", 18, 4, true)} esGMX deposited for vesting.
-                  </Tooltip>
+                  <Tooltip
+                    handle={`${formatKeyAmount(vestingData, "glpVesterClaimSum", 18, 4, true)} / ${formatKeyAmount(vestingData, "glpVesterVestedAmount", 18, 4, true)}`}
+                    position="right-bottom"
+                    renderContent={() => {
+                      return <>
+                        {formatKeyAmount(vestingData, "glpVesterClaimSum", 18, 4, true)} tokens have been converted to GMX from the&nbsp;
+                        {formatKeyAmount(vestingData, "glpVesterVestedAmount", 18, 4, true)} esGMX deposited for vesting.
+                      </>
+                    }}
+                  />
                 </div>
               </div>
               <div className="App-card-row">
                 <div className="label">Claimable</div>
                 <div>
-                  <Tooltip handle={`${formatKeyAmount(vestingData, "glpVesterClaimable", 18, 4, true)} GMX`} position="right-bottom">
-                    {formatKeyAmount(vestingData, "glpVesterClaimable", 18, 4, true)} GMX tokens can be claimed, use the options under the Total Rewards section to claim them.
+                  <Tooltip
+                    handle={`${formatKeyAmount(vestingData, "glpVesterClaimable", 18, 4, true)} GMX`}
+                    position="right-bottom"
+                    renderContent={() => `${formatKeyAmount(vestingData, "glpVesterClaimable", 18, 4, true)} GMX tokens can be claimed, use the options under the Total Rewards section to claim them.`}>
+
                   </Tooltip>
                 </div>
               </div>

--- a/src/components/Exchange/ConfirmationBox.js
+++ b/src/components/Exchange/ConfirmationBox.js
@@ -338,11 +338,12 @@ export default function ConfirmationBox(props) {
       <Tooltip
         position="right-bottom"
         handleClassName={isLiquidityRisk ? "negative" : null}
-        handle={<>{formatAmount(availableLiquidity, token.decimals, token.isStable ? 0 : 2, true)} {token.symbol}</>
-      }>
-        {!isLiquidityRisk && "The order will only execute if the price conditions are met and there is sufficient liquidity"}
-        {isLiquidityRisk && "There may not be sufficient liquidity to execute your order when the price conditions are met"}
-      </Tooltip>
+        handle={<>{formatAmount(availableLiquidity, token.decimals, token.isStable ? 0 : 2, true)} {token.symbol}</>}
+        renderContent={() => isLiquidityRisk
+            ? "There may not be sufficient liquidity to execute your order when the price conditions are met"
+            : "The order will only execute if the price conditions are met and there is sufficient liquidity"
+        }
+      />
     </ExchangeInfoRow>
   }, [toTokenInfo, shortCollateralToken, isShort, isSwap, toAmount, toUsdMax])
 

--- a/src/components/Exchange/OrdersList.js
+++ b/src/components/Exchange/OrdersList.js
@@ -160,9 +160,12 @@ export default function OrdersList(props) {
               Swap {formatAmount(order.amountIn, fromTokenInfo.decimals, (fromTokenInfo.isStable || fromTokenInfo.isUsdg) ? 2 : 4, true)} {fromTokenInfo.symbol} for {formatAmount(order.minOut, toTokenInfo.decimals, (toTokenInfo.isStable || toTokenInfo.isUsdg) ? 2 : 4, true)} {toTokenInfo.symbol}
             </td>
             <td>
-              <Tooltip handle={getExchangeRateDisplay(order.triggerRatio, fromTokenInfo, toTokenInfo)}>
-                You will receive at least {formatAmount(order.minOut, toTokenInfo.decimals, (toTokenInfo.isStable || toTokenInfo.isUsdg) ? 2 : 4, true)} {toTokenInfo.symbol} if this order is executed. The execution price may vary depending on swap fees at the time the order is executed.
-              </Tooltip>
+              <Tooltip
+                handle={getExchangeRateDisplay(order.triggerRatio, fromTokenInfo, toTokenInfo)}
+                renderContent={() => `
+                  You will receive at least ${formatAmount(order.minOut, toTokenInfo.decimals, (toTokenInfo.isStable || toTokenInfo.isUsdg) ? 2 : 4, true)} ${toTokenInfo.symbol} if this order is executed. The execution price may vary depending on swap fees at the time the order is executed.
+                `}
+              />
             </td>
             <td>
               {getExchangeRateDisplay(markExchangeRate, fromTokenInfo, toTokenInfo, true)}
@@ -238,9 +241,13 @@ export default function OrdersList(props) {
             <div className="App-card-row">
               <div className="label">Price</div>
               <div>
-                <Tooltip position="right-bottom" handle={getExchangeRateDisplay(order.triggerRatio, fromTokenInfo, toTokenInfo)}>
-                  You will receive at least {formatAmount(order.minOut, toTokenInfo.decimals, (toTokenInfo.isStable || toTokenInfo.isUsdg) ? 2 : 4, true)} {toTokenInfo.symbol} if this order is executed. The exact execution price may vary depending on fees at the time the order is executed.
-                </Tooltip>
+                <Tooltip
+                  position="right-bottom"
+                  handle={getExchangeRateDisplay(order.triggerRatio, fromTokenInfo, toTokenInfo)}
+                  renderContent={() => `
+                    You will receive at least ${formatAmount(order.minOut, toTokenInfo.decimals, (toTokenInfo.isStable || toTokenInfo.isUsdg) ? 2 : 4, true)} ${toTokenInfo.symbol} if this order is executed. The exact execution price may vary depending on fees at the time the order is executed.
+                  `}
+                />
               </div>
             </div>
             <div className="App-card-row">

--- a/src/components/Exchange/PositionsList.js
+++ b/src/components/Exchange/PositionsList.js
@@ -261,11 +261,18 @@ export default function PositionsList(props) {
               </td>
               <td>
                 <div>
-                  <Tooltip handle={`$${formatAmount(position.netValue, USD_DECIMALS, 2, true)}`} position="left-bottom" handleClassName="plain">
-                    Net Value: Collateral + PnL<br/>
-                    Collateral: ${formatAmount(position.collateral, USD_DECIMALS, 2, true)}<br/>
-                    PnL: {position.deltaStr} ({position.deltaPercentageStr})
-                  </Tooltip>
+                  <Tooltip
+                    handle={`$${formatAmount(position.netValue, USD_DECIMALS, 2, true)}`}
+                    position="left-bottom"
+                    handleClassName="plain"
+                    renderContent={() => {
+                      return <>
+                        Net Value: Collateral + PnL<br/>
+                        Collateral: ${formatAmount(position.collateral, USD_DECIMALS, 2, true)}<br/>
+                        PnL: {position.deltaStr} ({position.deltaPercentageStr})
+                      </>
+                    }}
+                  />
                 </div>
                 <div className={cx("Exchange-list-info-label", { "positive": position.hasProfit && position.pendingDelta.gt(0), "negative": !position.hasProfit && position.pendingDelta.gt(0), "muted": position.pendingDelta.eq(0) })}>
                   {position.deltaStr} ({position.deltaPercentageStr})
@@ -276,28 +283,45 @@ export default function PositionsList(props) {
                   ${formatAmount(position.size, USD_DECIMALS, 2, true)}
                 </div>
                 {positionOrders.length > 0 && <div onClick={() => setListSection && setListSection("Orders")}>
-                  <Tooltip handle={`Orders (${positionOrders.length})`} position="left-bottom" handleClassName="Exchange-list-info-label muted plain clickable">
-                    <strong>Active Orders</strong>
-                    {positionOrders.map(order => {
-                      return <div key={`${order.orderType}-${order.index}`}>
-                        {order.triggerAboveThreshold ? ">" : "<"} {formatAmount(order.triggerPrice, 30, 2, true)}:
-                        {order.orderType === LIMIT ? " +" : " -"}${formatAmount(order.sizeDelta, 30, 2, true)}
-                      </div>
-                    })}
-                  </Tooltip>
+                  <Tooltip
+                    handle={`Orders (${positionOrders.length})`}
+                    position="left-bottom"
+                    handleClassName="Exchange-list-info-label muted plain clickable"
+                    renderContent={() => {
+                      return <>
+                        <strong>Active Orders</strong>
+                        {positionOrders.map(order => {
+                          return <div key={`${order.orderType}-${order.index}`}>
+                            {order.triggerAboveThreshold ? ">" : "<"} {formatAmount(order.triggerPrice, 30, 2, true)}:
+                            {order.orderType === LIMIT ? " +" : " -"}${formatAmount(order.sizeDelta, 30, 2, true)}
+                          </div>
+                        })}
+                      </>
+                    }}
+                  />
                 </div>}
               </td>
               <td>
-                <Tooltip handle={`$${formatAmount(position.collateral, USD_DECIMALS, 2, true)}`} position="left-bottom" handleClassName="plain">
-                  Use the "Edit" button to deposit or withdraw collateral.
-                </Tooltip>
+                <Tooltip
+                  handle={`$${formatAmount(position.collateral, USD_DECIMALS, 2, true)}`}
+                  position="left-bottom"
+                  handleClassName="plain"
+                  renderContent={() => "Use the \"Edit\" button to deposit or withdraw collateral."}
+                />
               </td>
               <td className="clickable" onClick={() => onPositionClick(position)}>
-                <Tooltip handle={`$${formatAmount(position.markPrice, USD_DECIMALS, 2, true)}`} position="left-bottom" handleClassName="plain clickable">
-                  Click on a row to select the position's market, then use the swap box to increase your position size if needed.<br/>
-                  <br/>
-                  Use the "Close" button to reduce your position size, or to set stop-loss / take-profit orders.
-                </Tooltip>
+                <Tooltip
+                  handle={`$${formatAmount(position.markPrice, USD_DECIMALS, 2, true)}`}
+                  position="left-bottom"
+                  handleClassName="plain clickable"
+                  renderContent={() => {
+                    return <>
+                      Click on a row to select the position's market, then use the swap box to increase your position size if needed.<br/>
+                      <br/>
+                      Use the "Close" button to reduce your position size, or to set stop-loss / take-profit orders.
+                    </>
+                  }}
+                />
               </td>
               <td className="clickable" onClick={() => onPositionClick(position)}>
                 ${formatAmount(position.averagePrice, USD_DECIMALS, 2, true)}

--- a/src/components/Exchange/SwapBox.js
+++ b/src/components/Exchange/SwapBox.js
@@ -1494,9 +1494,11 @@ export default function SwapBox(props) {
 							<div>
 								{!feesUsd && "-"}
 								{feesUsd &&
-                  <Tooltip handle={`${formatAmount(MARGIN_FEE_BASIS_POINTS, 2, 2, false)}% (${formatAmount(feesUsd, USD_DECIMALS, 2, true)} USD)`} position="right-bottom">
-                    Fees are calculated based on your position size.
-                  </Tooltip>
+                  <Tooltip
+                    handle={`${formatAmount(MARGIN_FEE_BASIS_POINTS, 2, 2, false)}% (${formatAmount(feesUsd, USD_DECIMALS, 2, true)} USD)`}
+                    position="right-bottom"
+                    renderContent={() => "Fees are calculated based on your position size."}
+                  />
                 }
 							</div>
             </ExchangeInfoRow>
@@ -1538,36 +1540,52 @@ export default function SwapBox(props) {
           <div className="Exchange-info-row">
             <div className="Exchange-info-label">Entry Price</div>
             <div className="align-right">
-              <Tooltip handle={`${formatAmount(entryMarkPrice, USD_DECIMALS, 2, true)} USD`} position="right-bottom">
-                The position will be opened at {formatAmount(entryMarkPrice, USD_DECIMALS, 2, true)} USD with a max slippage of {parseFloat(savedSlippageAmount / 100.0).toFixed(2)}%.<br/>
-                <br/>
-                The slippage amount can be configured by clicking on the "..." icon in the top right of the page after connecting your wallet.<br/>
-                <br/>
-                <a href="https://gmxio.gitbook.io/gmx/trading#opening-a-position" target="_blank" rel="noopener noreferrer">More Info</a>
-              </Tooltip>
+              <Tooltip
+                handle={`${formatAmount(entryMarkPrice, USD_DECIMALS, 2, true)} USD`}
+                position="right-bottom"
+                renderContent={() => {
+                  return <>
+                    The position will be opened at {formatAmount(entryMarkPrice, USD_DECIMALS, 2, true)} USD with a max slippage of {parseFloat(savedSlippageAmount / 100.0).toFixed(2)}%.<br/>
+                    <br/>
+                    The slippage amount can be configured by clicking on the "..." icon in the top right of the page after connecting your wallet.<br/>
+                    <br/>
+                    <a href="https://gmxio.gitbook.io/gmx/trading#opening-a-position" target="_blank" rel="noopener noreferrer">More Info</a>
+                    }}>
+                  </>
+                }}
+              />
             </div>
           </div>
           <div className="Exchange-info-row">
             <div className="Exchange-info-label">Exit Price</div>
             <div className="align-right">
-              <Tooltip handle={`${formatAmount(exitMarkPrice, USD_DECIMALS, 2, true)} USD`} position="right-bottom">
-                If you have an existing position, the position will be closed at {formatAmount(entryMarkPrice, USD_DECIMALS, 2, true)} USD.<br/>
-                <br/>
-                This exit price will change with the price of the asset.
-                <br/>
-                <br/>
-                <a href="https://gmxio.gitbook.io/gmx/trading#opening-a-position" target="_blank" rel="noopener noreferrer">More Info</a>
-              </Tooltip>
+              <Tooltip
+                handle={`${formatAmount(exitMarkPrice, USD_DECIMALS, 2, true)} USD`}
+                position="right-bottom"
+                renderContent={() => {
+                  return <>
+                    If you have an existing position, the position will be closed at {formatAmount(entryMarkPrice, USD_DECIMALS, 2, true)} USD.<br/>
+                    <br/>
+                    This exit price will change with the price of the asset.
+                    <br/>
+                    <br/>
+                    <a href="https://gmxio.gitbook.io/gmx/trading#opening-a-position" target="_blank" rel="noopener noreferrer">More Info</a>
+                    }}>
+                  </>
+                }}
+              />
             </div>
           </div>
           <div className="Exchange-info-row">
             <div className="Exchange-info-label">Borrow Fee</div>
             <div className="align-right">
-              <Tooltip handle={borrowFeeText} position="right-bottom">
-                The borrow fee is calculated as (assets borrowed) / (total assets in pool) * 0.01% per hour.<br/>
-                <br/>
-                <a href="https://gmxio.gitbook.io/gmx/trading#opening-a-position" target="_blank" rel="noopener noreferrer">More Info</a>
-              </Tooltip>
+              <Tooltip handle={borrowFeeText} position="right-bottom" renderContent={() => {
+                return <>
+                  The borrow fee is calculated as (assets borrowed) / (total assets in pool) * 0.01% per hour.<br/>
+                  <br/>
+                  <a href="https://gmxio.gitbook.io/gmx/trading#opening-a-position" target="_blank" rel="noopener noreferrer">More Info</a>
+                </>
+              }} />
             </div>
           </div>
         </div>

--- a/src/components/Glp/GlpSwap.js
+++ b/src/components/Glp/GlpSwap.js
@@ -599,25 +599,29 @@ export default function GlpSwap(props) {
             {!isBuying && <div className="App-card-row">
               <div className="label">Reserved</div>
               <div>
-                <Tooltip handle={`${formatAmount(reservedAmount, 18, 4, true)} GLP ($${formatAmount(reserveAmountUsd, USD_DECIMALS, 2, true)})`} position="right-bottom">
-                  {formatAmount(reservedAmount, 18, 4, true)} GLP have been reserved for vesting.
-                </Tooltip>
+                <Tooltip
+                  handle={`${formatAmount(reservedAmount, 18, 4, true)} GLP ($${formatAmount(reserveAmountUsd, USD_DECIMALS, 2, true)})`}
+                  position="right-bottom"
+                  renderContent={() => `${formatAmount(reservedAmount, 18, 4, true)} GLP have been reserved for vesting.`}
+                />
               </div>
             </div>}
             <div className="App-card-divider"></div>
             <div className="App-card-row">
               <div className="label">APR</div>
               <div>
-                <Tooltip handle={`${formatAmount(totalApr, 2, 2, true)}%`} position="right-bottom">
-                  <div className="Tooltip-row">
-                    <span className="label">ETH (WETH) APR</span>
-                    <span>{formatAmount(feeGlpTrackerApr, 2, 2, false)}%</span>
-                  </div>
-                  <div className="Tooltip-row">
-                    <span className="label">Escrowed GMX APR</span>
-                    <span>{formatAmount(stakedGlpTrackerApr, 2, 2, false)}%</span>
-                  </div>
-                </Tooltip>
+                <Tooltip handle={`${formatAmount(totalApr, 2, 2, true)}%`} position="right-bottom" renderContent={() => {
+                  return <>
+                    <div className="Tooltip-row">
+                      <span className="label">ETH (WETH) APR</span>
+                      <span>{formatAmount(feeGlpTrackerApr, 2, 2, false)}%</span>
+                    </div>
+                    <div className="Tooltip-row">
+                      <span className="label">Escrowed GMX APR</span>
+                      <span>{formatAmount(stakedGlpTrackerApr, 2, 2, false)}%</span>
+                    </div>
+                  </>
+                }} />
               </div>
             </div>
             <div className="App-card-row">
@@ -700,14 +704,18 @@ export default function GlpSwap(props) {
                 {feeBasisPoints > 50 ? "WARNING: High Fees" : "Fees"}
               </div>
               <div className="align-right">
-                {isBuying && <Tooltip handle={feePercentageText} position="right-bottom">
-                  {feeBasisPoints > 50 && <div>To reduce fees, select a different asset to pay with.</div>}
-                  Check the "Save on Fees" section below to get the lowest fee percentages.
-                </Tooltip>}
-                {!isBuying && <Tooltip handle={feePercentageText} position="right-bottom">
-                  {feeBasisPoints > 50 && <div>To reduce fees, select a different asset to receive.</div>}
-                  Check the "Save on Fees" section below to get the lowest fee percentages.
-                </Tooltip>}
+                {isBuying && <Tooltip handle={feePercentageText} position="right-bottom" renderContent={() => {
+                  return <>
+                    {feeBasisPoints > 50 && <div>To reduce fees, select a different asset to pay with.</div>}
+                    Check the "Save on Fees" section below to get the lowest fee percentages.
+                  </>
+                }} />}
+                {!isBuying && <Tooltip handle={feePercentageText} position="right-bottom" renderContent={() => {
+                  return <>
+                    {feeBasisPoints > 50 && <div>To reduce fees, select a different asset to receive.</div>}
+                    Check the "Save on Fees" section below to get the lowest fee percentages.
+                  </>
+                }} />}
               </div>
             </div>
           </div>
@@ -778,11 +786,17 @@ export default function GlpSwap(props) {
                 {isBuying && <div className="App-card-row">
                   <div className="label">Pool</div>
                   <div>
-                    <Tooltip handle={`$${formatAmount(poolAmountUsd, USD_DECIMALS, 2, true)}`} position="right-bottom">
-                        Pool Amount: {formatKeyAmount(tokenInfo, "poolAmount", token.decimals, 2, true)} {token.symbol}<br/>
-                        <br/>
-                        Max {tokenInfo.symbol} Capacity: ${formatAmount(maxUsdgAmount, 18, 0, true)}
-                    </Tooltip>
+                    <Tooltip
+                      handle={`$${formatAmount(poolAmountUsd, USD_DECIMALS, 2, true)}`}
+                      position="right-bottom"
+                      renderContent={() => {
+                        return <>
+                          Pool Amount: {formatKeyAmount(tokenInfo, "poolAmount", token.decimals, 2, true)} {token.symbol}<br/>
+                          <br/>
+                          Max {tokenInfo.symbol} Capacity: ${formatAmount(maxUsdgAmount, 18, 0, true)}
+                        </>
+                      }}
+                    />
                   </div>
                 </div>}
                 {!isBuying && <div className="App-card-row">

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -63,7 +63,7 @@ export default function Tooltip(props) {
        </span>
       {visible &&
         <div className={cx(['Tooltip-popup', position])}>
-          {props.children}
+          {props.renderContent()}
         </div>
       }
     </span>


### PR DESCRIPTION
currently Tooltip’s content is always evaluated even for hidden tooltips because content is passed as children. with a lot of tooltips there are wasted calculations of content
i’ve changed that to using prop renderContent that called only when tooltip’s content is visible
