### PR TITLE
Fix infinite order toast 

### DIFF
--- a/src/components/Synthetics/StatusNotification/OrderStatusNotification.tsx
+++ b/src/components/Synthetics/StatusNotification/OrderStatusNotification.tsx
@@ -289,17 +289,17 @@ export function OrdersStatusNotificiation({
   );
 
   const [ordersByPendingKey, ordersByContractKey] = useMemo(() => {
-    const pendingKeyMap = new Map<string, PendingOrderData>();
-    const contractKeyMap = new Map<string, PendingOrderData>();
+    const ordersByPendingKey = new Map<string, PendingOrderData>();
+    const ordersByContractKey = new Map<string, PendingOrderData>();
     pendingOrders.forEach((order) => {
       if (order.orderKey) {
-        contractKeyMap.set(order.orderKey, order);
+        ordersByContractKey.set(order.orderKey, order);
       }
 
       const key = getPendingOrderKey(order);
-      pendingKeyMap.set(key, order);
+      ordersByPendingKey.set(key, order);
     });
-    return [pendingKeyMap, contractKeyMap];
+    return [ordersByPendingKey, ordersByContractKey];
   }, [pendingOrders]);
 
   useEffect(() => {

--- a/src/context/SyntheticsEvents/utils.ts
+++ b/src/context/SyntheticsEvents/utils.ts
@@ -1,29 +1,4 @@
-import { EventLogData, PendingDepositData, PendingOrderData, PendingWithdrawalData } from "./types";
-
-export function parseEventLogData(eventData): EventLogData {
-  const ret: any = {};
-  for (const typeKey of [
-    "addressItems",
-    "uintItems",
-    "intItems",
-    "boolItems",
-    "bytes32Items",
-    "bytesItems",
-    "stringItems",
-  ]) {
-    ret[typeKey] = {};
-
-    for (const listKey of ["items", "arrayItems"]) {
-      ret[typeKey][listKey] = {};
-
-      for (const item of eventData[typeKey][listKey]) {
-        ret[typeKey][listKey][item.key] = item.value;
-      }
-    }
-  }
-
-  return ret as EventLogData;
-}
+import { PendingDepositData, PendingOrderData, PendingWithdrawalData } from "./types";
 
 export function getPendingOrderKey(data: Omit<PendingOrderData, "txnType">) {
   return [

--- a/src/context/WebsocketContext/subscribeToEvents.ts
+++ b/src/context/WebsocketContext/subscribeToEvents.ts
@@ -1,0 +1,217 @@
+import EventEmitter from "abis/EventEmitter.json";
+import { getContract } from "config/contracts";
+import type { EventLogData, EventTxnParams } from "context/SyntheticsEvents/types";
+import { AbiCoder, Contract, Provider, ProviderEvent, ZeroAddress, ethers } from "ethers";
+import { MutableRefObject } from "react";
+
+const vaultEvents = {
+  UpdatePosition: "onUpdatePosition",
+  ClosePosition: "onClosePosition",
+  IncreasePosition: "onIncreasePosition",
+  DecreasePosition: "onDecreasePosition",
+} as const;
+
+const positionRouterEvents = {
+  CancelIncreasePosition: "onCancelIncreasePosition",
+  CancelDecreasePosition: "onCancelDecreasePosition",
+} as const;
+
+export function subscribeToV1Events(
+  wsVault: Contract,
+  wsPositionRouter: Contract,
+  callExchangeRef: (method: any, ...args: any[]) => void
+) {
+  const unsubs: (() => void)[] = [];
+
+  Object.keys(vaultEvents).forEach((eventName) => {
+    const handlerName = vaultEvents[eventName];
+    const handler = (...args) => callExchangeRef(handlerName, ...args);
+    wsVault.on(eventName, handler);
+    unsubs.push(() => wsVault.off(eventName, handler));
+  });
+
+  Object.keys(positionRouterEvents).forEach((eventName) => {
+    const handlerName = positionRouterEvents[eventName];
+    const handler = (...args) => callExchangeRef(handlerName, ...args);
+    wsPositionRouter.on(eventName, handler);
+    unsubs.push(() => wsPositionRouter.off(eventName, handler));
+  });
+
+  return () => {
+    unsubs.forEach((unsub) => unsub());
+  };
+}
+
+const DEPOSIT_CREATED_HASH = ethers.id("DepositCreated");
+const DEPOSIT_EXECUTED_HASH = ethers.id("DepositExecuted");
+const DEPOSIT_CANCELLED_HASH = ethers.id("DepositCancelled");
+
+const WITHDRAWAL_CREATED_HASH = ethers.id("WithdrawalCreated");
+const WITHDRAWAL_EXECUTED_HASH = ethers.id("WithdrawalExecuted");
+const WITHDRAWAL_CANCELLED_HASH = ethers.id("WithdrawalCancelled");
+
+const ORDER_CREATED_HASH = ethers.id("OrderCreated");
+const ORDER_EXECUTED_HASH = ethers.id("OrderExecuted");
+const ORDER_CANCELLED_HASH = ethers.id("OrderCancelled");
+const ORDER_UPDATED_HASH = ethers.id("OrderUpdated");
+
+const POSITION_INCREASE_HASH = ethers.id("PositionIncrease");
+const POSITION_DECREASE_HASH = ethers.id("PositionDecrease");
+
+export function subscribeToV2Events(
+  chainId: number,
+  provider: Provider,
+  account: string,
+  eventLogHandlers: MutableRefObject<
+    Record<string, undefined | ((data: EventLogData, txnOpts: EventTxnParams) => void)>
+  >
+) {
+  const eventEmitter = new ethers.Contract(getContract(chainId, "EventEmitter"), EventEmitter.abi, provider);
+
+  function handleEventLog(sender, eventName, eventNameHash, eventData, txnOpts) {
+    // console.log("handleEventLog", eventName);
+    eventLogHandlers.current[eventName]?.(parseEventLogData(eventData), txnOpts);
+  }
+
+  function handleEventLog1(sender, eventName, eventNameHash, topic1, eventData, txnOpts) {
+    // console.log("handleEventLog1", eventName);
+    eventLogHandlers.current[eventName]?.(parseEventLogData(eventData), txnOpts);
+  }
+
+  function handleEventLog2(msgSender, eventName, eventNameHash, topic1, topic2, eventData, txnOpts) {
+    // console.log("handleEventLog2", eventName);
+    eventLogHandlers.current[eventName]?.(parseEventLogData(eventData), txnOpts);
+  }
+
+  function handleCommonLog(e) {
+    const txnOpts: EventTxnParams = {
+      transactionHash: e.transactionHash,
+      blockNumber: e.blockNumber,
+    };
+
+    try {
+      const parsed = eventEmitter.interface.parseLog(e);
+
+      if (!parsed) throw new Error("Could not parse event");
+      if (parsed.name === "EventLog") {
+        handleEventLog(parsed.args[0], parsed.args[1], parsed.args[2], parsed.args[3], txnOpts);
+      } else if (parsed.name === "EventLog1") {
+        handleEventLog1(parsed.args[0], parsed.args[1], parsed.args[2], parsed.args[3], parsed.args[4], txnOpts);
+      } else if (parsed.name === "EventLog2") {
+        handleEventLog2(
+          parsed.args[0],
+          parsed.args[1],
+          parsed.args[2],
+          parsed.args[3],
+          parsed.args[4],
+          parsed.args[5],
+          txnOpts
+        );
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error("error parsing event", e);
+    }
+  }
+
+  const filters: ProviderEvent[] = createV2EventFilters(chainId, account, provider);
+
+  filters.forEach((filter) => {
+    provider.on(filter, handleCommonLog);
+  });
+
+  return () => {
+    filters.forEach((filter) => {
+      provider.off(filter, handleCommonLog);
+    });
+  };
+}
+
+function parseEventLogData(eventData): EventLogData {
+  const ret: any = {};
+  for (const typeKey of [
+    "addressItems",
+    "uintItems",
+    "intItems",
+    "boolItems",
+    "bytes32Items",
+    "bytesItems",
+    "stringItems",
+  ]) {
+    ret[typeKey] = {};
+
+    for (const listKey of ["items", "arrayItems"]) {
+      ret[typeKey][listKey] = {};
+
+      for (const item of eventData[typeKey][listKey]) {
+        ret[typeKey][listKey][item.key] = item.value;
+      }
+    }
+  }
+
+  return ret as EventLogData;
+}
+
+function createV2EventFilters(chainId: number, account: string, wsProvider: Provider): ProviderEvent[] {
+  const addressHash = AbiCoder.defaultAbiCoder().encode(["address"], [account]);
+  const eventEmitter = new ethers.Contract(getContract(chainId, "EventEmitter"), EventEmitter.abi, wsProvider);
+  const EVENT_LOG_TOPIC = eventEmitter.interface.getEvent("EventLog")?.topicHash ?? null;
+  const EVENT_LOG1_TOPIC = eventEmitter.interface.getEvent("EventLog1")?.topicHash ?? null;
+  const EVENT_LOG2_TOPIC = eventEmitter.interface.getEvent("EventLog2")?.topicHash ?? null;
+  return [
+    // DEPOSITS AND WITHDRAWALS
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [EVENT_LOG2_TOPIC, [DEPOSIT_CREATED_HASH, WITHDRAWAL_CREATED_HASH], null, addressHash],
+    },
+    // NEW CONTRACTS
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [EVENT_LOG2_TOPIC, [DEPOSIT_CREATED_HASH, WITHDRAWAL_CREATED_HASH], null, addressHash],
+    },
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [
+        EVENT_LOG_TOPIC,
+        [DEPOSIT_CANCELLED_HASH, DEPOSIT_EXECUTED_HASH, WITHDRAWAL_CANCELLED_HASH, WITHDRAWAL_EXECUTED_HASH],
+      ],
+    },
+    // NEW CONTRACTS
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [
+        EVENT_LOG2_TOPIC,
+        [DEPOSIT_CANCELLED_HASH, DEPOSIT_EXECUTED_HASH, WITHDRAWAL_CANCELLED_HASH, WITHDRAWAL_EXECUTED_HASH],
+        null,
+        addressHash,
+      ],
+    },
+    // ORDERS
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [EVENT_LOG2_TOPIC, ORDER_CREATED_HASH, null, addressHash],
+    },
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [EVENT_LOG1_TOPIC, [ORDER_CANCELLED_HASH, ORDER_UPDATED_HASH, ORDER_EXECUTED_HASH]],
+    },
+    // NEW CONTRACTS
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [EVENT_LOG2_TOPIC, [ORDER_CANCELLED_HASH, ORDER_UPDATED_HASH, ORDER_EXECUTED_HASH], null, addressHash],
+    },
+    // POSITIONS
+    {
+      address: getContract(chainId, "EventEmitter"),
+      topics: [EVENT_LOG1_TOPIC, [POSITION_INCREASE_HASH, POSITION_DECREASE_HASH], addressHash],
+    },
+  ];
+}
+
+export function getTotalSubscribersEventsCount(chainId: number, provider: Provider) {
+  return (
+    createV2EventFilters(chainId, ZeroAddress, provider).length +
+    Object.keys(vaultEvents).length +
+    Object.keys(positionRouterEvents).length
+  );
+}

