### PR TITLE
fix unwanted zoom to focused input

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="google" content="notranslate" />
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta property="og:title" content="GMX | Decentralized Perpetual Exchange" />
     <meta property="og:site_name" content="GMX" />


### PR DESCRIPTION
That's not obvious why this is a solution for unwanted auto-zoom on mobile devices while focusing input field. But it works good.
Originally viewport's `maximum-scale` property has limited user's ability to zoom-in more then by a specified ratio. But now Apple and Google ignore this property. The only side effect of this property is a disabled auto zoom while user is still capable to zoom the page manually as he wants.

Other possible solutions:
1. Make input's font-size 16px or more (mismatch original design)
2. Keep auto-zoom but let user do pinch actions while modal is open (may cause a problem with absolute positioning)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206189396973385