### PR TITLE
Drop (BB&D) suffix from Stats Dashboard fees tooltip [FEDEV-3757]

### DIFF
--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Yield Yak Swap"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "Annualisierter Kaufdruck (BB&D):"
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Kaufe</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>Kaufe</0> {wrappedNativeTokenSymbol}."
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "Annualisierter Kaufdruck:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Yield Yak Swap"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "Annualized buy pressure (BB&D):"
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr "Swap to"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Buy</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr "Annualized buy pressure:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>Comprar</0> {wrappedNativeTokenSymbol}."
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "Presión de compra anualizada:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Intercambio Yield Yak"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "Presión de compra anualizada (BB&D):"
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Comprar</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Swap Yield Yak"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "Pression d'achat annualisée (BB&D) :"
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Acheter</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>Acheter</0> {wrappedNativeTokenSymbol}."
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "Pression d'achat annualisée :"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>{wrappedNativeTokenSymbol}を購入</0>。"
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "年間購入圧力："
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Yield Yakスワップ"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "年間購入圧力（BB&D）："
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol}を購入</0>。"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Yield Yak 스왑"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "연간 매수 압력 (BB&D):"
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol} 구매</0>."
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>{wrappedNativeTokenSymbol} 구매</0>."
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "연간 매수 압력:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -1024,10 +1024,6 @@ msgstr ""
 msgid "Vaultka"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr ""
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4348,6 +4344,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
+msgstr ""
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
 msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>Купить</0> {wrappedNativeTokenSymbol}."
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "Годовое давление на покупку:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Обмен Yield Yak"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "Годовое давление на покупку (BB&D):"
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Купить</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Yield Yak Swap"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "年化買入壓力（BB&D）："
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>買入</0> {wrappedNativeTokenSymbol}。"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>買入</0> {wrappedNativeTokenSymbol}。"
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "年化買入壓力："
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1024,10 +1024,6 @@ msgstr "Yield Yak 交换"
 msgid "Vaultka"
 msgstr "Vaultka"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure (BB&D):"
-msgstr "年化买入压力 (BB&D)："
-
 #: src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
@@ -4349,6 +4345,10 @@ msgstr ""
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>购买</0> {wrappedNativeTokenSymbol}。"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized buy pressure:"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4348,7 +4348,7 @@ msgstr "<0>购买</0> {wrappedNativeTokenSymbol}。"
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized buy pressure:"
-msgstr ""
+msgstr "年化买入压力："
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -376,7 +376,7 @@ export function OverviewCard({
         </p>
         <p className="Tooltip-row">
           <span className="label">
-            <Trans>Annualized buy pressure (BB&D):</Trans>
+            <Trans>Annualized buy pressure:</Trans>
           </span>
           <span className="numbers">{formatAmountHuman(annualizedTotalBuyingPressure, USD_DECIMALS, true, 2)}</span>
         </p>


### PR DESCRIPTION
## Summary
- Removes the outdated `(BB&D)` suffix from the `Annualized buy pressure` row in the Stats Dashboard fees tooltip
- Locale catalogs updated via lingui compile.

Linear: [FEDEV-3757](https://linear.app/gmx-io/issue/FEDEV-3757)

## Test plan
- [ ] Stats Dashboard fees tooltip shows `Annualized buy pressure:` with no other visible change.