### PR TITLE
Bump postcss to patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "happy-dom": "^20.8.8",
     "husky": "7.0.4",
     "lint-staged": "12.3.4",
-    "postcss": "8.4.41",
+    "postcss": "8.5.12",
     "prettier": "3.2.5",
     "prettier-plugin-tailwindcss": "0.6.5",
     "rollup-plugin-visualizer": "5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12267,7 +12267,7 @@ __metadata:
     immer: "npm:10.1.1"
     lint-staged: "npm:12.3.4"
     lodash: "npm:4.18.1"
-    postcss: "npm:8.4.41"
+    postcss: "npm:8.5.12"
     prettier: "npm:3.2.5"
     prettier-plugin-tailwindcss: "npm:0.6.5"
     qrcode.react: "npm:^3.1.0"
@@ -14381,15 +14381,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.7":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/ac1eb60f615b272bccb0e2b9cd933720dad30bf9708424f691b8113826bb91aca7e9d14ef5d9415a6ba15c266b37817256f58d8ce980c82b0ba3185352565679
-  languageName: node
-  linkType: hard
-
 "napi-wasm@npm:^1.1.0":
   version: 1.1.0
   resolution: "napi-wasm@npm:1.1.0"
@@ -15376,36 +15367,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.41, postcss@npm:^8.4.23, postcss@npm:^8.4.40":
-  version: 8.4.41
-  resolution: "postcss@npm:8.4.41"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.0.1"
-    source-map-js: "npm:^1.2.0"
-  checksum: 10/6e6176c2407eff60493ca60a706c6b7def20a722c3adda94ea1ece38345eb99964191336fd62b62652279cec6938e79e0b1e1d477142c8d3516e7a725a74ee37
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.43":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
+"postcss@npm:8.5.12, postcss@npm:^8.4.23, postcss@npm:^8.4.40, postcss@npm:^8.4.43, postcss@npm:^8.5.3":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/9e4fbe97574091e9736d0e82a591e29aa100a0bf60276a926308f8c57249698935f35c5d2f4e80de778d0cbb8dcffab4f383d85fd50c5649aca421c3df729b86
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.3":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/cbacbfd7f767e2c820d4bf09a3a744834dd7d14f69ff08d1f57b1a7defce9ae5efcf31981890d9697a972a64e9965de677932ef28e4c8ba23a87aad45b82c459
+  checksum: 10/ec6b79b68c363eca3c8ffceb134a4ab637274aee6ac0857614bf7c18d40ce4ce5f9036edec57b7e0be99895724d2599d0ec7328dbd7f407204e7548697b322f1
   languageName: node
   linkType: hard
 
@@ -17317,7 +17286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.2.0":
+"source-map-js@npm:>=0.6.2 <2.0.0":
   version: 1.2.0
   resolution: "source-map-js@npm:1.2.0"
   checksum: 10/74f331cfd2d121c50790c8dd6d3c9de6be21926de80583b23b37029b0f37aefc3e019fa91f9a10a5e120c08135297e1ecf312d561459c45908cb1e0e365f49e5


### PR DESCRIPTION
## Summary

Updates the direct `postcss` dependency from `8.4.41` to `8.5.12` and dedupes the lockfile so all PostCSS ranges resolve to `8.5.12`.

## Why

The existing tree contained `postcss@8.4.41`, which is affected by GHSA-qx2v-qp2m-jg93 / audit ID 1117015. The advisory is fixed in `8.5.10`; `8.5.12` is the current patched release.

## Validation

- `yarn npm audit --severity moderate --no-deprecations --ignore 1112686 --ignore 1116005 --ignore 1116229`
- `yarn why postcss`
- `yarn install --immutable`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn build`
- pre-push checks from `git push -u origin check-postcss-audit`