### PR TITLE
Order positions by available markets, sort descending by Size within the same market

### DIFF
--- a/src/components/Synthetics/PositionList/PositionList.tsx
+++ b/src/components/Synthetics/PositionList/PositionList.tsx
@@ -3,6 +3,7 @@ import PositionShare from "components/Exchange/PositionShare";
 import { PositionItem } from "components/Synthetics/PositionItem/PositionItem";
 import { useIsPositionsLoading, usePositionsInfoData } from "context/SyntheticsStateContext/hooks/globalsHooks";
 import { usePositionEditorPositionState } from "context/SyntheticsStateContext/hooks/positionEditorHooks";
+import { selectPositionsInfoDataSortedByMarket } from "context/SyntheticsStateContext/selectors/positionsSelectors";
 import { selectShowPnlAfterFees } from "context/SyntheticsStateContext/selectors/settingsSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { PositionInfo } from "domain/synthetics/positions";
@@ -36,7 +37,7 @@ export function PositionList(p: Props) {
   const [isPositionShareModalOpen, setIsPositionShareModalOpen] = useState(false);
   const [positionToShareKey, setPositionToShareKey] = useState<string>();
   const positionToShare = getByKey(positionsInfoData, positionToShareKey);
-  const positions = Object.values(positionsInfoData || {});
+  const positions = useSelector(selectPositionsInfoDataSortedByMarket);
   const handleSharePositionClick = useCallback((positionKey: string) => {
     setPositionToShareKey(positionKey);
     setIsPositionShareModalOpen(true);

--- a/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
@@ -1,11 +1,11 @@
 import { createSelector } from "../utils";
 import { selectPositionsInfoData } from "./globalSelectors";
-import { selectTradeboxMarketsOrder } from "./tradeboxSelectors";
+import { selectTradeboxMarketsOrderMap } from "./tradeboxSelectors";
 import { bigintToNumber } from "lib/numbers";
 
 export const selectPositionsInfoDataSortedByMarket = createSelector((q) => {
   const positionsInfoData = q(selectPositionsInfoData);
-  const marketsOrder = q(selectTradeboxMarketsOrder);
+  const marketsOrder = q(selectTradeboxMarketsOrderMap);
 
   const positions = Object.values(positionsInfoData || {});
 
@@ -14,7 +14,7 @@ export const selectPositionsInfoDataSortedByMarket = createSelector((q) => {
     const aMarketIdx = marketsOrder[b.indexToken.symbol];
 
     if (aMarketIdx === bMarketIdx) {
-      return bigintToNumber(a.sizeInUsd - b.sizeInUsd, 1);
+      return bigintToNumber(b.sizeInUsd - a.sizeInUsd, 1);
     }
 
     return bMarketIdx - aMarketIdx;

--- a/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
@@ -1,23 +1,21 @@
 import { createSelector } from "../utils";
 import { selectPositionsInfoData } from "./globalSelectors";
 import { selectTradeboxMarketsOrderMap } from "./tradeboxSelectors";
-import { bigintToNumber } from "lib/numbers";
 
 export const selectPositionsInfoDataSortedByMarket = createSelector((q) => {
   const positionsInfoData = q(selectPositionsInfoData);
   const marketsOrder = q(selectTradeboxMarketsOrderMap);
 
   const positions = Object.values(positionsInfoData || {});
-
   const sortedPositions = positions.sort((a, b) => {
-    const bMarketIdx = marketsOrder[a.indexToken.symbol];
-    const aMarketIdx = marketsOrder[b.indexToken.symbol];
+    const aMarketIdx = marketsOrder[a.marketInfo.indexTokenAddress];
+    const bMarketIdx = marketsOrder[b.marketInfo.indexTokenAddress];
 
     if (aMarketIdx === bMarketIdx) {
-      return bigintToNumber(b.sizeInUsd - a.sizeInUsd, 1);
+      return b.sizeInUsd - a.sizeInUsd > 0n ? 1 : -1;
     }
 
-    return bMarketIdx - aMarketIdx;
+    return aMarketIdx - bMarketIdx;
   });
   return sortedPositions;
 });

--- a/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
@@ -1,15 +1,15 @@
 import { createSelector } from "../utils";
 import { selectPositionsInfoData } from "./globalSelectors";
-import { selectTradeboxMarketsOrderMap } from "./tradeboxSelectors";
+import { selectTradeboxMarketsSortMap } from "./tradeboxSelectors";
 
 export const selectPositionsInfoDataSortedByMarket = createSelector((q) => {
   const positionsInfoData = q(selectPositionsInfoData);
-  const marketsOrder = q(selectTradeboxMarketsOrderMap);
+  const marketsSortMap = q(selectTradeboxMarketsSortMap);
 
   const positions = Object.values(positionsInfoData || {});
   const sortedPositions = positions.sort((a, b) => {
-    const aMarketIdx = marketsOrder[a.marketInfo.indexTokenAddress];
-    const bMarketIdx = marketsOrder[b.marketInfo.indexTokenAddress];
+    const aMarketIdx = marketsSortMap[a.marketInfo.indexTokenAddress];
+    const bMarketIdx = marketsSortMap[b.marketInfo.indexTokenAddress];
 
     if (aMarketIdx === bMarketIdx) {
       return b.sizeInUsd - a.sizeInUsd > 0n ? 1 : -1;

--- a/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/positionsSelectors.ts
@@ -1,0 +1,23 @@
+import { createSelector } from "../utils";
+import { selectPositionsInfoData } from "./globalSelectors";
+import { selectTradeboxMarketsOrder } from "./tradeboxSelectors";
+import { bigintToNumber } from "lib/numbers";
+
+export const selectPositionsInfoDataSortedByMarket = createSelector((q) => {
+  const positionsInfoData = q(selectPositionsInfoData);
+  const marketsOrder = q(selectTradeboxMarketsOrder);
+
+  const positions = Object.values(positionsInfoData || {});
+
+  const sortedPositions = positions.sort((a, b) => {
+    const bMarketIdx = marketsOrder[a.indexToken.symbol];
+    const aMarketIdx = marketsOrder[b.indexToken.symbol];
+
+    if (aMarketIdx === bMarketIdx) {
+      return bigintToNumber(a.sizeInUsd - b.sizeInUsd, 1);
+    }
+
+    return bMarketIdx - aMarketIdx;
+  });
+  return sortedPositions;
+});

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
@@ -776,10 +776,10 @@ export const selectTradeboxLeverageSliderMarks = createSelector((q) => {
 });
 
 export const selectTradeboxMarketsOrderMap = createSelector((q) => {
-  const { sortedAllMarkets } = q(selectTradeboxAvailableTokensOptions);
+  const { sortedIndexTokensWithPoolValue } = q(selectTradeboxAvailableTokensOptions);
 
-  return sortedAllMarkets.reduce((acc, market, idx) => {
-    acc[market.indexToken.symbol] = idx;
+  return sortedIndexTokensWithPoolValue.reduce((acc, address, idx) => {
+    acc[address] = idx;
     return acc;
   }, {});
 });

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
@@ -774,3 +774,12 @@ export const selectTradeboxLeverageSliderMarks = createSelector((q) => {
   const maxAllowedLeverage = q(selectTradeboxMaxLeverage);
   return getTradeboxLeverageSliderMarks(maxAllowedLeverage);
 });
+
+export const selectTradeboxMarketsOrder = createSelector((q) => {
+  const { sortedAllMarkets } = q(selectTradeboxAvailableTokensOptions);
+
+  return sortedAllMarkets.reduce((acc, market, idx) => {
+    acc[market.indexToken.symbol] = idx;
+    return acc;
+  }, {});
+});

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
@@ -775,7 +775,7 @@ export const selectTradeboxLeverageSliderMarks = createSelector((q) => {
   return getTradeboxLeverageSliderMarks(maxAllowedLeverage);
 });
 
-export const selectTradeboxMarketsOrder = createSelector((q) => {
+export const selectTradeboxMarketsOrderMap = createSelector((q) => {
   const { sortedAllMarkets } = q(selectTradeboxAvailableTokensOptions);
 
   return sortedAllMarkets.reduce((acc, market, idx) => {

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
@@ -775,7 +775,7 @@ export const selectTradeboxLeverageSliderMarks = createSelector((q) => {
   return getTradeboxLeverageSliderMarks(maxAllowedLeverage);
 });
 
-export const selectTradeboxMarketsOrderMap = createSelector((q) => {
+export const selectTradeboxMarketsSortMap = createSelector((q) => {
   const { sortedIndexTokensWithPoolValue } = q(selectTradeboxAvailableTokensOptions);
 
   return sortedIndexTokensWithPoolValue.reduce((acc, address, idx) => {


### PR DESCRIPTION
1. I attempted to break down usage of [useAvailableTokenOptions](https://github.com/gmx-io/gmx-interface/blob/master/src/domain/synthetics/trade/useAvailableTokenOptions.ts) to separate selectors, but found that it widely used [in building of trade state](https://github.com/gmx-io/gmx-interface/blob/master/src/domain/synthetics/trade/useTradeboxState.ts#L79). Ideal solution seems to in in removing redundant useSomthings which are not making any requests but just mapping the data for building state and replace them by clear selectors, but it requires a massive refactor, so I retreated.

2. Tried to move all positions-specific selectors to a separate file, but it will create a triangle of circular deps, so I didn't change much, just add new file for complex selectors. I opened to discuss and change it.

Before:
<img width="1087" alt="Screenshot 2024-06-12 at 16 28 42" src="https://github.com/gmx-io/gmx-interface/assets/171488563/0b8c41df-df21-42f1-9267-69a8f6705596">

After:
<img width="1088" alt="Screenshot 2024-06-12 at 16 26 17" src="https://github.com/gmx-io/gmx-interface/assets/171488563/e66933ab-2fdd-447b-bcba-314e0c9dba4e">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207057109124491