### PR TITLE
Remove all validations from buy GM/GLV button (temporary)

### DIFF
--- a/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
@@ -1,58 +1,18 @@
 import { t, Trans } from "@lingui/macro";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useCallback, useMemo } from "react";
-import { zeroAddress } from "viem";
 
-import { AVALANCHE, SettlementChainId } from "config/chains";
-import { getMappedTokenId } from "config/multichain";
 import {
   selectPoolsDetailsFlags,
   selectPoolsDetailsGlvInfo,
-  selectPoolsDetailsIsMarketTokenDeposit,
-  selectPoolsDetailsLongTokenAddress,
-  selectPoolsDetailsMarketInfo,
-  selectPoolsDetailsMarketTokenData,
-  selectPoolsDetailsMarketTokensData,
   selectPoolsDetailsOperation,
-  selectPoolsDetailsPayLongToken,
-  selectPoolsDetailsPayShortToken,
-  selectPoolsDetailsPaySource,
-  selectPoolsDetailsShortTokenAddress,
 } from "context/PoolsDetailsContext/selectors";
-import { selectDepositWithdrawalAmounts } from "context/PoolsDetailsContext/selectors/selectDepositWithdrawalAmounts";
-import { selectGasPaymentToken } from "context/SyntheticsStateContext/selectors/expressSelectors";
-import {
-  selectChainId,
-  selectGasPrice,
-  selectSrcChainId,
-  selectTokensData,
-} from "context/SyntheticsStateContext/selectors/globalSelectors";
-import { selectGasPaymentTokenAddress } from "context/SyntheticsStateContext/selectors/settingsSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
-import { useSourceChainNativeFeeError } from "domain/multichain/useSourceChainNetworkFeeError";
-import { ExpressEstimationInsufficientGasPaymentTokenBalanceError } from "domain/synthetics/express/expressOrderUtils";
-import type { GlvAndGmMarketsInfoData, GmPaySource, MarketsInfoData } from "domain/synthetics/markets";
+import type { GlvAndGmMarketsInfoData, MarketsInfoData } from "domain/synthetics/markets";
 import { TechnicalGmFees } from "domain/synthetics/markets/technicalFees/technical-fees-types";
 import { Operation } from "domain/synthetics/markets/types";
-import { convertToTokenAmount, type TokenData } from "domain/synthetics/tokens";
-import {
-  getCommonError,
-  getDefaultInsufficientGasMessage,
-  getGmSwapError,
-  getNativeGasError,
-  takeValidationResult,
-  ValidationBannerErrorName,
-  ValidationResult,
-} from "domain/synthetics/trade/utils/validation";
-import { isCustomError } from "lib/errors";
-import { adjustForDecimals, formatBalanceAmount } from "lib/numbers";
-import { getByKey } from "lib/objects";
-import { useHasOutdatedUi } from "lib/useHasOutdatedUi";
 import useWallet from "lib/wallets/useWallet";
-import { bigMath } from "sdk/utils/bigmath";
 import { GmSwapFees } from "sdk/utils/trade/types";
-
-import { ValidationBannerErrorContent } from "components/Errors/gasErrors";
 
 import SpinnerIcon from "img/ic_spinner.svg?react";
 
@@ -87,309 +47,30 @@ type SubmitButtonState = {
   bannerErrorContent?: React.ReactNode;
 };
 
