### PR TITLE
fix: align mobile size selector chevron spacing (FEDEV-3763)

### DIFF
--- a/src/components/SelectorBase/SelectorBase.tsx
+++ b/src/components/SelectorBase/SelectorBase.tsx
@@ -282,9 +282,14 @@ function SelectorBaseMobile(props: Props) {
 
   return (
     <>
-      <div className={cx("SelectorBase-button group/selector-base", props.handleClassName)} onClick={toggleVisibility}>
+      <div
+        className={cx("SelectorBase-button group/selector-base gap-5", props.handleClassName)}
+        onClick={toggleVisibility}
+      >
         <span className="overflow-hidden text-ellipsis">{props.label}</span>
-        {!props.disabled && <ChevronDownIcon className={cx("inline-block size-16", props.chevronClassName)} />}
+        {!props.disabled && (
+          <ChevronDownIcon className={cx("inline-block size-16 text-typography-secondary", props.chevronClassName)} />
+        )}
       </div>
 
       <SlideModal


### PR DESCRIPTION
## Summary
- Fixes [FEDEV-3763](https://linear.app/gmx-io/issue/FEDEV-3763): on mobile, the Size row's chevron sat flush against the token text while the Margin row had proper spacing.
- Root cause: `SelectorBaseMobile` was missing the `gap-5` class that `SelectorBaseDesktop` has, so the mobile USD/Token toggle in the trade box rendered with no gap between the label and the chevron.
- Also adds `text-typography-secondary` to the mobile chevron to match the desktop chevron's default color.

## Test plan
- [x] At mobile width (<=768px), open `/trade`, expand the trade box, switch the Size selector to token mode (e.g. CRV) and verify the chevron now has the same spacing as the Margin row's selector.
- [x] Verify desktop view is unchanged (only `SelectorBaseMobile` was modified).