### PR TITLE
Update padding in TradeHistorySynthetics.scss for padded-cell class

### DIFF
--- a/src/components/Synthetics/TradeHistory/TradeHistorySynthetics.scss
+++ b/src/components/Synthetics/TradeHistory/TradeHistorySynthetics.scss
@@ -32,8 +32,7 @@
   }
 
   &-padded-cell {
-    padding: 1em;
-    padding-left: 1.4em;
+    padding: 1em 1.5rem;
   }
 
   &-controls {


### PR DESCRIPTION
[bad padding]"No trades yet"
<img width="151" alt="image" src="https://github.com/gmx-io/gmx-interface/assets/155806380/13b0cc30-059c-415c-af72-ee25a33a811b">