-export const useGmSwapSubmitState = ({
-  logicalFees,
-  technicalFees,
-  technicalFeesError,
-  longTokenLiquidityUsd,
-  shortTokenLiquidityUsd,
-  shouldDisableValidation,
-}: Props): SubmitButtonState => {
-  const { isDeposit, isPair } = useSelector(selectPoolsDetailsFlags);
+export const useGmSwapSubmitState = ({ shouldDisableValidation, technicalFees }: Props): SubmitButtonState => {
+  const { isDeposit } = useSelector(selectPoolsDetailsFlags);
   const operation = useSelector(selectPoolsDetailsOperation);
-  const paySource = useSelector(selectPoolsDetailsPaySource);
-  const isMarketTokenDeposit = useSelector(selectPoolsDetailsIsMarketTokenDeposit);
   const glvInfo = useSelector(selectPoolsDetailsGlvInfo);
-  const glvToken = glvInfo?.glvToken;
-  const marketTokensData = useSelector(selectPoolsDetailsMarketTokensData);
-  const marketToken = useSelector(selectPoolsDetailsMarketTokenData);
 
-  const longTokenAddress = useSelector(selectPoolsDetailsLongTokenAddress);
-  const shortTokenAddress = useSelector(selectPoolsDetailsShortTokenAddress);
-  const payLongToken = useSelector(selectPoolsDetailsPayLongToken);
-  const payShortToken = useSelector(selectPoolsDetailsPayShortToken);
-
-  const marketInfo = useSelector(selectPoolsDetailsMarketInfo);
-  const amounts = useSelector(selectDepositWithdrawalAmounts);
-  const chainId = useSelector(selectChainId);
-  const srcChainId = useSelector(selectSrcChainId);
-  const gasPrice = useSelector(selectGasPrice);
-  const tokensData = useSelector(selectTokensData);
-  const gasPaymentTokenAddress = useSelector(selectGasPaymentTokenAddress);
-  const gasPaymentToken = useSelector(selectGasPaymentToken);
-  const hasOutdatedUi = useHasOutdatedUi();
-  const { openConnectModal } = useConnectModal();
-  const { account } = useWallet();
-
-  const {
-    glvTokenAmount = 0n,
-    glvTokenUsd = 0n,
-    longTokenAmount = 0n,
-    longTokenUsd = 0n,
-    marketTokenAmount = 0n,
-    marketTokenUsd = 0n,
-    shortTokenAmount = 0n,
-    shortTokenUsd = 0n,
-  } = amounts ?? {};
-
-  const {
-    isSubmitting,
-    onSubmit,
-    isLoading,
-    error: estimationError,
-  } = useLpTransactions({
+  const { isSubmitting, onSubmit } = useLpTransactions({
     shouldDisableValidation,
     technicalFees,
   });
+
+  const { openConnectModal } = useConnectModal();
+  const { account } = useWallet();
 
   const onConnectAccount = useCallback(() => {
     openConnectModal?.();
   }, [openConnectModal]);
 
-  const commonError = getCommonError({
-    chainId,
-    isConnected: true,
-    hasOutdatedUi,
-  });
-
-  // TODO Make all errors in validation language agnostic
-  const swapError = getGmSwapError({
-    isDeposit,
-    marketInfo,
-    glvInfo,
-    longToken: payLongToken,
-    shortToken: payShortToken,
-    glvToken,
-    glvTokenAmount,
-    glvTokenUsd,
-    marketTokenAmount,
-    marketTokenUsd,
-    longTokenAmount,
-    shortTokenAmount,
-    longTokenUsd,
-    shortTokenUsd,
-    longTokenLiquidityUsd: longTokenLiquidityUsd,
-    shortTokenLiquidityUsd: shortTokenLiquidityUsd,
-    fees: logicalFees,
-    priceImpactUsd: logicalFees?.swapPriceImpact?.deltaUsd,
-    marketTokensData,
-    isMarketTokenDeposit,
-    paySource,
-    isPair,
-    chainId,
-    srcChainId,
-    marketToken,
-  });
-
-  const expressError = useExpressError({
-    paySource,
-    technicalFees,
-    gasPaymentToken,
-    gasPaymentTokenAddress,
-    longTokenAddress,
-    shortTokenAddress,
-    longTokenAmount,
-    shortTokenAmount,
-    isDeposit,
-  });
-
-  const settlementChainNativeTokenAmount = useMemo(() => {
-    if (paySource !== "settlementChain" || !isDeposit) {
-      return 0n;
-    }
-
-    let amount = 0n;
-
-    if (payLongToken?.address === zeroAddress) {
-      amount += longTokenAmount;
-    }
-
-    if (payShortToken?.address === zeroAddress) {
-      amount += shortTokenAmount;
-    }
-
-    return amount;
-  }, [isDeposit, longTokenAmount, payLongToken, payShortToken, paySource, shortTokenAmount]);
-
-  const nativeGasError = useMemo((): ValidationResult | undefined => {
-    if (technicalFees?.kind !== "settlementChain") {
-      return undefined;
-    }
-
-    const walletTxGasAmount = gasPrice !== undefined ? technicalFees.fees.gasLimit * gasPrice : 0n;
-    const requiredAmount = technicalFees.fees.feeTokenAmount + settlementChainNativeTokenAmount + walletTxGasAmount;
-
-    return getNativeGasError({
-      networkFee: requiredAmount,
-      nativeBalance: getByKey(tokensData, zeroAddress)?.walletBalance,
-    });
-  }, [gasPrice, settlementChainNativeTokenAmount, technicalFees, tokensData]);
-
-  const paySourceChainNativeTokenAmount = useMemo(() => {
-    if (srcChainId === undefined || !isDeposit) {
-      return 0n;
-    }
-
-    let paySourceChainNativeTokenAmount = 0n;
-
-    if (payLongToken !== undefined) {
-      const sourceChainToken = getMappedTokenId(chainId as SettlementChainId, payLongToken.address, srcChainId);
-
-      if (sourceChainToken !== undefined && sourceChainToken.address === zeroAddress) {
-        paySourceChainNativeTokenAmount += adjustForDecimals(
-          longTokenAmount,
-          payLongToken.decimals,
-          sourceChainToken.decimals
-        );
-      }
-    }
-    if (payShortToken !== undefined) {
-      const sourceChainToken = getMappedTokenId(chainId as SettlementChainId, payShortToken.address, srcChainId);
-
-      if (sourceChainToken !== undefined && sourceChainToken.address === zeroAddress) {
-        paySourceChainNativeTokenAmount += adjustForDecimals(
-          shortTokenAmount,
-          payShortToken.decimals,
-          sourceChainToken.decimals
-        );
-      }
-    }
-
-    return paySourceChainNativeTokenAmount;
-  }, [isDeposit, payLongToken, longTokenAmount, payShortToken, shortTokenAmount, srcChainId, chainId]);
-
-  const sourceChainNativeFeeError = useSourceChainNativeFeeError({
-    networkFeeUsd:
-      logicalFees?.logicalNetworkFee?.deltaUsd !== undefined
-        ? bigMath.abs(logicalFees.logicalNetworkFee.deltaUsd)
-        : undefined,
-    paySource,
-    chainId,
-    srcChainId,
-    paySourceChainNativeTokenAmount,
-  });
-
-  const nativeToken = getByKey(tokensData, zeroAddress);
-  const nativeTokenWalletBalance = nativeToken?.walletBalance;
-  const settlementChainFeeTokenAmount =
-    technicalFees?.kind === "settlementChain" ? technicalFees.fees.feeTokenAmount : undefined;
-
-  const settlementChainNativeFeeError = useMemo((): ValidationResult | undefined => {
-    if (
-      paySource !== "settlementChain" ||
-      nativeTokenWalletBalance === undefined ||
-      settlementChainFeeTokenAmount === undefined
-    ) {
-      return undefined;
-    }
-
-    const insufficientWithLongCollateral =
-      isDeposit &&
-      payLongToken &&
-      nativeToken &&
-      payLongToken.address === nativeToken.address &&
-      nativeTokenWalletBalance < settlementChainFeeTokenAmount + longTokenAmount;
-
-    const insufficientWithShortCollateral =
-      isDeposit &&
-      payShortToken &&
-      nativeToken &&
-      payShortToken.address === nativeToken.address &&
-      nativeTokenWalletBalance < settlementChainFeeTokenAmount + shortTokenAmount;
-
-    if (
-      nativeTokenWalletBalance < settlementChainFeeTokenAmount ||
-      insufficientWithLongCollateral ||
-      insufficientWithShortCollateral
-    ) {
-      return {
-        buttonErrorMessage: getDefaultInsufficientGasMessage(),
-        bannerErrorName: ValidationBannerErrorName.insufficientNativeTokenBalance,
-      };
-    }
-  }, [
-    paySource,
-    nativeTokenWalletBalance,
-    settlementChainFeeTokenAmount,
-    isDeposit,
-    payLongToken,
-    nativeToken,
-    longTokenAmount,
-    payShortToken,
-    shortTokenAmount,
-  ]);
-
-  const formattedEstimationError = useMemo((): ValidationResult | undefined => {
-    if (estimationError instanceof ExpressEstimationInsufficientGasPaymentTokenBalanceError) {
-      if (gasPaymentToken) {
-        const { symbol, decimals } = gasPaymentToken;
-
-        const availableFormatted = formatBalanceAmount(
-          estimationError.params?.balance ?? gasPaymentToken.gmxAccountBalance ?? 0n,
-          decimals
-        );
-
-        let collateralAmount = 0n;
-        if (isDeposit) {
-          if (longTokenAddress === gasPaymentToken.address) {
-            collateralAmount += longTokenAmount;
-          }
-          if (shortTokenAddress === gasPaymentToken.address) {
-            collateralAmount += shortTokenAmount;
-          }
-        }
-
-        const totalRequired = collateralAmount + (estimationError.params?.requiredAmount ?? 0n);
-        const requiredFormatted = formatBalanceAmount(totalRequired, decimals);
-
-        return {
-          buttonErrorMessage: t`Insufficient ${symbol} balance: ${availableFormatted} available, ${requiredFormatted} required`,
-        };
-      }
-    } else if (estimationError) {
-      return {
-        buttonErrorMessage: estimationError.name,
-      };
-    }
-
-    return undefined;
-  }, [
-    estimationError,
-    gasPaymentToken,
-    longTokenAddress,
-    shortTokenAddress,
-    longTokenAmount,
-    shortTokenAmount,
-    isDeposit,
-  ]);
-
-  const error = takeValidationResult(
-    commonError,
-    swapError,
-    expressError,
-    nativeGasError,
-    sourceChainNativeFeeError,
-    settlementChainNativeFeeError,
-    formattedEstimationError
-  );
-
   const { approve, isAllowanceLoaded, isAllowanceLoading, tokensToApproveSymbols, isApproving } = useTokensToApprove();
-
-  const isAvalancheGmxAccountWarning = paySource === "gmxAccount" && chainId === AVALANCHE && isDeposit;
 
   return useMemo((): SubmitButtonState => {
     if (!account) {
       return {
         text: t`Connect wallet`,
         onSubmit: onConnectAccount,
-      };
-    }
-
-    if (isAvalancheGmxAccountWarning) {
-      return {
-        text: t`Not supported`,
-        disabled: true,
-        onSubmit,
       };
     }
 
@@ -402,24 +83,6 @@ export const useGmSwapSubmitState = ({
           </>
         ),
         disabled: true,
-      };
-    }
-
-    if (error.buttonErrorMessage) {
-      return {
-        text: error.buttonErrorMessage,
-        disabled: !shouldDisableValidation,
-        onSubmit: onSubmit,
-        isAllowanceLoaded,
-        isAllowanceLoading,
-        errorDescription: error.buttonTooltipMessage,
-        bannerErrorContent: error.bannerErrorName ? (
-          <ValidationBannerErrorContent
-            validationBannerErrorName={error.bannerErrorName}
-            chainId={chainId}
-            srcChainId={srcChainId}
-          />
-        ) : null,
       };
     }
 
@@ -452,145 +115,22 @@ export const useGmSwapSubmitState = ({
       };
     }
 
-    if ((!technicalFees && !technicalFeesError) || isLoading) {
-      return {
-        text: (
-          <>
-            <Trans>Loading network fees…</Trans>
-            <SpinnerIcon className="ml-4 animate-spin" />
-          </>
-        ),
-        disabled: true,
-      };
-    }
-
-    if (technicalFeesError) {
-      let errorText: string;
-
-      if (isCustomError(technicalFeesError)) {
-        const errorName = technicalFeesError.name;
-
-        if (errorName === "InsufficientMultichainBalance") {
-          errorText = t`Insufficient balance`;
-        } else if (errorName === "MaxPoolAmountExceeded" || errorName === "MaxPoolAmountForDepositExceeded") {
-          errorText = t`Max pool amount exceeded`;
-        } else {
-          errorText = isDeposit ? t`Error simulating deposit` : t`Error simulating withdrawal`;
-        }
-      } else {
-        errorText = isDeposit ? t`Error simulating deposit` : t`Error simulating withdrawal`;
-      }
-
-      return {
-        text: errorText,
-        disabled: true,
-      };
-    }
-
     return {
       text: isDeposit ? t`Buy ${operationTokenSymbol}` : t`Sell ${operationTokenSymbol}`,
       onSubmit,
     };
   }, [
     account,
-    isAvalancheGmxAccountWarning,
     isAllowanceLoading,
-    technicalFees,
-    technicalFeesError,
-    error.buttonErrorMessage,
-    error.buttonTooltipMessage,
-    error.bannerErrorName,
     isApproving,
     tokensToApproveSymbols,
     isAllowanceLoaded,
     glvInfo,
     isSubmitting,
-    isLoading,
     isDeposit,
     onSubmit,
     onConnectAccount,
-    shouldDisableValidation,
-    chainId,
-    srcChainId,
     approve,
     operation,
   ]);
 };
-
-function useExpressError({
-  paySource,
-  technicalFees,
-  gasPaymentToken,
-  gasPaymentTokenAddress,
-  longTokenAddress,
-  shortTokenAddress,
-  longTokenAmount,
-  shortTokenAmount,
-  isDeposit,
-}: {
-  paySource: GmPaySource | undefined;
-  technicalFees: TechnicalGmFees | undefined;
-  gasPaymentToken: TokenData | undefined;
-  gasPaymentTokenAddress: string | undefined;
-  longTokenAddress: string | undefined;
-  shortTokenAddress: string | undefined;
-  longTokenAmount: bigint | undefined;
-  shortTokenAmount: bigint | undefined;
-  isDeposit: boolean;
-}): ValidationResult | undefined {
-  return useMemo(() => {
-    if (paySource !== "gmxAccount" || !technicalFees || !gasPaymentToken || !gasPaymentTokenAddress) {
-      return undefined;
-    }
-
-    const fees = technicalFees.kind === "gmxAccount" ? technicalFees.fees : undefined;
-    if (!fees) {
-      return undefined;
-    }
-
-    if (gasPaymentToken.prices.minPrice === undefined) {
-      return undefined;
-    }
-
-    const gasPaymentTokenAmount = convertToTokenAmount(
-      fees.executionFee.feeUsd + fees.relayFeeUsd,
-      gasPaymentToken.decimals,
-      gasPaymentToken.prices.minPrice
-    );
-
-    if (gasPaymentTokenAmount === undefined || gasPaymentTokenAmount === 0n) {
-      return undefined;
-    }
-
-    let collateralAmount = 0n;
-    if (isDeposit) {
-      if (longTokenAddress === gasPaymentTokenAddress) {
-        collateralAmount = longTokenAmount ?? 0n;
-      } else if (shortTokenAddress === gasPaymentTokenAddress) {
-        collateralAmount = shortTokenAmount ?? 0n;
-      }
-    }
-
-    const gmxAccountBalance = gasPaymentToken.gmxAccountBalance ?? 0n;
-    const totalRequired = collateralAmount + gasPaymentTokenAmount;
-
-    if (totalRequired > gmxAccountBalance) {
-      return {
-        buttonErrorMessage: getDefaultInsufficientGasMessage(),
-        bannerErrorName: ValidationBannerErrorName.insufficientGmxAccountSomeGasTokenBalance,
-      };
-    }
-
-    return undefined;
-  }, [
-    paySource,
-    technicalFees,
-    gasPaymentToken,
-    gasPaymentTokenAddress,
-    longTokenAddress,
-    shortTokenAddress,
-    isDeposit,
-    longTokenAmount,
-    shortTokenAmount,
-  ]);
-}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} pro {1}"
 msgid "In liquidity"
 msgstr "In Liquidität"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "Staken gesendet"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "Unzureichendes {symbol}-Guthaben: {availableFormatted} verfügbar, {requiredFormatted} erforderlich"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "Trigger-Orders"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX verwendet TradingView für Echtzeit-Kryptowährungscharts. Verfolgen Sie <0>BTCUSD</0> und andere Paare mit interaktiven Charting-Tools."
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "Fehler bei der Einzahlungssimulation"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "Limit aktualisieren"
 msgid "Edit order"
 msgstr "Order bearbeiten"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "Fehler bei der Simulation der Abhebung"
@@ -9594,7 +9582,6 @@ msgstr "Hohe TWAP-Netzwerkgebühr"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "Position wäre liquidierbar. Aktuell: {remainingCollateralUsdText}, erforderlich: {minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "Net-Rate-Projektion:"
 msgid "Enter a new size or price"
 msgstr "Neue Größe oder Preis eingeben"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "GLV Bonusanreiz (Test)"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} per {1}"
 msgid "In liquidity"
 msgstr "In liquidity"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "Stake submitted"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr "Net"
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "Trigger orders"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "Error simulating deposit"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "Update Limit"
 msgid "Edit order"
 msgstr "Edit order"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "Error simulating withdrawal"
