### PR TITLE
feat(trade): hide deprecated markets from chart dropdown (FEDEV-3773)

### DIFF
--- a/sdk/src/utils/markets/utils.ts
+++ b/sdk/src/utils/markets/utils.ts
@@ -8,7 +8,7 @@ import { convertTokenAddress, getTokenVisualMultiplier, NATIVE_TOKEN_ADDRESS } f
 import type { DayPriceCandle } from "utils/24h/types";
 import { bigMath } from "utils/bigmath";
 import { getBorrowingFactorPerPeriod, getFundingFactorPerPeriod } from "utils/fees";
-import { applyFactor, PRECISION } from "utils/numbers";
+import { applyFactor, expandDecimals, PRECISION } from "utils/numbers";
 import { getByKey } from "utils/objects";
 import { periodToSeconds } from "utils/time";
 import { convertToContractTokenPrices, convertToUsd, getMidPrice } from "utils/tokens";
@@ -317,6 +317,10 @@ export function getIsMarketAvailableForExpressSwaps(marketInfo: MarketInfo) {
   return [marketInfo.indexToken, marketInfo.longToken, marketInfo.shortToken].every(
     (token) => token.hasPriceFeedProvider
   );
+}
+
+export function getIsMarketDeprecated(marketInfo: MarketInfo) {
+  return marketInfo.maxOpenInterestLong <= expandDecimals(1n, 30) && marketInfo.maxOpenInterestShort <= expandDecimals(1n, 30);
 }
 
 export function getMarket24Stats(dayPriceCandle: DayPriceCandle) {

--- a/src/domain/synthetics/trade/useAvailableTokenOptions.ts
+++ b/src/domain/synthetics/trade/useAvailableTokenOptions.ts
@@ -4,7 +4,14 @@ import { zeroAddress } from "viem";
 import { ARBITRUM, ARBITRUM_SEPOLIA, AVALANCHE, AVALANCHE_FUJI, BOTANIX, MEGAETH } from "config/chains";
 import { getSortedMarketsAddressesKey } from "config/localStorage";
 import { SORTED_MARKETS } from "config/static/sortedMarkets";
-import { GlvAndGmMarketsInfoData, Market, MarketInfo, MarketsData, isMarketInfo } from "domain/synthetics/markets";
+import {
+  GlvAndGmMarketsInfoData,
+  Market,
+  MarketInfo,
+  MarketsData,
+  getIsMarketDeprecated,
+  isMarketInfo,
+} from "domain/synthetics/markets";
 import { InfoTokens, Token, getMidPrice } from "domain/tokens";
 import { getByKey } from "lib/objects";
 import type { ContractsChainId, SourceChainId } from "sdk/configs/chains";
@@ -178,7 +185,7 @@ export function useAvailableTokenOptions(
       shortTokensWithPoolValue[shortToken.address] =
         (shortTokensWithPoolValue[shortToken.address] ?? 0n) + shortPoolAmountUsd;
 
-      if (!marketInfo.isSpotOnly) {
+      if (!marketInfo.isSpotOnly && !getIsMarketDeprecated(marketInfo)) {
         indexTokens.add(indexToken);
         allMarkets.add(marketInfo);
         indexTokensWithPoolValue[indexToken.address] =


### PR DESCRIPTION
## Summary
Markets with both OI caps set to 0 (the protocol's soft-deprecation signal) are now filtered out of the trade page market dropdown — including the favorites tab. The filter is applied at `useAvailableTokenOptions` in the non-spot index-token branch, so `sortedAllMarkets` / `indexTokens` / `sortedIndexTokensWithPoolValue` skip deprecated markets while collateral and swap-token lists stay intact. `/pools` (`GmList`), the pool deposit selector, existing positions, and existing orders are unaffected since they use different data sources, and deep links to deprecated markets fall back gracefully via the existing invalid-param cleanup in `useTradeParamsProcessor`.

Linear: https://linear.app/gmx-io/issue/FEDEV-3773

## Test plan
- [x] On Arbitrum, confirm BOME, BRETT, MEME, MEW, mSATS, AI16Z, WELL no longer appear in the trade market dropdown (All + Favorites tabs).
- [x] Open `/pools` and confirm the same markets still appear and can be withdrawn from.
- [x] If you have an existing position/order on a now-hidden market, confirm it still shows in the Positions/Orders tabs and can be closed/cancelled.
- [x] Visit `/trade?market=BOME` (or similar) and confirm the app lands on a valid market and the query params get cleared.
- [x] Open the pool deposit market selector and confirm behavior is unchanged.