### PR TITLE
handle no existingOrder for decreaseOrdersThatWillBeExecuted

### DIFF
--- a/src/components/Exchange/ConfirmationBox.js
+++ b/src/components/Exchange/ConfirmationBox.js
@@ -176,14 +176,15 @@ export default function ConfirmationBox(props) {
   }, [orders, chainId, isLong, toToken.address, toToken.isNative]);
 
   const decreaseOrdersThatWillBeExecuted = useMemo(() => {
+    if (isSwap) return [];
     return existingTriggerOrders.filter((order) => {
       if (order.triggerAboveThreshold) {
-        return existingPosition.markPrice.gte(order.triggerPrice);
+        return existingPosition?.markPrice.gte(order.triggerPrice);
       } else {
-        return existingPosition.markPrice.lte(order.triggerPrice);
+        return existingPosition?.markPrice.lte(order.triggerPrice);
       }
     });
-  }, [existingPosition, existingTriggerOrders]);
+  }, [existingPosition, existingTriggerOrders, isSwap]);
 
   const getError = () => {
     if (!isSwap && hasExistingPosition && !isMarketOrder) {


### PR DESCRIPTION
Fix screen getting blank in the situation where:

There is no existing position and user has trigger orders, While using swap screen getting blank with the message in attachement:
<img width="1149" alt="Screenshot 2022-07-16 at 12 17 56 PM" src="https://user-images.githubusercontent.com/73279781/179344373-b2fa4e37-c8ec-4b47-af6d-cbb4d051660c.png">
