### PR TITLE
fix swap path bug

### DIFF
--- a/src/components/Synthetics/ConfirmationBox/ConfirmationBox.tsx
+++ b/src/components/Synthetics/ConfirmationBox/ConfirmationBox.tsx
@@ -125,12 +125,12 @@ import {
   selectTradeboxSetKeepLeverage,
   selectTradeboxSetSelectedAcceptablePriceImpactBps,
   selectTradeboxSwapAmounts,
-  selectTradeboxSwapRoutes,
   selectTradeboxToTokenAddress,
   selectTradeboxTradeFlags,
   selectTradeboxTradeRatios,
   selectTradeboxTriggerPrice,
   selectTradeboxSelectedPositionKey,
+  selectTradeboxMaxLiquidityPath,
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import "./ConfirmationBox.scss";
@@ -184,8 +184,7 @@ export function ConfirmationBox(p: Props) {
   const toToken = getByKey(tokensData, toTokenAddress);
 
   const { isLong, isShort, isPosition, isSwap, isMarket, isLimit, isTrigger, isIncrease } = tradeFlags;
-  const swapRoute = useSelector(selectTradeboxSwapRoutes);
-  const swapLiquidityUsd = swapRoute.maxSwapLiquidity;
+  const { maxLiquidity: swapLiquidityUsd } = useSelector(selectTradeboxMaxLiquidityPath);
   const { indexToken } = marketInfo || {};
 
   const { signer, account } = useWallet();

--- a/src/components/Synthetics/OrderEditor/OrderEditor.tsx
+++ b/src/components/Synthetics/OrderEditor/OrderEditor.tsx
@@ -78,7 +78,7 @@ import {
   selectOrderEditorPriceImpactFeeBps,
   selectOrderEditorSetAcceptablePriceImpactBps,
   selectOrderEditorSizeDeltaUsd,
-  selectOrderEditorSwapRoutes,
+  selectOrderEditorFindSwapPath,
   selectOrderEditorToToken,
   selectOrderEditorTradeFlags,
   selectOrderEditorTriggerPrice,
@@ -156,7 +156,7 @@ export function OrderEditor(p: Props) {
   const nextPositionValuesForIncrease = useSelector(selectOrderEditorNextPositionValuesForIncrease);
   const nextPositionValuesWithoutPnlForIncrease = useSelector(selectOrderEditorNextPositionValuesWithoutPnlForIncrease);
 
-  const swapRoute = useSelector(selectOrderEditorSwapRoutes);
+  const findSwapPath = useSelector(selectOrderEditorFindSwapPath);
 
   const userReferralInfo = useUserReferralInfo();
   const uiFeeFactor = useUiFeeFactor(chainId);
@@ -325,7 +325,7 @@ export function OrderEditor(p: Props) {
         const leverage = BigInt((lev / 10) * BASIS_POINTS_DIVISOR);
         const increaseAmounts = getIncreasePositionAmounts({
           collateralToken,
-          findSwapPath: swapRoute.findSwapPath,
+          findSwapPath,
           indexToken: positionIndexToken,
           indexTokenAmount,
           initialCollateralAmount: positionOrder.initialCollateralDeltaAmount,

--- a/src/components/Synthetics/PositionSeller/PositionSeller.tsx
+++ b/src/components/Synthetics/PositionSeller/PositionSeller.tsx
@@ -72,12 +72,12 @@ import { selectGasLimits, selectGasPrice } from "context/SyntheticsStateContext/
 import {
   selectPositionSellerAcceptablePrice,
   selectPositionSellerDecreaseAmounts,
+  selectPositionSellerMaxLiquidityPath,
   selectPositionSellerNextPositionValuesForDecrease,
   selectPositionSellerPosition,
   selectPositionSellerReceiveToken,
   selectPositionSellerShouldSwap,
   selectPositionSellerSwapAmounts,
-  selectPositionSellerSwapRoutes,
 } from "context/SyntheticsStateContext/selectors/positionSellerSelectors";
 import {
   selectTradeboxAvailableTokensOptions,
@@ -180,7 +180,7 @@ export function PositionSeller(p: Props) {
     ? getMarkPrice({ prices: position.indexToken.prices, isLong: position.isLong, isIncrease: false })
     : undefined;
 
-  const { maxSwapLiquidity } = useSelector(selectPositionSellerSwapRoutes);
+  const { maxLiquidity: maxSwapLiquidity } = useSelector(selectPositionSellerMaxLiquidityPath);
   const decreaseAmounts = useSelector(selectPositionSellerDecreaseAmounts);
   const acceptablePrice = useSelector(selectPositionSellerAcceptablePrice);
 

--- a/src/components/Synthetics/TradeBox/TradeBox.tsx
+++ b/src/components/Synthetics/TradeBox/TradeBox.tsx
@@ -36,18 +36,19 @@ import {
   selectTradeboxExecutionFee,
   selectTradeboxExecutionPrice,
   selectTradeboxFees,
+  selectTradeboxFindSwapPath,
   selectTradeboxIncreasePositionAmounts,
   selectTradeboxLeverage,
   selectTradeboxLeverageSliderMarks,
   selectTradeboxLiquidity,
   selectTradeboxMarkPrice,
   selectTradeboxMaxLeverage,
+  selectTradeboxMaxLiquidityPath,
   selectTradeboxNextLeverageWithoutPnl,
   selectTradeboxNextPositionValues,
   selectTradeboxSelectedPosition,
   selectTradeboxState,
   selectTradeboxSwapAmounts,
-  selectTradeboxSwapRoutes,
   selectTradeboxTradeFeesType,
   selectTradeboxTradeFlags,
   selectTradeboxTradeRatios,
@@ -255,7 +256,9 @@ export function TradeBox(p: Props) {
   const feesType = useSelector(selectTradeboxTradeFeesType);
   const executionFee = useSelector(selectTradeboxExecutionFee);
   const { markRatio, triggerRatio } = useSelector(selectTradeboxTradeRatios);
-  const swapRoutes = useSelector(selectTradeboxSwapRoutes);
+  const findSwapPath = useSelector(selectTradeboxFindSwapPath);
+  const { maxLiquidity: swapOutLiquidity } = useSelector(selectTradeboxMaxLiquidityPath);
+
   const acceptablePriceImpactBuffer = useSelector(selectSavedAcceptablePriceImpactBuffer);
   const { longLiquidity, shortLiquidity, isOutPositionLiquidity } = useSelector(selectTradeboxLiquidity);
   const leverageSliderMarks = useSelector(selectTradeboxLeverageSliderMarks);
@@ -294,8 +297,6 @@ export function TradeBox(p: Props) {
     [setToTokenInputValueRaw, setIsHighPositionImpactAcceptedRef, setIsHighSwapImpactAcceptedRef]
   );
 
-  const swapOutLiquidity = swapRoutes.maxSwapLiquidity;
-
   const userReferralInfo = useUserReferralInfo();
 
   const detectAndSetAvailableMaxLeverage = useCallback(() => {
@@ -309,7 +310,7 @@ export function TradeBox(p: Props) {
         const leverage = BigInt((lev / 10) * BASIS_POINTS_DIVISOR);
         const increaseAmounts = getIncreasePositionAmounts({
           collateralToken,
-          findSwapPath: swapRoutes.findSwapPath,
+          findSwapPath,
           indexToken: toToken,
           indexTokenAmount: toTokenAmount,
           initialCollateralAmount: fromTokenAmount,
@@ -380,6 +381,7 @@ export function TradeBox(p: Props) {
   }, [
     acceptablePriceImpactBuffer,
     collateralToken,
+    findSwapPath,
     fromToken,
     fromTokenAmount,
     isLeverageEnabled,
@@ -391,7 +393,6 @@ export function TradeBox(p: Props) {
     selectedTriggerAcceptablePriceImpactBps,
     setLeverageOption,
     setToTokenInputValue,
-    swapRoutes.findSwapPath,
     toToken,
     toTokenAmount,
     triggerPrice,

--- a/src/context/SyntheticsStateContext/selectors/orderEditorSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/orderEditorSelectors.ts
@@ -44,7 +44,7 @@ import {
   selectUserReferralInfo,
 } from "./globalSelectors";
 import { selectIsPnlInLeverage, selectSavedAcceptablePriceImpactBuffer } from "./settingsSelectors";
-import { makeSelectNextPositionValuesForIncrease, makeSelectSwapRoutes } from "./tradeSelectors";
+import { makeSelectFindSwapPath, makeSelectNextPositionValuesForIncrease } from "./tradeSelectors";
 import { selectTradeboxAvailableTokensOptions } from "./tradeboxSelectors";
 import { getWrappedToken } from "config/tokens";
 import {
@@ -435,8 +435,8 @@ export const selectOrderEditorIncreaseAmounts = createSelector((q) => {
   const market = q((s) => selectMarketsInfoData(s)?.[order.marketAddress]);
   if (!market) return undefined;
 
-  const selectSwapRoutes = makeSelectSwapRoutes(order.initialCollateralTokenAddress, toToken?.address);
-  const swapRoute = q(selectSwapRoutes);
+  const selectFindSwapPath = makeSelectFindSwapPath(order.initialCollateralTokenAddress, toToken?.address);
+  const findSwapPath = q(selectFindSwapPath);
   const triggerPrice = q(selectOrderEditorTriggerPrice);
   const existingPosition = q(selectOrderEditorExistingPosition);
   const sizeDeltaUsd = q(selectOrderEditorSizeDeltaUsd);
@@ -457,21 +457,21 @@ export const selectOrderEditorIncreaseAmounts = createSelector((q) => {
     leverage: existingPosition?.leverage,
     triggerPrice: isLimitOrderType(order.orderType) ? triggerPrice : undefined,
     position: existingPosition,
-    findSwapPath: swapRoute.findSwapPath,
+    findSwapPath,
     userReferralInfo,
     uiFeeFactor,
     strategy: "independent",
   });
 });
 
-export const selectOrderEditorSwapRoutes = createSelector((q) => {
+export const selectOrderEditorFindSwapPath = createSelector((q) => {
   const order = q(selectEditingOrder);
   if (!order) throw new Error("selectOrderEditorSwapRoutes: Order is not defined");
 
   const toToken = q(selectOrderEditorToToken);
-  const selectSwapRoutes = makeSelectSwapRoutes(order.initialCollateralTokenAddress, toToken?.address);
+  const selectFindSwapPath = makeSelectFindSwapPath(order.initialCollateralTokenAddress, toToken?.address);
 
-  return q(selectSwapRoutes);
+  return q(selectFindSwapPath);
 });
 
 export const selectOrderEditorMaxAllowedLeverage = createSelector((q) => {

--- a/src/context/SyntheticsStateContext/selectors/orderSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/orderSelectors.ts
@@ -5,10 +5,10 @@ import {
   isOrderForPosition,
   sortPositionOrders,
 } from "domain/synthetics/orders";
-import { createSelector, createSelectorFactory } from "../utils";
 import { SyntheticsState } from "../SyntheticsStateContextProvider";
+import { createSelector, createSelectorFactory } from "../utils";
 import { selectMarketsInfoData, selectPositionsInfoData, selectUiFeeFactor } from "./globalSelectors";
-import { makeSelectSwapRoutes } from "./tradeSelectors";
+import { makeSelectFindSwapPath } from "./tradeSelectors";
 
 const selectOrdersInfoData = (s: SyntheticsState) => s.globals.ordersInfo.ordersInfoData;
 
@@ -22,8 +22,8 @@ export const makeSelectOrderErrorByOrderKey = createSelectorFactory((orderId: st
     if (!marketsInfoData) return { errors: [], level: undefined };
 
     const uiFeeFactor = q(selectUiFeeFactor);
-    const { findSwapPath } = q(
-      makeSelectSwapRoutes(orderInfo.initialCollateralToken.address, orderInfo.targetCollateralToken.address)
+    const findSwapPath = q(
+      makeSelectFindSwapPath(orderInfo.initialCollateralToken.address, orderInfo.targetCollateralToken.address)
     );
 
     const { errors, level } = getOrderErrors({

--- a/src/context/SyntheticsStateContext/selectors/positionSellerSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/positionSellerSelectors.ts
@@ -12,8 +12,9 @@ import {
 } from "./globalSelectors";
 import {
   makeSelectDecreasePositionAmounts,
+  makeSelectFindSwapPath,
+  makeSelectMaxLiquidityPath,
   makeSelectNextPositionValuesForDecrease,
-  makeSelectSwapRoutes,
 } from "./tradeSelectors";
 import {
   getMinCollateralFactorForPosition,
@@ -186,26 +187,39 @@ export const selectPositionSellerShouldSwap = createSelector((q) => {
   return position && receiveToken && !getIsEquivalentTokens(position.collateralToken, receiveToken);
 });
 
-export const selectPositionSellerSwapRoutes = createSelector((q) => {
+export const selectPositionSellerMaxLiquidityPath = createSelector((q) => {
   const position = q(selectPositionSellerPosition);
   const receiveTokenAddress = q(selectPositionSellerReceiveTokenAddress);
+  const selectMakeLiquidityPath = makeSelectMaxLiquidityPath(position?.collateralTokenAddress, receiveTokenAddress);
 
-  const selectSwapRoutes = makeSelectSwapRoutes(position?.collateralTokenAddress, receiveTokenAddress);
-  return q(selectSwapRoutes);
+  return q(selectMakeLiquidityPath);
+});
+
+export const selectPositionSellerFindSwapPath = createSelector((q) => {
+  const position = q(selectPositionSellerPosition);
+  const receiveTokenAddress = q(selectPositionSellerReceiveTokenAddress);
+  const selectFindSwapPath = makeSelectFindSwapPath(position?.collateralTokenAddress, receiveTokenAddress);
+
+  return q(selectFindSwapPath);
 });
 
 export const selectPositionSellerSwapAmounts = createSelector((q) => {
-  const shouldSwap = q(selectPositionSellerShouldSwap);
-  const receiveToken = q(selectPositionSellerReceiveToken);
-  const decreaseAmounts = q(selectPositionSellerDecreaseAmounts);
   const position = q(selectPositionSellerPosition);
-  const uiFeeFactor = q(selectUiFeeFactor);
 
-  if (!shouldSwap || !receiveToken || decreaseAmounts?.receiveTokenAmount === undefined || !position) {
+  if (!position) {
     return undefined;
   }
 
-  const findSwapPath = q(selectPositionSellerSwapRoutes).findSwapPath;
+  const shouldSwap = q(selectPositionSellerShouldSwap);
+  const receiveToken = q(selectPositionSellerReceiveToken);
+  const decreaseAmounts = q(selectPositionSellerDecreaseAmounts);
+  const uiFeeFactor = q(selectUiFeeFactor);
+
+  if (!shouldSwap || !receiveToken || decreaseAmounts?.receiveTokenAmount === undefined) {
+    return undefined;
+  }
+
+  const findSwapPath = q(selectPositionSellerFindSwapPath);
 
   return getSwapAmountsByFromValue({
     tokenIn: position.collateralToken,

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
@@ -40,10 +40,11 @@ import {
 import {
   createTradeFlags,
   makeSelectDecreasePositionAmounts,
+  makeSelectFindSwapPath,
   makeSelectIncreasePositionAmounts,
+  makeSelectMaxLiquidityPath,
   makeSelectNextPositionValuesForDecrease,
   makeSelectNextPositionValuesForIncrease,
-  makeSelectSwapRoutes,
 } from "../tradeSelectors";
 import { SyntheticsState } from "context/SyntheticsStateContext/SyntheticsStateContextProvider";
 import { createSelector, createSelectorDeprecated } from "context/SyntheticsStateContext/utils";
@@ -95,7 +96,7 @@ export const selectTradeboxSetTradeConfig = (s: SyntheticsState) => s.tradebox.s
 export const selectTradeboxSetKeepLeverage = (s: SyntheticsState) => s.tradebox.setKeepLeverage;
 export const selectTradeboxSetCollateralAddress = (s: SyntheticsState) => s.tradebox.setCollateralAddress;
 
-export const selectTradeboxSwapRoutes = createSelector((q) => {
+export const selectTradeboxFindSwapPath = createSelector((q) => {
   const fromTokenAddress = q(selectTradeboxFromTokenAddress);
   const toTokenAddress = q(selectTradeboxToTokenAddress);
   const collateralTokenAddress = q(selectTradeboxCollateralTokenAddress);
@@ -103,7 +104,20 @@ export const selectTradeboxSwapRoutes = createSelector((q) => {
   const tradeType = q(selectTradeboxTradeType);
   const tradeFlags = createTradeFlags(tradeType, tradeMode);
 
-  return q(makeSelectSwapRoutes(fromTokenAddress, tradeFlags.isPosition ? collateralTokenAddress : toTokenAddress));
+  return q(makeSelectFindSwapPath(fromTokenAddress, tradeFlags.isPosition ? collateralTokenAddress : toTokenAddress));
+});
+
+export const selectTradeboxMaxLiquidityPath = createSelector((q) => {
+  const fromTokenAddress = q(selectTradeboxFromTokenAddress);
+  const toTokenAddress = q(selectTradeboxToTokenAddress);
+  const collateralTokenAddress = q(selectTradeboxCollateralTokenAddress);
+  const tradeMode = q(selectTradeboxTradeMode);
+  const tradeType = q(selectTradeboxTradeType);
+  const tradeFlags = createTradeFlags(tradeType, tradeMode);
+
+  return q(
+    makeSelectMaxLiquidityPath(fromTokenAddress, tradeFlags.isPosition ? collateralTokenAddress : toTokenAddress)
+  );
 });
 
 export const selectTradeboxIncreasePositionAmounts = createSelector((q) => {
@@ -208,8 +222,8 @@ export const selectTradeboxSwapAmounts = createSelector((q) => {
     return undefined;
   }
 
-  const { findSwapPath } = q(
-    makeSelectSwapRoutes(fromTokenAddress, tradeFlags.isPosition ? collateralTokenAddress : toTokenAddress)
+  const findSwapPath = q(
+    makeSelectFindSwapPath(fromTokenAddress, tradeFlags.isPosition ? collateralTokenAddress : toTokenAddress)
   );
 
   const { markRatio, triggerRatio } = q(selectTradeboxTradeRatios);

--- a/src/domain/synthetics/sidecarOrders/useSidecarOrders.ts
+++ b/src/domain/synthetics/sidecarOrders/useSidecarOrders.ts
@@ -8,7 +8,6 @@ import {
   useUserReferralInfo,
 } from "context/SyntheticsStateContext/hooks/globalsHooks";
 import {
-  selectTradeboxSwapRoutes,
   selectTradeboxMarketInfo,
   selectTradeboxTradeFlags,
   selectTradeboxCollateralToken,
@@ -17,6 +16,7 @@ import {
   selectTradeboxMarkPrice,
   selectTradeboxSelectedPosition,
   selectTradeboxNextPositionValues,
+  selectTradeboxFindSwapPath,
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
 import {
   selectConfirmationBoxSidecarOrdersExistingSlEntries,
@@ -37,7 +37,7 @@ export function useSidecarOrders() {
   const uiFeeFactor = useUiFeeFactor();
 
   const { isLong, isLimit } = useSelector(selectTradeboxTradeFlags);
-  const swapRoute = useSelector(selectTradeboxSwapRoutes);
+  const findSwapPath = useSelector(selectTradeboxFindSwapPath);
   const marketInfo = useSelector(selectTradeboxMarketInfo);
   const collateralToken = useSelector(selectTradeboxCollateralToken);
   const increaseAmounts = useSelector(selectTradeboxIncreasePositionAmounts);
@@ -166,7 +166,7 @@ export function useSidecarOrders() {
       )
         return;
 
-      if (!marketInfo || !mockPositionInfo || !swapRoute || !order) {
+      if (!marketInfo || !mockPositionInfo || !findSwapPath || !order) {
         return;
       }
 
@@ -182,13 +182,13 @@ export function useSidecarOrders() {
         indexTokenAmount: size,
         triggerPrice: price.value,
         position: mockPositionInfo,
-        findSwapPath: swapRoute.findSwapPath,
+        findSwapPath,
         userReferralInfo,
         uiFeeFactor,
         strategy: "independent",
       });
     },
-    [marketInfo, mockPositionInfo, swapRoute, uiFeeFactor, userReferralInfo]
+    [marketInfo, mockPositionInfo, findSwapPath, uiFeeFactor, userReferralInfo]
   );
 
   const limit = useMemo(() => {


### PR DESCRIPTION
The fix is removing `.slice(0, 5)`, i.e. we now check all possible options (40+) instead of just 5.
It takes less than 1ms so that's fine.

The rest of changes are:
- splitting `makeSelectSwapRoutes` into two separate selectors (before selectors it was just one `useMemo` call)
- `makeSelectAllPaths` is now separate selector

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207370518809255