### PR TITLE
Fix TraderJOE URL

### DIFF
--- a/src/views/BuyGMX/BuyGMX.js
+++ b/src/views/BuyGMX/BuyGMX.js
@@ -198,7 +198,7 @@ export default function BuyGMX() {
                     <Button
                       size="xl"
                       imgSrc={gmxAvax}
-                      href="https://traderjoexyz.com/#/trade?outputCurrency=0x62edc0692BD897D2295872a9FFCac5425011c661"
+                      href="https://traderjoexyz.com/trade?outputCurrency=0x62edc0692BD897D2295872a9FFCac5425011c661#/"
                     >
                       Purchase GMX
                     </Button>


### PR DESCRIPTION
Fix the TraderJOE URL to redirect to the trade page with the token already input.

The current link just return to home.