### PR TITLE
Ignore JIT when it reduces available liquidity

### DIFF
--- a/src/domain/synthetics/markets/utils.ts
+++ b/src/domain/synthetics/markets/utils.ts
@@ -112,7 +112,11 @@ export function getAvailableUsdLiquidityForPosition(
     return 0n;
   }
 
-  const maxReservedUsd = maxReservedUsdWithJit ?? getMaxReservedUsd(marketInfo, isLong);
+  const nativeMaxReservedUsd = getMaxReservedUsd(marketInfo, isLong);
+  const maxReservedUsd =
+    maxReservedUsdWithJit !== undefined
+      ? bigMath.max(maxReservedUsdWithJit, nativeMaxReservedUsd)
+      : nativeMaxReservedUsd;
   const reservedUsd = getReservedUsd(marketInfo, isLong);
 
   const maxOpenInterest = getMaxOpenInterestUsd(marketInfo, isLong);


### PR DESCRIPTION
## Summary
- JIT liquidity info is returned for both long and short sides, but only one side may actually benefit from JIT
- When `maxReservedUsdWithJit` is lower than the native `maxReservedUsd` for a given side, the UI was incorrectly reducing available liquidity instead of ignoring JIT for that side
- Fix: use `bigMath.max(maxReservedUsdWithJit, nativeMaxReservedUsd)` so JIT can only increase liquidity, never decrease it

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 498 tests pass
- [x] Verify on markets where JIT is active that liquidity values remain correct
- [ ] Verify that the non-JIT side shows native liquidity (unchanged from before JIT was introduced)