### PR TITLE
changed referral link so that trader attribution works

### DIFF
--- a/src/components/Referrals/AffiliatesStats.js
+++ b/src/components/Referrals/AffiliatesStats.js
@@ -145,7 +145,9 @@ function AffiliatesStats({
                           <span className="referral-text ">{stat.referralCode}</span>
                           <div
                             onClick={() => {
-                              copyToClipboard(`https://gmx.io/#/?${REFERRAL_CODE_QUERY_PARAM}=${stat.referralCode}`);
+                              copyToClipboard(
+                                `https://app.gmx.io/#/?${REFERRAL_CODE_QUERY_PARAM}=${stat.referralCode}`
+                              );
                               helperToast.success("Referral link copied to your clipboard");
                             }}
                             className="copy-icon"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87622099/190879041-eb91777e-d4cf-49ed-88f6-f46ba4460b0d.png)

Previously this link goes to https://gmx.io/#/?ref=jonomnom . When the referred trader tries to trade on the app (app.gmx.io), they will lose their affiliation with the affiliate. Going directly to http://app.gmx.io/#/?ref=jonomnom lets the affiliation stay with the trader (does not need to do extra steps) and the trader does not have to sign a transaction.

The potential downsides with the proposed changes are:
 -  the referral link does not go to the landing page
 - using localstorage to save the referral link is temporary


