### PR TITLE
add adaptive funding rate text to markets

### DIFF
--- a/src/components/Synthetics/MarketCard/MarketCard.tsx
+++ b/src/components/Synthetics/MarketCard/MarketCard.tsx
@@ -63,6 +63,7 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
 
   const renderFundingFeeTooltipContent = useCallback(() => {
     if (!fundingRateLong || !fundingRateShort) return [];
+    const isMarketWithAdaptiveFundingRate = marketInfo?.fundingIncreaseFactorPerSecond.gt(0);
 
     const isLongPositive = fundingRateLong?.gt(0);
     const long = (
@@ -96,9 +97,22 @@ export function MarketCard({ marketInfo, allowedSlippage, isLong, isIncrease }: 
         <br />
         <br />
         {oppositeFeeElement}
+        {isMarketWithAdaptiveFundingRate && (
+          <>
+            <br />
+            <br />
+            <Trans>
+              This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio
+              of longs and shorts.
+              <br />
+              <br />
+              <ExternalLink href="https://docs.gmx.io/docs/trading/v2/#adaptive-funding">Read more</ExternalLink>.
+            </Trans>
+          </>
+        )}
       </div>
     );
-  }, [fundingRateLong, fundingRateShort, isLong]);
+  }, [fundingRateLong, fundingRateShort, isLong, marketInfo]);
 
   return (
     <div className="Exchange-swap-market-box App-box App-box-border">

--- a/src/config/dataStore.ts
+++ b/src/config/dataStore.ts
@@ -27,6 +27,7 @@ export const CUMULATIVE_BORROWING_FACTOR_KEY = hashString("CUMULATIVE_BORROWING_
 export const TOTAL_BORROWING_KEY = hashString("TOTAL_BORROWING");
 export const FUNDING_FACTOR_KEY = hashString("FUNDING_FACTOR");
 export const FUNDING_EXPONENT_FACTOR_KEY = hashString("FUNDING_EXPONENT_FACTOR");
+export const FUNDING_INCREASE_FACTOR_PER_SECOND = hashString("FUNDING_INCREASE_FACTOR_PER_SECOND");
 export const MAX_PNL_FACTOR_KEY = hashString("MAX_PNL_FACTOR");
 export const MAX_PNL_FACTOR_FOR_WITHDRAWALS_KEY = hashString("MAX_PNL_FACTOR_FOR_WITHDRAWALS");
 export const MAX_PNL_FACTOR_FOR_DEPOSITS_KEY = hashString("MAX_PNL_FACTOR_FOR_DEPOSITS");
@@ -140,6 +141,10 @@ export function fundingFactorKey(market: string) {
 
 export function fundingExponentFactorKey(market: string) {
   return hashData(["bytes32", "address"], [FUNDING_EXPONENT_FACTOR_KEY, market]);
+}
+
+export function fundingIncreaseFactorPerSecondKey(market: string) {
+  return hashData(["bytes32", "address"], [FUNDING_INCREASE_FACTOR_PER_SECOND, market]);
 }
 
 export function maxPnlFactorKey(pnlFactorType: string, market: string, isLong: boolean) {

--- a/src/config/events.ts
+++ b/src/config/events.ts
@@ -53,6 +53,20 @@ export const appEventsData: EventData[] = [
       },
     ],
   },
+  {
+    id: "v2-adaptive-funding",
+    title: "Adaptive Funding is live",
+    isActive: true,
+    validTill: "30 Oct 2023, 12:00",
+    bodyText: "Adaptive Funding has been enabled for the AVAX/USD market on Avalanche.",
+    buttons: [
+      {
+        text: "Read More",
+        link: "https://docs.gmx.io/docs/trading/v2/#adaptive-funding",
+        newTab: true,
+      },
+    ],
+  },
   // {
   //   id: "usdc-to-usdce",
   //   title: "USDC renamed to USDC.e",

--- a/src/config/events.ts
+++ b/src/config/events.ts
@@ -61,7 +61,7 @@ export const appEventsData: EventData[] = [
     bodyText: "Adaptive Funding has been enabled for the AVAX/USD market on Avalanche.",
     buttons: [
       {
-        text: "Read More",
+        text: "Read More.",
         link: "https://docs.gmx.io/docs/trading/v2/#adaptive-funding",
         newTab: true,
       },

--- a/src/domain/synthetics/markets/types.ts
+++ b/src/domain/synthetics/markets/types.ts
@@ -54,6 +54,7 @@ export type MarketInfo = Market & {
 
   fundingFactor: BigNumber;
   fundingExponentFactor: BigNumber;
+  fundingIncreaseFactorPerSecond: BigNumber;
 
   totalBorrowingFees: BigNumber;
 

--- a/src/domain/synthetics/markets/useMarketsInfo.ts
+++ b/src/domain/synthetics/markets/useMarketsInfo.ts
@@ -8,6 +8,7 @@ import {
   claimableFundingAmountKey,
   fundingExponentFactorKey,
   fundingFactorKey,
+  fundingIncreaseFactorPerSecondKey,
   isMarketDisabledKey,
   maxPnlFactorKey,
   maxPoolAmountForDepositKey,
@@ -210,6 +211,10 @@ export function useMarketsInfo(chainId: number): MarketsInfoResult {
               fundingExponentFactor: {
                 methodName: "getUint",
                 params: [fundingExponentFactorKey(marketAddress)],
+              },
+              fundingIncreaseFactorPerSecond: {
+                methodName: "getUint",
+                params: [fundingIncreaseFactorPerSecondKey(marketAddress)],
               },
               maxPnlFactorForTradersLong: {
                 methodName: "getUint",
@@ -434,6 +439,9 @@ export function useMarketsInfo(chainId: number): MarketsInfoResult {
           borrowingExponentFactorShort: BigNumber.from(dataStoreValues.borrowingExponentFactorShort.returnValues[0]),
           fundingFactor: BigNumber.from(dataStoreValues.fundingFactor.returnValues[0]),
           fundingExponentFactor: BigNumber.from(dataStoreValues.fundingExponentFactor.returnValues[0]),
+          fundingIncreaseFactorPerSecond: BigNumber.from(
+            dataStoreValues.fundingIncreaseFactorPerSecond.returnValues[0]
+          ),
           pnlLongMax: BigNumber.from(poolValueInfoMax.longPnl),
           pnlLongMin: BigNumber.from(poolValueInfoMin.longPnl),
           pnlShortMax: BigNumber.from(poolValueInfoMax.shortPnl),

--- a/src/domain/synthetics/testUtils/mocks.ts
+++ b/src/domain/synthetics/testUtils/mocks.ts
@@ -204,6 +204,7 @@ export function mockMarketsInfoData(
       borrowingExponentFactorShort: BigNumber.from(0),
       fundingFactor: BigNumber.from(0),
       fundingExponentFactor: BigNumber.from(0),
+      fundingIncreaseFactorPerSecond: BigNumber.from(0),
 
       totalBorrowingFees: BigNumber.from(0),
       minCollateralFactor: BigNumber.from(0),

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4507,6 +4507,10 @@ msgstr "Dieser Code wurde von jemand anderem auf {0} genommen, du wirst keine Ra
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "Dieser Code ist noch nicht auf {0} registriert, du wirst dort keine Rabatte erhalten.<0/><1/>Schalte dein Netzwerk um, um diesen Code auf {1} zu erstellen."
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "Diese Position wurde liquidiert, da die maximale Hebelwirkung von 100x überschritten wurde."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4510,6 +4510,10 @@ msgstr "This code has been taken by someone else on {0}, you will not receive re
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "This position was liquidated as the max leverage of 100x was exceeded."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4507,6 +4507,10 @@ msgstr "Este código ya ha sido cogido por alguien más en {0}, no recibirás re
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "Este código no está registrado en {0}, por lo que no recibirás reembolsos ahí.<0/><1/>Cambia de red para crear este código en {1}."
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "Esta posición fue liquidada debido a que el apalancamiento máximo de 100x fue superado"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4507,6 +4507,10 @@ msgstr "Ce code a été utilisé par quelqu'un d'autre sur {0}, vous ne recevrez
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "Ce code n'est pas encore enregistré sur {0}, vous ne recevrez pas de remise dans ce cas.<0/><1/>Changez votre réseau pour créer ce code sur  {1}."
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "Cette position a été liquidée car le levier maximal de 100x a été dépassé."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4507,6 +4507,10 @@ msgstr "このコードは{0}上で他の人がすでに取得済です。この
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "このコードは{0}上ではまだ登録されていないため、紹介報酬を受け取ることはできません。<0/><1/>ネットワークを切り替えて、{1}上でこのコードを作成してください。"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "このポジションは最大レバレッジ倍率(100倍)を超過したため清算されました。"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4507,6 +4507,10 @@ msgstr "해당 코드는 {0}에서 다른 사용자에 의해 이미 사용되�
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "해당 코드는 {0}에 아직 등록되지 않았기때문에, 소개 보수를 받을 수 없습니다.<0/><1/>네트워크를 변경후 해당 코드를 {1}상에서 생성하세요."
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "해당 포지션은 최대 레버리지인 100x를 초과하여 청산되었습니다."

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4507,6 +4507,10 @@ msgstr ""
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr ""
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4507,6 +4507,10 @@ msgstr "Этот код был взят кем-то другим на {0}, вы 
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "Этот код еще не зарегистрирован на {0}, вы не будете получать рибейты там.<0/><1/>Переключите свою сеть, чтобы создать этот код на {1}."
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "Эта позиция была ликвидирована, так как было превышено максимальное кредитное плечо 100x."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4507,6 +4507,10 @@ msgstr "这个代码在{0}上已被别人取用，你将不会获得从{1}上使
 msgid "This code is not yet registered on {0}, you will not receive rebates there.<0/><1/>Switch your network to create this code on {1}."
 msgstr "此代码尚未在{0}上注册，你将不会收到回扣<0/><1/>切换你的网络，在{1}上创建此代码"
 
+#: src/components/Synthetics/MarketCard/MarketCard.tsx
+msgid "This market uses an Adaptive Funding Rate. The Funding Rate will adjust over time depending on the ratio of longs and shorts.<0/><1/><2>Read more</2>."
+msgstr ""
+
 #: src/components/Exchange/TradeHistory.js
 msgid "This position was liquidated as the max leverage of 100x was exceeded."
 msgstr "这个头寸因超过100倍的最大杠杆而被清算了"


### PR DESCRIPTION
[x] Add adaptive funding rate text to events and on the market card on trade page

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205743945727419