### PR TITLE
fix stats page tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -145,9 +145,9 @@ export default function Tooltip<T extends PropsWithChildren = PropsWithChildren>
 
   const color = middlewareData?.color?.color ?? DEFAULT_ARROW_COLOR;
 
-  const finalContent = content ?? renderContent?.();
+  const finalContent = visible ? content ?? renderContent?.() : undefined;
 
-  const tooltipContent = (
+  const tooltipContent = visible ? (
     <div
       ref={refs.setFloating}
       style={floatingStyles}
@@ -157,7 +157,7 @@ export default function Tooltip<T extends PropsWithChildren = PropsWithChildren>
       <FloatingArrow ref={arrowRef} context={context} fill={color} />
       {finalContent}
     </div>
-  );
+  ) : undefined;
 
   if (as) {
     const Container = as as any;

--- a/src/pages/SyntheticsStats/SyntheticsStats.tsx
+++ b/src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -746,8 +746,12 @@ export function SyntheticsStats() {
                           <StatsTooltipRow
                             label="Distribution Rate per Day, USD"
                             value={formatAmount(
-                              market.positionImpactPoolDistributionRate * 86400n * market.indexToken.prices.minPrice,
-                              market.indexToken.decimals + 60,
+                              bigMath.mulDiv(
+                                market.positionImpactPoolDistributionRate * 86400n,
+                                market.indexToken.prices.minPrice,
+                                expandDecimals(1, 60)
+                              ),
+                              market.indexToken.decimals,
                               2,
                               true
                             )}


### PR DESCRIPTION
first issue was, we rendered all tooltips contents even for hidden ones

initial error was there since release-28
error looks like this:
<img width="488" alt="image" src="https://github.com/gmx-io/gmx-interface/assets/144131435/c73462e7-d5de-4897-8bfd-4c62755842bd">