@@ -9594,7 +9582,6 @@ msgstr "High TWAP network fee"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "Net Rate Projection:"
 msgid "Enter a new size or price"
 msgstr "Enter a new size or price"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "GLV bonus incentive (test)"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} por {1}"
 msgid "In liquidity"
 msgstr "En liquidez"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "Stake enviado"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "Saldo de {symbol} insuficiente: {availableFormatted} disponible, {requiredFormatted} requerido"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "Órdenes de activación"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX utiliza TradingView para gráficos de criptomonedas en tiempo real. Siga <0>BTCUSD</0> y otros pares con herramientas interactivas de gráficos."
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "Error al simular el depósito"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "Actualizar Límite"
 msgid "Edit order"
 msgstr "Editar orden"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "Error simulando retiro"
@@ -9594,7 +9582,6 @@ msgstr "Alta tarifa de red TWAP"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "La posición sería liquidable. Actual: {remainingCollateralUsdText}, requerido: {minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "Proyección de tasa neta:"
 msgid "Enter a new size or price"
 msgstr "Ingresa un nuevo tamaño o precio"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "Incentivo de bonificación GLV (test)"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} par {1}"
 msgid "In liquidity"
 msgstr "En liquidité"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "Staking soumis"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "Solde {symbol} insuffisant : {availableFormatted} disponible, {requiredFormatted} requis"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "Ordres de déclenchement"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX utilise TradingView pour les graphiques de cryptomonnaies en temps réel. Suivez <0>BTCUSD</0> et d'autres paires avec des outils graphiques interactifs."
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "Erreur lors de la simulation du dépôt"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "Mettre à jour la limite"
 msgid "Edit order"
 msgstr "Modifier l'ordre"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "Erreur de simulation de retrait"
