### PR TITLE
change the helper toast message for Metamask error

### DIFF
--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -2360,7 +2360,7 @@ export const getInjectedHandler = activate => {
         );
         return;
       }
-      helperToast.error(e.toString());
+      helperToast.error(e?.message || 'Something went wrong!');
     });
   };
   return fn;


### PR DESCRIPTION
We were showing converting the error object to string and display in toast. So converting the object returns `[Object object]`. Changed that to display the `e.message`.