### PR TITLE
change leverage message to >100 x

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -525,7 +525,7 @@ function FullApp() {
                 <Actions />
               </Route>
               <Route exact path="/actions/:account">
-                <Actions />
+                <Actions savedIsPnlInLeverage={savedIsPnlInLeverage} savedShowPnlAfterFees={savedShowPnlAfterFees} />
               </Route>
               <Route exact path="/orders_overview">
                 <OrdersOverview />

--- a/src/components/Exchange/PositionsList.js
+++ b/src/components/Exchange/PositionsList.js
@@ -260,7 +260,7 @@ export default function PositionsList(props) {
                         <Trans>Leverage</Trans>
                       </div>
                       <div>
-                        {formatAmount(position.leverage, 4, 2, true)}x&nbsp;
+                        <span className="Position-leverage">{position.leverageStr}</span>
                         <span
                           className={cx("Exchange-list-side", {
                             positive: position.isLong,
@@ -556,9 +556,7 @@ export default function PositionsList(props) {
                     {position.hasPendingChanges && <ImSpinner2 className="spin position-loading-icon" />}
                   </div>
                   <div className="Exchange-list-info-label">
-                    {position.leverage && (
-                      <span className="muted">{formatAmount(position.leverage, 4, 2, true)}x&nbsp;</span>
-                    )}
+                    {position.leverageStr && <span className="muted Position-leverage">{position.leverageStr}</span>}
                     <span className={cx({ positive: position.isLong, negative: !position.isLong })}>
                       {position.isLong ? t`Long` : t`Short`}
                     </span>

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -744,6 +744,15 @@ export function getLeverage({
   return nextSize.mul(BASIS_POINTS_DIVISOR).div(remainingCollateral);
 }
 
+export function getLeverageStr(leverage) {
+  if (leverage && ethers.BigNumber.isBigNumber(leverage)) {
+    if (leverage.lt(0)) {
+      return "> 100x";
+    }
+    return `${formatAmount(leverage, 4, 2, true)}x`;
+  }
+}
+
 export function getFundingFee(data: {
   size: BigNumber;
   entryFundingRate?: BigNumber;

--- a/src/pages/Actions/Actions.js
+++ b/src/pages/Actions/Actions.js
@@ -28,7 +28,7 @@ import { useChainId } from "lib/chains";
 
 const USD_DECIMALS = 30;
 
-export default function Actions() {
+export default function Actions({ savedIsPnlInLeverage, savedShowPnlAfterFees }) {
   const { account } = useParams();
   const { active, library } = useWeb3React();
 
@@ -76,8 +76,8 @@ export default function Actions() {
     positionQuery,
     positionData,
     infoTokens,
-    true,
-    true,
+    savedIsPnlInLeverage,
+    savedShowPnlAfterFees,
     checkSummedAccount,
     undefined,
     undefined
@@ -138,8 +138,8 @@ export default function Actions() {
             flagOrdersEnabled={false}
             chainId={chainId}
             nativeTokenAddress={nativeTokenAddress}
-            savedIsPnlInLeverage={true}
-            showPnlAfterFees={true}
+            savedIsPnlInLeverage={savedIsPnlInLeverage}
+            showPnlAfterFees={savedShowPnlAfterFees}
             hideActions
           />
         </div>

--- a/src/pages/Actions/Actions.js
+++ b/src/pages/Actions/Actions.js
@@ -76,8 +76,8 @@ export default function Actions() {
     positionQuery,
     positionData,
     infoTokens,
-    false,
-    false,
+    true,
+    true,
     checkSummedAccount,
     undefined,
     undefined
@@ -136,10 +136,10 @@ export default function Actions() {
             account={checkSummedAccount}
             library={library}
             flagOrdersEnabled={false}
-            savedIsPnlInLeverage={false}
             chainId={chainId}
             nativeTokenAddress={nativeTokenAddress}
-            showPnlAfterFees={false}
+            savedIsPnlInLeverage={true}
+            showPnlAfterFees={true}
             hideActions
           />
         </div>

--- a/src/pages/Exchange/Exchange.css
+++ b/src/pages/Exchange/Exchange.css
@@ -902,6 +902,10 @@ table.Exchange-list-small td {
   opacity: 1;
 }
 
+.Position-leverage {
+  margin-right: 0.25rem;
+}
+
 @media (max-width: 1500px) {
   .Exchange-swap-box {
     width: 38.75rem;

--- a/src/pages/Exchange/Exchange.js
+++ b/src/pages/Exchange/Exchange.js
@@ -19,6 +19,7 @@ import {
   useAccountOrders,
   getPageTitle,
   getFundingFee,
+  getLeverageStr,
 } from "lib/legacy";
 import { getConstant, getExplorerUrl } from "config/chains";
 import { approvePlugin, useMinExecutionFee, cancelMultipleOrders } from "domain/legacy";
@@ -289,6 +290,7 @@ export function getPositions(
       delta: position.delta,
       includeDelta,
     });
+    position.leverageStr = getLeverageStr(position.leverage);
 
     positionsMap[key] = position;
 


### PR DESCRIPTION
[x] Show `> 100x` instead of negative leverage numbers when the `Include PnL in leverage display` is unchecked.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203668976600222
  - https://app.asana.com/0/0/1203777627855630