@@ -9594,7 +9582,6 @@ msgstr "Frais de réseau TWAP élevé"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "La position serait liquidable. Actuel : {remainingCollateralUsdText}, requis : {minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "Projection du taux net :"
 msgid "Enter a new size or price"
 msgstr "Saisir une nouvelle taille ou prix"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "Incitation bonus GLV (test)"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} / {1}"
 msgid "In liquidity"
 msgstr "流動性プール内"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "ステークが送信されました"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "{symbol}の残高が不足しています：利用可能 {availableFormatted}、必要額 {requiredFormatted}"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "トリガー注文"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMXはTradingViewを使用してリアルタイムの暗号通貨チャートを提供しています。<0>BTCUSD</0>やその他のペアをインタラクティブなチャートツールで追跡できます。"
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "入金シミュレーションエラー"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "指値を更新"
 msgid "Edit order"
 msgstr "注文を編集"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "引き出しシミュレーションエラー"
@@ -9594,7 +9582,6 @@ msgstr "高いTWAPネットワーク手数料"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "ポジションが清算対象となります。現在: {remainingCollateralUsdText}、必要: {minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "ネットレート予測:"
 msgid "Enter a new size or price"
 msgstr "新しいサイズまたは価格を入力"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "GLVボーナスインセンティブ（テスト）"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0}/{1}"
 msgid "In liquidity"
 msgstr "유동성 내"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "스테이킹이 제출되었습니다"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "{symbol} 잔액 부족: {availableFormatted} 사용 가능, {requiredFormatted} 필요"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "조건부 주문"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX는 실시간 암호화폐 차트를 위해 TradingView를 사용합니다. <0>BTCUSD</0> 및 기타 거래쌍을 인터랙티브 차트 도구로 확인하십시오."
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "입금 시뮬레이션 오류"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "지정가 업데이트"
 msgid "Edit order"
 msgstr "주문 수정"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "출금 시뮬레이션 오류"