--- a/src/lib/useHasPageLostFocus.ts
+++ b/src/lib/useHasPageLostFocus.ts
@@ -22,7 +22,7 @@ export function useHasLostFocus(p: {
     }
 
     if (whiteListedPages?.length) {
-      checks.push(whiteListedPages.includes(location.pathname));
+      checks.push(whiteListedPages.some((whitelistedPart) => location.pathname.includes(whitelistedPart)));
     }
 
     return checks.every(Boolean);


### PR DESCRIPTION
As I understand this issue doesn't directly affected by bigints
Or maybe there is another issue with toasts but I didn't manage to find one

Issues fixed here:

- v1 was watching for incorrect url (v2 instead of v1)
- v2 was watching for incorrect urls as well 
e.x. `/trade/long` didn't satisfy condition `/trade`, see fix in `src/lib/useHasPageLostFocus.ts`

Last issue created race condition where we don't subscribe to v2 events:
https://github.com/gmx-io/gmx-interface/blob/master/src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx#L465

That looked like this:
<img width="787" alt="image" src="https://github.com/gmx-io/gmx-interface/assets/144131435/b0f7c9f7-20cb-406d-8989-36917dc553e9">

I also improved ws health check so that we check that subscriptions count matches all events that we are interested in. See `getTotalSubscribersEventsCount` implementation and usage.

Btw I also don't really like the way `useHasLostFocus` works as it immediately brings back `lostFocus` to `false`. Meaning that we are always subscribed to both v1 and v2 events which I think is redundant. But since it's just one websocket maybe it's not that crucial but open for opinions here.