### PR TITLE
fix 'autoRefreshOnNetworkChange' undefined

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -99,7 +99,7 @@ import { useChainId } from "lib/chains";
 import ExternalLink from "components/ExternalLink/ExternalLink";
 import { isDevelopment } from "config/env";
 
-if ("ethereum" in window) {
+if ("ethereum" in window && typeof window.ethereum.autoRefreshOnNetworkChange !== "undefined") {
   window.ethereum.autoRefreshOnNetworkChange = false;
 }
 


### PR DESCRIPTION
# Description
According to MetaMask docs, "autoRefreshOnNetworkChange" has been removed:
https://docs.metamask.io/guide/provider-migration.html#handling-the-removal-of-ethereum-autorefreshonnetworkchange

It will crash the app when Metamask is installed, with the error

> Uncaught TypeError: Cannot set properties of undefined (setting 'autoRefreshOnNetworkChange')

## Type of change
[x] Bug fix (non-breaking change which fixes an issue)

## Solution
Put a check if `ethereum.autoRefreshOnNetworkChange` is defined.