@@ -9594,7 +9582,6 @@ msgstr "높은 TWAP 네트워크 수수료"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "포지션이 청산 대상이 됩니다. 현재: {remainingCollateralUsdText}, 필요: {minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "순이자율 예측:"
 msgid "Enter a new size or price"
 msgstr "새 크기 또는 가격 입력"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "GLV 보너스 인센티브 (테스트)"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -1736,7 +1736,6 @@ msgstr ""
 msgid "In liquidity"
 msgstr ""
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2961,10 +2960,6 @@ msgstr ""
 
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
-msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
 msgstr ""
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
@@ -5536,11 +5531,6 @@ msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
-msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
 msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr ""
 msgid "Edit order"
 msgstr ""
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr ""
@@ -9594,7 +9582,6 @@ msgstr ""
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr ""
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr ""
 msgid "Enter a new size or price"
 msgstr ""
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} за {1}"
 msgid "In liquidity"
 msgstr "В ликвидности"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "Запрос на стейкинг отправлен"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "Недостаточный баланс {symbol}: доступно {availableFormatted}, требуется {requiredFormatted}"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "Триггерные ордера"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX использует TradingView для отображения криптовалютных графиков в реальном времени. Отслеживайте <0>BTCUSD</0> и другие пары с помощью интерактивных инструментов построения графиков."
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "Ошибка симуляции депозита"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "Обновить лимит"
 msgid "Edit order"
 msgstr "Редактировать ордер"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "Ошибка симуляции вывода"
