### PR TITLE
share referral code link based on the root url

### DIFF
--- a/src/components/Referrals/AffiliatesStats.js
+++ b/src/components/Referrals/AffiliatesStats.js
@@ -6,7 +6,7 @@ import { IoWarningOutline } from "react-icons/io5";
 import { BiCopy, BiErrorCircle } from "react-icons/bi";
 import Card from "../Common/Card";
 import Modal from "../Modal/Modal";
-import { REFERRAL_CODE_QUERY_PARAM, shortenAddress } from "lib/legacy";
+import { shortenAddress } from "lib/legacy";
 import EmptyMessage from "./EmptyMessage";
 import InfoCard from "./InfoCard";
 import {
@@ -24,7 +24,6 @@ import { helperToast } from "lib/helperToast";
 import { bigNumberify, formatAmount } from "lib/numbers";
 import { getNativeToken, getToken } from "config/tokens";
 import { formatDate } from "lib/dates";
-import { getRootUrl } from "lib/url";
 
 function AffiliatesStats({
   referralsData,
@@ -58,8 +57,6 @@ function AffiliatesStats({
   if (cumulativeStats && cumulativeStats.totalRebateUsd && cumulativeStats.discountUsd) {
     referrerRebates = cumulativeStats.totalRebateUsd.sub(cumulativeStats.discountUsd);
   }
-  const rootUrl = getRootUrl();
-
   return (
     <div className="referral-body-container">
       <div className="referral-stats">

--- a/src/components/Referrals/AffiliatesStats.js
+++ b/src/components/Referrals/AffiliatesStats.js
@@ -23,6 +23,7 @@ import { helperToast } from "lib/helperToast";
 import { bigNumberify, formatAmount } from "lib/numbers";
 import { getNativeToken, getToken } from "config/tokens";
 import { formatDate } from "lib/dates";
+import { getRootUrl } from "domain/common";
 
 function AffiliatesStats({
   referralsData,
@@ -56,6 +57,7 @@ function AffiliatesStats({
   if (cumulativeStats && cumulativeStats.totalRebateUsd && cumulativeStats.discountUsd) {
     referrerRebates = cumulativeStats.totalRebateUsd.sub(cumulativeStats.discountUsd);
   }
+  const rootUrl = getRootUrl();
 
   return (
     <div className="referral-body-container">
@@ -140,7 +142,7 @@ function AffiliatesStats({
                           <span className="referral-text ">{stat.referralCode}</span>
                           <div
                             onClick={() => {
-                              copyToClipboard(`https://gmx.io/#/?${REFERRAL_CODE_QUERY_PARAM}=${stat.referralCode}`);
+                              copyToClipboard(`${rootUrl}/#/?${REFERRAL_CODE_QUERY_PARAM}=${stat.referralCode}`);
                               helperToast.success("Referral link copied to your clipboard");
                             }}
                             className="referral-code-icon"

--- a/src/components/Referrals/AffiliatesStats.js
+++ b/src/components/Referrals/AffiliatesStats.js
@@ -10,6 +10,7 @@ import { REFERRAL_CODE_QUERY_PARAM, shortenAddress } from "lib/legacy";
 import EmptyMessage from "./EmptyMessage";
 import InfoCard from "./InfoCard";
 import {
+  getReferralCodeTradeUrl,
   getTierIdDisplay,
   getTwitterShareUrl,
   getUSDValue,
@@ -142,7 +143,7 @@ function AffiliatesStats({
                           <span className="referral-text ">{stat.referralCode}</span>
                           <div
                             onClick={() => {
-                              copyToClipboard(`${rootUrl}/#/trade/?${REFERRAL_CODE_QUERY_PARAM}=${stat.referralCode}`);
+                              copyToClipboard(getReferralCodeTradeUrl(stat.referralCode));
                               helperToast.success("Referral link copied to your clipboard");
                             }}
                             className="referral-code-icon"

--- a/src/components/Referrals/AffiliatesStats.js
+++ b/src/components/Referrals/AffiliatesStats.js
@@ -142,7 +142,7 @@ function AffiliatesStats({
                           <span className="referral-text ">{stat.referralCode}</span>
                           <div
                             onClick={() => {
-                              copyToClipboard(`${rootUrl}/#/?${REFERRAL_CODE_QUERY_PARAM}=${stat.referralCode}`);
+                              copyToClipboard(`${rootUrl}/#/trade/?${REFERRAL_CODE_QUERY_PARAM}=${stat.referralCode}`);
                               helperToast.success("Referral link copied to your clipboard");
                             }}
                             className="referral-code-icon"

--- a/src/components/Referrals/AffiliatesStats.js
+++ b/src/components/Referrals/AffiliatesStats.js
@@ -23,7 +23,7 @@ import { helperToast } from "lib/helperToast";
 import { bigNumberify, formatAmount } from "lib/numbers";
 import { getNativeToken, getToken } from "config/tokens";
 import { formatDate } from "lib/dates";
-import { getRootUrl } from "domain/common";
+import { getRootUrl } from "lib/url";
 
 function AffiliatesStats({
   referralsData,

--- a/src/components/Referrals/referralsHelper.js
+++ b/src/components/Referrals/referralsHelper.js
@@ -1,7 +1,8 @@
-import { isAddressZero, USD_DECIMALS, MAX_REFERRAL_CODE_LENGTH } from "lib/legacy";
+import { isAddressZero, USD_DECIMALS, MAX_REFERRAL_CODE_LENGTH, getTwitterIntentURL } from "lib/legacy";
 import { encodeReferralCode, getReferralCodeOwner } from "domain/referrals";
 import { ARBITRUM, AVALANCHE } from "config/chains";
 import { bigNumberify, formatAmount } from "lib/numbers";
+import { getRootUrl } from "lib/url";
 
 export const REFERRAL_CODE_REGEX = /^\w+$/; // only number, string and underscore is allowed
 export const REGEX_VERIFY_BYTES32 = /^0x[0-9a-f]{64}$/;
@@ -125,6 +126,7 @@ export function getCodeError(value) {
 
 export function getTwitterShareUrl(referralCode) {
   const message = "Trying out trading on @GMX_IO, up to 30x leverage on $BTC, $ETH 📈%0a%0aFor fee discounts use:";
+  const shareURL = `${getRootUrl()}/#/?ref=${referralCode}`;
 
-  return `http://twitter.com/intent/tweet?text=${message}&url=https://gmx.io?ref=${referralCode}`;
+  return getTwitterIntentURL(message, shareURL);
 }

--- a/src/components/Referrals/referralsHelper.js
+++ b/src/components/Referrals/referralsHelper.js
@@ -1,4 +1,10 @@
-import { isAddressZero, USD_DECIMALS, MAX_REFERRAL_CODE_LENGTH, getTwitterIntentURL } from "lib/legacy";
+import {
+  isAddressZero,
+  USD_DECIMALS,
+  MAX_REFERRAL_CODE_LENGTH,
+  getTwitterIntentURL,
+  REFERRAL_CODE_QUERY_PARAM,
+} from "lib/legacy";
 import { encodeReferralCode, getReferralCodeOwner } from "domain/referrals";
 import { ARBITRUM, AVALANCHE } from "config/chains";
 import { bigNumberify, formatAmount } from "lib/numbers";
@@ -124,9 +130,13 @@ export function getCodeError(value) {
   return "";
 }
 
+export function getReferralCodeTradeUrl(referralCode) {
+  return `${getRootUrl()}/#/trade/?${REFERRAL_CODE_QUERY_PARAM}=${referralCode}`;
+}
+
 export function getTwitterShareUrl(referralCode) {
-  const message = "Trying out trading on @GMX_IO, up to 30x leverage on $BTC, $ETH 📈%0a%0aFor fee discounts use:";
-  const shareURL = `${getRootUrl()}/#/?ref=${referralCode}`;
+  const message = ["Trying out trading on @GMX_IO, up to 30x leverage on $BTC, $ETH 📈", "For fee discounts use:"];
+  const shareURL = getReferralCodeTradeUrl(referralCode);
 
   return getTwitterIntentURL(message, shareURL);
 }

--- a/src/domain/common.js
+++ b/src/domain/common.js
@@ -3,3 +3,14 @@ export function get1InchSwapUrl(chainId, from, to) {
   if (!from && !to) return rootUrl;
   return `${rootUrl}/${from}/${to}`;
 }
+
+export function getRootUrl() {
+  if (!window.location.origin) {
+    window.location.origin =
+      window.location.protocol +
+      "//" +
+      window.location.hostname +
+      (window.location.port ? ":" + window.location.port : "");
+  }
+  return window.location.origin;
+}

--- a/src/domain/common.js
+++ b/src/domain/common.js
@@ -3,14 +3,3 @@ export function get1InchSwapUrl(chainId, from, to) {
   if (!from && !to) return rootUrl;
   return `${rootUrl}/${from}/${to}`;
 }
-
-export function getRootUrl() {
-  if (!window.location.origin) {
-    window.location.origin =
-      window.location.protocol +
-      "//" +
-      window.location.hostname +
-      (window.location.port ? ":" + window.location.port : "");
-  }
-  return window.location.origin;
-}

--- a/src/lib/legacy.js
+++ b/src/lib/legacy.js
@@ -1414,20 +1414,7 @@ export function importImage(name) {
 export function getTwitterIntentURL(text, url = "", hashtag = "") {
   let finalURL = "https://twitter.com/intent/tweet?text=";
   if (text.length > 0) {
-    if (Array.isArray(text)) {
-      finalURL += text
-        .map((t) =>
-          encodeURIComponent(t.replace(/[\r\n]+/g, " "))
-            .replace(/\*%7C/g, "*|URL:")
-            .replace(/%7C\*/g, "|*")
-        )
-        .join("%0a%0a");
-    } else {
-      finalURL += encodeURIComponent(text.replace(/[\r\n]+/g, " "))
-        .replace(/\*%7C/g, "*|URL:")
-        .replace(/%7C\*/g, "|*");
-    }
-
+    finalURL += Array.isArray(text) ? text.map((t) => encodeURIComponent(t)).join("%0a%0a") : encodeURIComponent(text);
     if (hashtag.length > 0) {
       finalURL += "&hashtags=" + encodeURIComponent(hashtag.replace(/#/g, ""));
     }

--- a/src/lib/legacy.js
+++ b/src/lib/legacy.js
@@ -1414,9 +1414,19 @@ export function importImage(name) {
 export function getTwitterIntentURL(text, url = "", hashtag = "") {
   let finalURL = "https://twitter.com/intent/tweet?text=";
   if (text.length > 0) {
-    finalURL += encodeURIComponent(text.replace(/[\r\n]+/g, " "))
-      .replace(/\*%7C/g, "*|URL:")
-      .replace(/%7C\*/g, "|*");
+    if (Array.isArray(text)) {
+      finalURL += text
+        .map((t) =>
+          encodeURIComponent(t.replace(/[\r\n]+/g, " "))
+            .replace(/\*%7C/g, "*|URL:")
+            .replace(/%7C\*/g, "|*")
+        )
+        .join("%0a%0a");
+    } else {
+      finalURL += encodeURIComponent(text.replace(/[\r\n]+/g, " "))
+        .replace(/\*%7C/g, "*|URL:")
+        .replace(/%7C\*/g, "|*");
+    }
 
     if (hashtag.length > 0) {
       finalURL += "&hashtags=" + encodeURIComponent(hashtag.replace(/#/g, ""));

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,11 @@
+export function getRootUrl() {
+  let url = window.location.origin;
+  if (!window.location.origin) {
+    url =
+      window.location.protocol +
+      "//" +
+      window.location.hostname +
+      (window.location.port ? ":" + window.location.port : "");
+  }
+  return url;
+}

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,10 +1,9 @@
 export function getRootUrl() {
-  const { origin } = window.location;
+  const { origin, protocol, hostname, port } = window.location;
   let url = origin;
   if (!origin) {
-    url = `${window.location.protocol}//${window.location.hostname}${
-      window.location.port && `:${window.location.port}`
-    }`;
+    const portString = port && `:${port}`;
+    url = `${protocol}//${hostname}${portString}`;
   }
   return url;
 }

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,11 +1,10 @@
 export function getRootUrl() {
-  let url = window.location.origin;
-  if (!window.location.origin) {
-    url =
-      window.location.protocol +
-      "//" +
-      window.location.hostname +
-      (window.location.port ? ":" + window.location.port : "");
+  const { origin } = window.location;
+  let url = origin;
+  if (!origin) {
+    url = `${window.location.protocol}//${window.location.hostname}${
+      window.location.port && `:${window.location.port}`
+    }`;
   }
   return url;
 }


### PR DESCRIPTION
[x] Add root url of the domain when we copy the sharable link for referral code

The idea is to make the interface being deployed to any URL in future and not depend on just app.gmx.io. Like few days back `runonflux` team deployed GMX interface on an IFPS and when you copy the sharable link it still goes to `app.gmx.io` it should go to the `runonflux` domain. So now the link copy will depend on the domain origin.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203036542861572