### PR TITLE
fix tier display for code from localstorage

### DIFF
--- a/src/views/Referrals/Referrals.js
+++ b/src/views/Referrals/Referrals.js
@@ -161,18 +161,18 @@ function Referrals({ connectWallet, setPendingTxns, pendingTxns }) {
   const [activeTab, setActiveTab] = useLocalStorage(REFERRALS_SELECTED_TAB_KEY, TRADERS);
   const { data: referralsData, loading } = useReferralsData(chainIdWithoutLocalStorage, account);
   const [recentlyAddedCodes, setRecentlyAddedCodes] = useLocalStorageSerializeKey([chainId, "REFERRAL", account], []);
-  const { userReferralCode } = useUserReferralCode(library, chainId, account);
+  let { userReferralCode } = useUserReferralCode(library, chainId, account);
+  const userReferralCodeInLocalStorage = window.localStorage.getItem(REFERRAL_CODE_KEY);
+  if (isHashZero(userReferralCode) && userReferralCodeInLocalStorage) {
+    userReferralCode = userReferralCodeInLocalStorage;
+  }
+
   const { codeOwner } = useCodeOwner(library, chainId, account, userReferralCode);
   const { referrerTier: traderTier } = useReferrerTier(library, chainId, codeOwner);
-  const userReferralCodeInLocalStorage = window.localStorage.getItem(REFERRAL_CODE_KEY);
 
   let referralCodeInString;
   if (userReferralCode && !isHashZero(userReferralCode)) {
     referralCodeInString = decodeReferralCode(userReferralCode);
-  }
-
-  if (!referralCodeInString && userReferralCodeInLocalStorage && !isHashZero(userReferralCodeInLocalStorage)) {
-    referralCodeInString = decodeReferralCode(userReferralCodeInLocalStorage);
   }
 
   function handleCreateReferralCode(code) {


### PR DESCRIPTION
Issue:
- Use referral link with code of tier 2 or 3
- Open /referrals
- You're getting Tier 1

You can try this link https://gmx.io/?ref=Algod with account that **doesn't have code saved onchain**

That reproduces with code from localstorage only, because UI doesn't retrieve owner for that code. And shows default tier 1

cc @xvi10 would be good to merge it soon i guess

@vipineth could you please support that change in `staging`? tell me if there is a better solution to fix this