### PR TITLE
add opposite funding rate text in tooltip

### DIFF
--- a/src/components/Synthetics/MarketCard/MarketCard.tsx
+++ b/src/components/Synthetics/MarketCard/MarketCard.tsx
@@ -65,18 +65,27 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
     if (!fundingRateLong || !fundingRateShort) return [];
 
     const positiveLong = fundingRateLong?.gt(0);
+    const longSign = positiveLong ? "+" : "-";
     const long = (
       <Trans>
         Long positions {positiveLong ? t`receive` : t`pay`} a Funding Fee of{" "}
-        <span className={positiveLong ? "text-green" : "text-red"}>{formatAmount(fundingRateLong.abs(), 30, 4)}%</span>{" "}
+        <span className={positiveLong ? "text-green" : "text-red"}>
+          {longSign}
+          {formatAmount(fundingRateLong.abs(), 30, 4)}%
+        </span>{" "}
         per hour.
       </Trans>
     );
+
     const positveShort = fundingRateShort?.gt(0);
+    const shortSign = positveShort ? "+" : "-";
     const short = (
       <Trans>
         Short positions {positveShort ? t`receive` : t`pay`} a Funding Fee of{" "}
-        <span className={positveShort ? "text-green" : "text-red"}>{formatAmount(fundingRateShort.abs(), 30, 4)}%</span>{" "}
+        <span className={positveShort ? "text-green" : "text-red"}>
+          {shortSign}
+          {formatAmount(fundingRateShort.abs(), 30, 4)}%
+        </span>{" "}
         per hour.
       </Trans>
     );

--- a/src/components/Synthetics/MarketCard/MarketCard.tsx
+++ b/src/components/Synthetics/MarketCard/MarketCard.tsx
@@ -61,7 +61,7 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
   const indexName = marketInfo && getMarketIndexName(marketInfo);
   const poolName = marketInfo && getMarketPoolName(marketInfo);
 
