### PR TITLE
update csp to support base 64 images

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,4 +15,4 @@
     X-XSS-Protection = "1; mode=block"
     Referrer-Policy = "no-referrer"
     X-Content-Type-Options = "nosniff"
-    Content-Security-Policy = "default-src 'self' netlify-cdp-loader.netlify.app; script-src 'self' 'unsafe-inline' netlify-cdp-loader.netlify.app; connect-src *; frame-src 'self' app.netlify.com; style-src 'self' 'unsafe-inline';"
+    Content-Security-Policy = "default-src 'self' netlify-cdp-loader.netlify.app; img-src 'self' data:; script-src 'self' 'unsafe-inline' netlify-cdp-loader.netlify.app; connect-src *; frame-src 'self' app.netlify.com; style-src 'self' 'unsafe-inline';"


### PR DESCRIPTION
- [x] PR will fix the issue for not displaying the AVAX background image on homepage

![Screenshot 2022-06-21 at 11 40 25 PM](https://user-images.githubusercontent.com/73279781/174869256-dc91ee1a-50d9-41ab-9438-af80034464bf.png)
