### PR TITLE
Rename getBestInternalSwapStrategy to getBestFeeSwapStrategy

### DIFF
--- a/sdk/src/utils/express/utils/relayParamsUtils.ts
+++ b/sdk/src/utils/express/utils/relayParamsUtils.ts
@@ -150,7 +150,7 @@ export function getRelayerFeeParams({
       });
     }
 
-    const bestFeeSwapStrategy = getBestInternalSwapStrategy(feeSwapAmounts, feeExternalSwapQuote);
+    const bestFeeSwapStrategy = getBestFeeSwapStrategy(feeSwapAmounts, feeExternalSwapQuote);
 
     if (bestFeeSwapStrategy?.swapPath) {
       feeParams = {
@@ -190,7 +190,7 @@ export function getRelayerFeeParams({
   };
 }
 
-export function getBestInternalSwapStrategy(
+export function getBestFeeSwapStrategy(
   internalSwapAmounts: SwapAmounts | undefined,
   externalSwapQuote: ExternalSwapQuote | undefined
 ) {


### PR DESCRIPTION
The function compares both internal swap amounts and external swap quotes, returning whichever has a better usdOut. The name 'InternalSwapStrategy' was misleading as it implied it only considers internal swaps.

Renamed to getBestFeeSwapStrategy which accurately describes its purpose: finding the best strategy for fee swaps, whether internal or external.