### PR TITLE
display force closed action if executed by liquidator

### DIFF
--- a/src/components/Exchange/TradeHistory.js
+++ b/src/components/Exchange/TradeHistory.js
@@ -108,7 +108,7 @@ export default function TradeHistory(props) {
       if (params.flags?.isOrderExecution) {
         return
       }
-      
+
       const indexToken = getTokenInfo(infoTokens, params.indexToken, true, nativeTokenAddress)
       if (!indexToken) {
         return defaultMsg
@@ -116,8 +116,10 @@ export default function TradeHistory(props) {
       if (bigNumberify(params.sizeDelta).eq(0)) {
         return `Withdraw ${formatAmount(params.collateralDelta, USD_DECIMALS, 2, true)} USD from ${indexToken.symbol} ${params.isLong ? "Long" : "Short"}`
       }
+      const isLiquidation = params.flags?.isLiquidation
+      const actionDisplay = isLiquidation ? "Partially Liquidated" : "Decrease"
       return `
-        Decrease ${indexToken.symbol} ${params.isLong ? "Long" : "Short"},
+        ${actionDisplay} ${indexToken.symbol} ${params.isLong ? "Long" : "Short"},
         -${formatAmount(params.sizeDelta, USD_DECIMALS, 2, true)} USD,
         ${indexToken.symbol} Price: ${formatAmount(params.price, USD_DECIMALS, 2, true)} USD
       `


### PR DESCRIPTION
Traders ask why their position was decreased. Rn UI doesn't show that it was decreased by liquidator (or force closed). 

Not sure if "force closed" is the best term, CPC suggested to use "Protected close"

![image](https://user-images.githubusercontent.com/748652/142077580-38a651b3-1fe2-4394-86b9-beed0eaa8314.png)