@@ -9594,7 +9582,6 @@ msgstr "Высокая сетевая комиссия TWAP"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "Позиция будет подвержена ликвидации. Текущее: {remainingCollateralUsdText}, требуется: {minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "Прогноз чистой ставки:"
 msgid "Enter a new size or price"
 msgstr "Введите новый размер или цену"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "Бонусное поощрение GLV (тест)"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} / {1}"
 msgid "In liquidity"
 msgstr "在流動性中"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "質押已提交"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "{symbol} 餘額不足：可用 {availableFormatted}，需要 {requiredFormatted}"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "觸發訂單"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX 使用 TradingView 提供即時加密貨幣圖表。透過互動式圖表工具追蹤 <0>BTCUSD</0> 及其他交易對。"
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "模擬存入時發生錯誤"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "更新限價單"
 msgid "Edit order"
 msgstr "編輯訂單"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "模擬提取時發生錯誤"
@@ -9594,7 +9582,6 @@ msgstr "TWAP 網路費用偏高"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "倉位將面臨清算。目前：{remainingCollateralUsdText}，要求：{minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "淨費率預測："
 msgid "Enter a new size or price"
 msgstr "輸入新的數量或價格"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "GLV 獎勵激勵（測試）"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1736,7 +1736,6 @@ msgstr "{0} 每 {1}"
 msgid "In liquidity"
 msgstr "在流动性池中"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "Not supported"
