### PR TITLE
Filter disabled GM markets from Buy GLV pool selector [FEDEV-3740]

### DIFF
--- a/src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
+++ b/src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
@@ -2,6 +2,7 @@ import { Trans, t } from "@lingui/macro";
 import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
 
+import { isDepositDisabledMarket } from "config/static/markets";
 import { useTokensFavorites } from "context/TokensFavoritesContext/TokensFavoritesContextProvider";
 import {
   GlvInfo,
@@ -99,6 +100,10 @@ export function GmPoolsSelectorForGlvMarket({
             return null;
           }
 
+          if (isDeposit && (marketInfo.isDisabled || isDepositDisabledMarket(chainId, marketInfo.marketTokenAddress))) {
+            return null;
+          }
+
           const indexName = getMarketIndexName(marketInfo);
           const marketToken = getByKey(marketTokensData, marketInfo.marketTokenAddress);
           const gmBalance = marketToken?.balance;
@@ -133,7 +138,7 @@ export function GmPoolsSelectorForGlvMarket({
     });
 
     return [...sortedMarketsWithBalance, ...marketsWithoutBalance];
-  }, [getMarketState, marketTokensData, markets]);
+  }, [chainId, getMarketState, isDeposit, marketTokensData, markets]);
 
   const selectedPool = useMemo(
     () => marketsOptions.find((option) => getGlvOrMarketAddress(option.glvOrMarketInfo) === selectedMarketAddress),

--- a/src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
+++ b/src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
@@ -140,13 +140,10 @@ export function GmPoolsSelectorForGlvMarket({
     return [...sortedMarketsWithBalance, ...marketsWithoutBalance];
   }, [chainId, getMarketState, isDeposit, marketTokensData, markets]);
 
-  const selectedPool = useMemo(
-    () => marketsOptions.find((option) => getGlvOrMarketAddress(option.glvOrMarketInfo) === selectedMarketAddress),
-    [marketsOptions, selectedMarketAddress]
+  const marketInfo = useMemo(
+    () => markets.find((m) => m.market?.marketTokenAddress === selectedMarketAddress)?.market,
+    [markets, selectedMarketAddress]
   );
-
-  const selectedMarketInfo = selectedPool?.glvOrMarketInfo;
-  const marketInfo = selectedMarketInfo && isMarketInfo(selectedMarketInfo) ? selectedMarketInfo : undefined;
 
   const filteredOptions = useMemo(() => {
     const textMatched = searchKeyword.trim()

--- a/src/components/MarketStats/hooks/useBestGmPoolForGlv.ts
+++ b/src/components/MarketStats/hooks/useBestGmPoolForGlv.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 
+import { isDepositDisabledMarket } from "config/static/markets";
 import {
   selectPoolsDetailsFlags,
   selectPoolsDetailsFocusedInput,
@@ -68,7 +69,13 @@ export const useBestGmPoolAddressForGlv = ({
 
     const halfOfLong = longTokenAmount !== undefined ? longTokenAmount / 2n : undefined;
 
-    return [...marketsWithComposition].map((marketConfig) => {
+    const candidateMarkets = isDeposit
+      ? marketsWithComposition.filter(
+          (marketConfig) => !isDepositDisabledMarket(chainId, marketConfig.market.marketTokenAddress)
+        )
+      : marketsWithComposition;
+
+    return [...candidateMarkets].map((marketConfig) => {
       const marketInfo = marketConfig.market;
 
       const adjustedLongTokenAmount = (marketInfo.isSameCollaterals ? halfOfLong : longTokenAmount) || 0n;


### PR DESCRIPTION
## Summary
- In the Buy GLV window, the pool selector now hides GM markets that are disabled (`marketInfo.isDisabled`) or on the deposit blocklist (`isDepositDisabledMarket`), preventing users from picking a pool whose transaction would fail with "Buying GM is disabled for this market". Sell flow is unchanged so positions in disabled pools can still be withdrawn.

Linear: [FEDEV-3740](https://linear.app/gmx-io/issue/FEDEV-3740/bug-remove-disabled-gm-markets-from-glv-pool-selector-when-buying)

## Test plan
- [ ] On a chain with a deposit-disabled GM market that is part of a GLV, open Buy GLV → pool selector and confirm the disabled market no longer appears.
- [ ] Open Sell GLV → pool selector and confirm all markets (including disabled ones) are still listed.
- [ ] Buying GLV via a non-disabled pool still works end-to-end.