-  const [currentFeeElement, oppositeFeeElement] = useMemo(() => {
+  const renderFeesTooltipContent = useCallback(() => {
     if (!fundingRateLong || !fundingRateShort) return [];
 
     const positiveLong = fundingRateLong?.gt(0);
@@ -88,10 +88,8 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
       </Trans>
     );
 
-    return isLong ? [long, short] : [short, long];
-  }, [fundingRateLong, fundingRateShort, isLong]);
+    const [currentFeeElement, oppositeFeeElement] = isLong ? [long, short] : [short, long];
 
-  const renderFeesTooltipContent = useCallback(() => {
     return (
       <div>
         {currentFeeElement}
@@ -100,7 +98,7 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
         {oppositeFeeElement}
       </div>
     );
-  }, [currentFeeElement, oppositeFeeElement]);
+  }, [fundingRateLong, fundingRateShort, isLong]);
 
   return (
     <div className="Exchange-swap-market-box App-box App-box-border">

--- a/src/components/Synthetics/MarketCard/MarketCard.tsx
+++ b/src/components/Synthetics/MarketCard/MarketCard.tsx
@@ -16,7 +16,7 @@ import { formatAmount, formatPercentage, formatUsd, getBasisPoints } from "lib/n
 import ExchangeInfoRow from "components/Exchange/ExchangeInfoRow";
 import { ShareBar } from "components/ShareBar/ShareBar";
 import { getBorrowingFactorPerPeriod, getFundingFactorPerPeriod } from "domain/synthetics/fees";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import "./MarketCard.scss";
 
 export type Props = {
@@ -61,7 +61,7 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
   const indexName = marketInfo && getMarketIndexName(marketInfo);
   const poolName = marketInfo && getMarketPoolName(marketInfo);
 
-  const fundingRateElements = useMemo(() => {
+  const [currentFeeElement, oppositeFeeElement] = useMemo(() => {
     if (!fundingRateLong || !fundingRateShort) return [];
 
     const positiveLong = fundingRateLong?.gt(0);
@@ -90,6 +90,17 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
 
     return isLong ? [long, short] : [short, long];
   }, [fundingRateLong, fundingRateShort, isLong]);
+
+  const renderFeesTooltipContent = useCallback(() => {
+    return (
+      <div>
+        {currentFeeElement}
+        <br />
+        <br />
+        {oppositeFeeElement}
+      </div>
+    );
+  }, [currentFeeElement, oppositeFeeElement]);
 
   return (
     <div className="Exchange-swap-market-box App-box App-box-border">
@@ -171,14 +182,7 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
                 fundingRate ? `${fundingRate.gt(0) ? "+" : "-"}${formatAmount(fundingRate.abs(), 30, 4)}% / 1h` : "..."
               }
               position="right-bottom"
-              renderContent={() => (
-                <div>
-                  <Trans>{fundingRateElements[0]}</Trans>
-                  <br />
-                  <br />
-                  <Trans>{fundingRateElements[1]}</Trans>
-                </div>
-              )}
+              renderContent={renderFeesTooltipContent}
             />
           }
         />

--- a/src/components/Synthetics/MarketCard/MarketCard.tsx
+++ b/src/components/Synthetics/MarketCard/MarketCard.tsx
@@ -61,7 +61,7 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
   const indexName = marketInfo && getMarketIndexName(marketInfo);
   const poolName = marketInfo && getMarketPoolName(marketInfo);
 
-  const renderFeesTooltipContent = useCallback(() => {
+  const renderFundingFeeTooltipContent = useCallback(() => {
     if (!fundingRateLong || !fundingRateShort) return [];
 
     const positiveLong = fundingRateLong?.gt(0);
@@ -180,7 +180,7 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
                 fundingRate ? `${fundingRate.gt(0) ? "+" : "-"}${formatAmount(fundingRate.abs(), 30, 4)}% / 1h` : "..."
               }
               position="right-bottom"
-              renderContent={renderFeesTooltipContent}
+              renderContent={renderFundingFeeTooltipContent}
             />
           }
         />

--- a/src/components/Synthetics/MarketCard/MarketCard.tsx
+++ b/src/components/Synthetics/MarketCard/MarketCard.tsx
@@ -65,12 +65,11 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
     if (!fundingRateLong || !fundingRateShort) return [];
 
     const positiveLong = fundingRateLong?.gt(0);
-    const longSign = positiveLong ? "+" : "-";
     const long = (
       <Trans>
         Long positions {positiveLong ? t`receive` : t`pay`} a Funding Fee of{" "}
         <span className={positiveLong ? "text-green" : "text-red"}>
-          {longSign}
+          {positiveLong ? "+" : "-"}
           {formatAmount(fundingRateLong.abs(), 30, 4)}%
         </span>{" "}
         per hour.
@@ -78,12 +77,11 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
     );
 
     const positveShort = fundingRateShort?.gt(0);
-    const shortSign = positveShort ? "+" : "-";
     const short = (
       <Trans>
         Short positions {positveShort ? t`receive` : t`pay`} a Funding Fee of{" "}
         <span className={positveShort ? "text-green" : "text-red"}>
-          {shortSign}
+          {positveShort ? "+" : "-"}
           {formatAmount(fundingRateShort.abs(), 30, 4)}%
         </span>{" "}
         per hour.

--- a/src/components/Synthetics/MarketCard/MarketCard.tsx
+++ b/src/components/Synthetics/MarketCard/MarketCard.tsx
@@ -64,24 +64,24 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
   const renderFundingFeeTooltipContent = useCallback(() => {
     if (!fundingRateLong || !fundingRateShort) return [];
 
-    const positiveLong = fundingRateLong?.gt(0);
+    const isLongPositive = fundingRateLong?.gt(0);
     const long = (
       <Trans>
-        Long positions {positiveLong ? t`receive` : t`pay`} a Funding Fee of{" "}
-        <span className={positiveLong ? "text-green" : "text-red"}>
-          {positiveLong ? "+" : "-"}
+        Long positions {isLongPositive ? t`receive` : t`pay`} a Funding Fee of{" "}
+        <span className={isLongPositive ? "text-green" : "text-red"}>
+          {isLongPositive ? "+" : "-"}
           {formatAmount(fundingRateLong.abs(), 30, 4)}%
         </span>{" "}
         per hour.
       </Trans>
     );
 
-    const positveShort = fundingRateShort?.gt(0);
+    const isShortPositive = fundingRateShort?.gt(0);
     const short = (
       <Trans>
-        Short positions {positveShort ? t`receive` : t`pay`} a Funding Fee of{" "}
-        <span className={positveShort ? "text-green" : "text-red"}>
-          {positveShort ? "+" : "-"}
+        Short positions {isShortPositive ? t`receive` : t`pay`} a Funding Fee of{" "}
+        <span className={isShortPositive ? "text-green" : "text-red"}>
+          {isShortPositive ? "+" : "-"}
           {formatAmount(fundingRateShort.abs(), 30, 4)}%
         </span>{" "}
         per hour.

--- a/src/domain/synthetics/fees/utils/index.ts
+++ b/src/domain/synthetics/fees/utils/index.ts
@@ -49,7 +49,7 @@ export function getFundingFactorPerPeriod(marketInfo: MarketInfo, isLong: boolea
 
   const isLargerSide = isLong ? longsPayShorts : !longsPayShorts;
 
-  let factorPerSecond;
+  let factorPerSecond: BigNumber;
 
   if (isLargerSide) {
     factorPerSecond = fundingFactorPerSecond.mul(-1);

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr "Long Positionen"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr "Short Positionen"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr "Long Positionen"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "Long {0}"
@@ -3864,6 +3868,10 @@ msgstr ""
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "Short Positionen"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr "Kollateral"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr "Nicht gestaket"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -2483,8 +2483,12 @@ msgstr "Long Positionen"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr "Short Positionen"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2482,8 +2482,12 @@ msgid "Long Positions"
 msgstr "Long Positions"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
-msgstr "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgstr "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3873,8 +3877,12 @@ msgid "Short Positions"
 msgstr "Short Positions"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
-msgstr "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgstr "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2486,8 +2486,12 @@ msgstr "Long Positions"
 #~ msgstr "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
-msgstr "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
+msgstr "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3881,8 +3885,12 @@ msgstr "Short Positions"
 #~ msgstr "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
-msgstr "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
+msgstr "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2481,6 +2481,10 @@ msgstr "Long Open Interest"
 msgid "Long Positions"
 msgstr "Long Positions"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "Long {0}"
@@ -3867,6 +3871,10 @@ msgstr "Short Open Interest"
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "Short Positions"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5270,8 +5278,8 @@ msgid "collateral"
 msgstr "collateral"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr "earn"
+#~ msgid "earn"
+#~ msgstr "earn"
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5295,8 +5303,14 @@ msgid "not staked"
 msgstr "not staked"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
 msgstr "pay"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
+msgstr "receive"
 
 #: src/pages/PositionsOverview/PositionsOverview.js
 msgid "size"
@@ -5323,6 +5337,11 @@ msgstr "{0, plural, one {Cancel order} other {Cancel # orders}}"
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
 msgstr "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
+msgstr "{0}"
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"
@@ -5509,8 +5528,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr "{longOrShortText} {0} market selected"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr "{longShortText} positions {0} a funding fee of {1}% per hour."
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -5356,8 +5356,8 @@ msgstr "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbols
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr "{0}"
+#~ msgid "{0}"
+#~ msgstr "{0}"
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr "Posiciones largas"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr "Posiciones en Corto"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2483,8 +2483,12 @@ msgstr "Posiciones largas"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr "Posiciones en Corto"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr "Posiciones largas"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "Largo {0}"
@@ -3864,6 +3868,10 @@ msgstr ""
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "Posiciones en Corto"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr "garantía"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr "no stakeado"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2483,8 +2483,12 @@ msgstr "Positions long"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr "Positions Shorts"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr "Positions long"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr "Positions Shorts"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr "Positions long"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "Long {0}"
@@ -3864,6 +3868,10 @@ msgstr ""
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "Positions Shorts"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr "collatéral"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr "non staké"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr "ロングポジション"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr "ショートポジション"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2483,8 +2483,12 @@ msgstr "ロングポジション"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr "ショートポジション"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr "ロングポジション"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "ロング {0}"
@@ -3864,6 +3868,10 @@ msgstr ""
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "ショートポジション"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr "担保"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr "ステークされていない"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr "롱 포지션"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr "숏 포지션"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr "롱 포지션"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "롱 {0}"
@@ -3864,6 +3868,10 @@ msgstr ""
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "숏 포지션"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr "담보"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr "스테이킹되지 않음"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2483,8 +2483,12 @@ msgstr "롱 포지션"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr "숏 포지션"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -2483,8 +2483,12 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr ""
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr ""
@@ -3863,6 +3867,10 @@ msgstr ""
 
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr "Лонг позиции"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr "Позиция Шорта"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr "Лонг позиции"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "Лонг {0}"
@@ -3864,6 +3868,10 @@ msgstr ""
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "Позиция Шорта"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr "залог"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr "без стейкинга"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2483,8 +2483,12 @@ msgstr "Лонг позиции"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr "Позиция Шорта"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2478,6 +2478,10 @@ msgstr ""
 msgid "Long Positions"
 msgstr "开仓做多"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
+
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
 msgstr "做多 {0}"
@@ -3864,6 +3868,10 @@ msgstr ""
 #: src/pages/Dashboard/DashboardV2.js
 msgid "Short Positions"
 msgstr "做空仓位"
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"
@@ -5267,8 +5275,8 @@ msgid "collateral"
 msgstr "抵押品"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "earn"
-msgstr ""
+#~ msgid "earn"
+#~ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.js
 msgid "esGMX OTC Market"
@@ -5292,7 +5300,13 @@ msgid "not staked"
 msgstr "未质押的"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
 msgid "pay"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "receive"
 msgstr ""
 
 #: src/pages/PositionsOverview/PositionsOverview.js
@@ -5319,6 +5333,11 @@ msgstr ""
 
 #: src/components/Synthetics/GmSwap/GmConfirmationBox/GmConfirmationBox.tsx
 msgid "{0, plural, one {Pending {symbolsText} approval} other {Pending {symbolsText} approvals}}"
+msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "{0}"
 msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -5503,8 +5522,8 @@ msgid "{longOrShortText} {0} market selected"
 msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
-msgstr ""
+#~ msgid "{longShortText} positions {0} a funding fee of {1}% per hour."
+#~ msgstr ""
 
 #: src/components/Synthetics/ClaimHistoryRow/ClaimHistoryRow.tsx
 msgid "{marketsCount, plural, one {# Market} other {# Markets}}"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2483,8 +2483,12 @@ msgstr "开仓做多"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+msgid "Long positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Long {0}"
@@ -3878,8 +3882,12 @@ msgstr "做空仓位"
 #~ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+msgid "Short positions {0} a Funding Fee of <0>{1}{2}%</0> per hour."
 msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+#~ msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
+#~ msgstr ""
 
 #: src/components/Exchange/SwapBox.js
 msgid "Short {0}"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -5353,8 +5353,8 @@ msgstr ""
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "{0}"
-msgstr ""
+#~ msgid "{0}"
+#~ msgstr ""
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "{0} <0><1>{indexName}</1><2>[{poolName}]</2></0> <3>market selected</3>;"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2479,7 +2479,11 @@ msgid "Long Positions"
 msgstr "开仓做多"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Long positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Long positions {0} a Funding Fee of <0>{longSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js
@@ -3870,7 +3874,11 @@ msgid "Short Positions"
 msgstr "做空仓位"
 
 #: src/components/Synthetics/MarketCard/MarketCard.tsx
-msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgid "Short positions {0} a Funding Fee of <0>{1}%</0> per hour."
+#~ msgstr ""
+
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "Short positions {0} a Funding Fee of <0>{shortSign}{1}%</0> per hour."
 msgstr ""
 
 #: src/components/Exchange/SwapBox.js


### PR DESCRIPTION
fundingRate -> fundingRateShort & fundingRateLong

fundingRateTexts is opposite messages, first message always relates to currently active position type

https://app.asana.com/0/1204313444805313/1205275952944438/f