@@ -2962,10 +2961,6 @@ msgstr "质押已提交"
 #: src/components/Referrals/shared/charts/GmxBarChart.tsx
 msgid "Net"
 msgstr ""
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
-msgstr "{symbol} 余额不足：可用 {availableFormatted}，需要 {requiredFormatted}"
 
 #: src/components/PositionList/SymbolSortDropdown.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -5537,11 +5532,6 @@ msgstr "触发订单"
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "GMX uses TradingView for real-time cryptocurrency charts. Track <0>BTCUSD</0> and other pairs with interactive charting tools."
 msgstr "GMX 使用 TradingView 提供实时加密货币图表。通过交互式图表工具跟踪 <0>BTCUSD</0> 及其他交易对。"
-
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-msgid "Error simulating deposit"
-msgstr "模拟存入时出错"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -8643,8 +8633,6 @@ msgstr "更新限价"
 msgid "Edit order"
 msgstr "编辑订单"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Error simulating withdrawal"
 msgstr "模拟提取错误"
@@ -9594,7 +9582,6 @@ msgstr "高 TWAP 网络费用"
 msgid "Position would be liquidatable. Current: {remainingCollateralUsdText}, required: {minCollateralUsdText}"
 msgstr "仓位将面临清算。当前：{remainingCollateralUsdText}，所需：{minCollateralUsdText}"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -10300,7 +10287,6 @@ msgstr "净费率预测："
 msgid "Enter a new size or price"
 msgstr "输入新规模或价格"
 
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max pool amount exceeded"
@@ -10952,7 +10938,6 @@ msgstr "GLV 奖金激励（测试）"
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
-#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Insufficient balance"


### PR DESCRIPTION
## Summary
- Temporarily removes all validation checks from the buy GM/GLV submit button
- Button will always show "Buy GM/GLV" or "Sell GM/GLV" and remain clickable regardless of validation state
- Keeps essential states: connect wallet, token approvals, and submitting spinner

## Test plan
- [ ] Verify buy GM button is always enabled
- [ ] Verify buy GLV button is always enabled
- [ ] Verify sell GM/GLV buttons are always enabled
- [ ] Verify connect wallet still shows when disconnected
- [ ] Verify token approval flow still works