### PR TITLE
use 24h volume from subgraph instead of server endpoint

### DIFF
--- a/src/config/localStorage.ts
+++ b/src/config/localStorage.ts
@@ -16,3 +16,5 @@ export const TV_SAVE_LOAD_CHARTS_KEY = "tv-save-load-charts";
 export const TV_CHART_RELOAD_TIMESTAMP_KEY = "tv-chart-reload-timestamp";
 export const REDIRECT_POPUP_TIMESTAMP_KEY = "redirect-popup-timestamp";
 export const PRODUCTION_PREVIEW_KEY = "production-preview";
+
+export const getSubgraphUrlKey = (chainId: number, subgraph: string) => `subgraphUrl:${chainId}:${subgraph}`;

--- a/src/config/subgraph.ts
+++ b/src/config/subgraph.ts
@@ -1,18 +1,36 @@
-import { ARBITRUM, AVALANCHE } from "./chains";
+import { ARBITRUM, AVALANCHE, ETH_MAINNET } from "./chains";
+import { isDevelopment } from "./env";
+import { getSubgraphUrlKey } from "./localStorage";
 
-export const SUBGRAPH_URLS = {
+const SUBGRAPH_URLS = {
   [ARBITRUM]: {
+    // stats: "https://api.thegraph.com/subgraphs/name/gdev8317/gmx-arbitrum-stats
     stats: "https://api.thegraph.com/subgraphs/name/gmx-io/gmx-stats",
     referrals: "https://api.thegraph.com/subgraphs/name/gmx-io/gmx-arbitrum-referrals",
     nissohVault: "https://api.thegraph.com/subgraphs/name/nissoh/gmx-vault",
   },
 
   [AVALANCHE]: {
+    // stats: "https://api.thegraph.com/subgraphs/name/gdev8317/gmx-avalanche-staging", // testing
     stats: "https://api.thegraph.com/subgraphs/name/gmx-io/gmx-avalanche-stats",
     referrals: "https://api.thegraph.com/subgraphs/name/gmx-io/gmx-avalanche-referrals",
   },
 
-  common: {
+  [ETH_MAINNET]: {
     chainLink: "https://api.thegraph.com/subgraphs/name/deividask/chainlink",
   },
 };
+
+export function getSubgraphUrl(chainId: number, subgraph: string) {
+  if (isDevelopment()) {
+    const localStorageKey = getSubgraphUrlKey(chainId, subgraph);
+    const url = localStorage.getItem(localStorageKey);
+    if (url) {
+      // eslint-disable-next-line no-console
+      console.warn("%s subgraph on chain %s url is overriden: %s", subgraph, chainId, url);
+      return url;
+    }
+  }
+
+  return SUBGRAPH_URLS[chainId][subgraph];
+}

--- a/src/domain/stats/index.ts
+++ b/src/domain/stats/index.ts
@@ -1,0 +1,3 @@
+export * from "./useFeesSummary";
+export * from "./useTotalVolume";
+export * from "./useVolumeInfo";

--- a/src/domain/stats/types.ts
+++ b/src/domain/stats/types.ts
@@ -1,0 +1,16 @@
+import { ARBITRUM, AVALANCHE } from "config/chains";
+import { BigNumber } from "ethers";
+
+export type VolumeInfo = {
+  totalVolume: BigNumber;
+  [AVALANCHE]: { totalVolume: BigNumber };
+  [ARBITRUM]: { totalVolume: BigNumber };
+};
+
+export type VolumeStat = {
+  swap: string;
+  margin: string;
+  liquidation: string;
+  mint: string;
+  burn: string;
+};

--- a/src/domain/stats/useFeesSummary.js
+++ b/src/domain/stats/useFeesSummary.js
@@ -1,0 +1,25 @@
+import useSWR from "swr";
+import { arrayURLFetcher } from "lib/legacy";
+import { ARBITRUM, AVALANCHE } from "config/chains";
+import { getServerUrl } from "config/backend";
+const ACTIVE_CHAIN_IDS = [ARBITRUM, AVALANCHE];
+
+export function useFeesSummary() {
+  const { data: feesSummary } = useSWR(
+    ACTIVE_CHAIN_IDS.map((chainId) => getServerUrl(chainId, "/fees_summary")),
+    {
+      fetcher: arrayURLFetcher,
+    }
+  );
+
+  const feesSummaryByChain = {};
+  for (let i = 0; i < ACTIVE_CHAIN_IDS.length; i++) {
+    if (feesSummary && feesSummary.length === ACTIVE_CHAIN_IDS.length) {
+      feesSummaryByChain[ACTIVE_CHAIN_IDS[i]] = feesSummary[i];
+    } else {
+      feesSummaryByChain[ACTIVE_CHAIN_IDS[i]] = {};
+    }
+  }
+
+  return { data: feesSummaryByChain };
+}

--- a/src/domain/stats/useTotalVolume.ts
+++ b/src/domain/stats/useTotalVolume.ts
@@ -1,0 +1,26 @@
+import useSWR from "swr";
+import { arrayURLFetcher, getTotalVolumeSum } from "lib/legacy";
+import { ARBITRUM, AVALANCHE } from "config/chains";
+import { getServerUrl } from "config/backend";
+import { bigNumberify } from "lib/numbers";
+const ACTIVE_CHAIN_IDS = [ARBITRUM, AVALANCHE];
+
+export function useTotalVolume() {
+  const { data: totalVolume } = useSWR<any>(
+    ACTIVE_CHAIN_IDS.map((chain) => getServerUrl(chain, "/total_volume")),
+    {
+      fetcher: arrayURLFetcher,
+    }
+  );
+  if (totalVolume?.length > 0) {
+    return ACTIVE_CHAIN_IDS.reduce(
+      (acc, chainId, index) => {
+        const sum = getTotalVolumeSum(totalVolume[index])!;
+        acc[chainId] = sum;
+        acc.total = acc.total.add(sum);
+        return acc;
+      },
+      { total: bigNumberify(0)! }
+    );
+  }
+}

--- a/src/domain/stats/useVolumeInfo.ts
+++ b/src/domain/stats/useVolumeInfo.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from "react";
+import { gql } from "@apollo/client";
+import { getGmxGraphClient } from "lib/subgraph/clients";
+import { bigNumberify } from "lib/numbers";
+import { ARBITRUM, AVALANCHE } from "config/chains";
+import { BigNumber } from "ethers";
+import { VolumeInfo, VolumeStat } from "./types";
+
+export function useVolumeInfo() {
+  const [volumeInfo, setVolumeInfo] = useState<null | VolumeInfo>(null);
+  useEffect(() => {
+    const _volumeInfo: VolumeInfo = {
+      totalVolume: bigNumberify(0) as BigNumber,
+      [AVALANCHE]: { totalVolume: bigNumberify(0) as BigNumber },
+      [ARBITRUM]: { totalVolume: bigNumberify(0) as BigNumber },
+    };
+
+    Promise.all(
+      [ARBITRUM, AVALANCHE].map(async (chainId) => {
+        const client = getGmxGraphClient(chainId);
+        const query = gql`
+          {
+            volumeStats(
+              orderBy: ${chainId === ARBITRUM ? "id" : "timestamp"},
+              orderDirection: desc,
+              first: 24
+              where: { period: hourly }
+            ) {
+              swap
+              margin
+              liquidation
+              mint
+              burn
+            }
+          }
+        `;
+        const res = await client!.query({ query });
+
+        const volume = res.data.volumeStats.reduce((acc: BigNumber, item: VolumeStat) => {
+          return acc.add(item.swap).add(item.margin).add(item.liquidation).add(item.mint).add(item.burn);
+        }, bigNumberify(0));
+
+        _volumeInfo[chainId] = { totalVolume: volume };
+        _volumeInfo.totalVolume = _volumeInfo.totalVolume.add(volume);
+      })
+    ).then(() => {
+      setVolumeInfo(_volumeInfo);
+    });
+  }, []);
+
+  return volumeInfo;
+}

--- a/src/lib/subgraph/clients.ts
+++ b/src/lib/subgraph/clients.ts
@@ -1,15 +1,14 @@
 import { createClient } from "./utils";
-import { SUBGRAPH_URLS } from "config/subgraph";
-import { ARBITRUM, ARBITRUM_TESTNET, AVALANCHE } from "config/chains";
+import { ARBITRUM, ARBITRUM_TESTNET, AVALANCHE, ETH_MAINNET } from "config/chains";
 
-export const chainlinkClient = createClient(SUBGRAPH_URLS.common.chainLink);
+export const chainlinkClient = createClient(ETH_MAINNET, "chainLink");
 
-export const arbitrumGraphClient = createClient(SUBGRAPH_URLS[ARBITRUM].stats);
-export const arbitrumReferralsGraphClient = createClient(SUBGRAPH_URLS[ARBITRUM].referrals);
-export const nissohGraphClient = createClient(SUBGRAPH_URLS[ARBITRUM].nissohVault);
+export const arbitrumGraphClient = createClient(ARBITRUM, "stats");
+export const arbitrumReferralsGraphClient = createClient(ARBITRUM, "referrals");
+export const nissohGraphClient = createClient(ARBITRUM, "nissohVault");
 
-export const avalancheGraphClient = createClient(SUBGRAPH_URLS[AVALANCHE].stats);
-export const avalancheReferralsGraphClient = createClient(SUBGRAPH_URLS[AVALANCHE].referrals);
+export const avalancheGraphClient = createClient(AVALANCHE, "stats");
+export const avalancheReferralsGraphClient = createClient(AVALANCHE, "referrals");
 
 export function getGmxGraphClient(chainId: number) {
   if (chainId === ARBITRUM) {

--- a/src/lib/subgraph/utils.ts
+++ b/src/lib/subgraph/utils.ts
@@ -1,8 +1,10 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { getSubgraphUrl } from "config/subgraph";
 
-export function createClient(uri: string) {
+export function createClient(chainId: number, subgraph: string) {
+  const url = getSubgraphUrl(chainId, subgraph);
   return new ApolloClient({
-    uri,
+    uri: url,
     cache: new InMemoryCache(),
   });
 }


### PR DESCRIPTION
**Currently subgraphs don't have hourly data for VolumeStat entities. They should be updated and reindexed before merging this PR**

test subgraphs:
- https://thegraph.com/hosted-service/subgraph/gdev8317/gmx-arbitrum-stats?version=pending
- https://thegraph.com/hosted-service/subgraph/gdev8317/gmx-avalanche-staging?version=pending

after they are fully synced production subgraphs may be updated

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204042351552672