### PR TITLE
FEDEV-3813 preserve full-close semantics for TP/SL orders

### DIFF
--- a/src/components/OrderEditor/OrderEditor.tsx
+++ b/src/components/OrderEditor/OrderEditor.tsx
@@ -78,7 +78,11 @@ import {
 import { useCloseSizeInput } from "domain/synthetics/trade/useCloseSizeInput";
 import { getExpressError, getIsMaxLeverageExceeded } from "domain/synthetics/trade/utils/validation";
 import { TokensRatioAndSlippage } from "domain/tokens";
-import { FULL_POSITION_CLOSE_SIZE_DELTA_USD, isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
+import {
+  FULL_POSITION_CLOSE_SIZE_DELTA_USD,
+  getPositionCloseSizeDeltaUsdForDisplay,
+  isFullPositionCloseSizeDeltaUsd,
+} from "domain/tpsl/utils";
 import { numericBinarySearch } from "lib/binarySearch";
 import { useChainId } from "lib/chains";
 import { helperToast } from "lib/helperToast";
@@ -638,10 +642,20 @@ export function OrderEditor(p: Props) {
         const positionOrder = p.order as PositionOrderInfo;
 
         if (isTriggerDecrease) {
+          const orderSizeDeltaUsd = positionOrder.sizeDeltaUsd ?? 0n;
+
+          if (isFullPositionCloseSizeDeltaUsd(orderSizeDeltaUsd) && !existingPosition) {
+            return;
+          }
+
+          const displaySizeDeltaUsd = getPositionCloseSizeDeltaUsdForDisplay(
+            orderSizeDeltaUsd,
+            existingPosition?.sizeInUsd
+          );
           const clampedSizeDeltaUsd =
-            existingPosition && (positionOrder.sizeDeltaUsd ?? 0n) > existingPosition.sizeInUsd
+            existingPosition && displaySizeDeltaUsd > existingPosition.sizeInUsd
               ? existingPosition.sizeInUsd
-              : positionOrder.sizeDeltaUsd ?? 0n;
+              : displaySizeDeltaUsd;
           closeSize.setFromUsdString(formatAmountFree(clampedSizeDeltaUsd, USD_DECIMALS));
         } else {
           setSizeInputValue(formatAmountFree(positionOrder.sizeDeltaUsd ?? 0n, USD_DECIMALS));

--- a/src/components/OrderEditor/OrderEditor.tsx
+++ b/src/components/OrderEditor/OrderEditor.tsx
@@ -78,6 +78,7 @@ import {
 import { useCloseSizeInput } from "domain/synthetics/trade/useCloseSizeInput";
 import { getExpressError, getIsMaxLeverageExceeded } from "domain/synthetics/trade/utils/validation";
 import { TokensRatioAndSlippage } from "domain/tokens";
+import { FULL_POSITION_CLOSE_SIZE_DELTA_USD, isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { numericBinarySearch } from "lib/binarySearch";
 import { useChainId } from "lib/chains";
 import { helperToast } from "lib/helperToast";
@@ -371,6 +372,12 @@ export function OrderEditor(p: Props) {
       };
     } else {
       const positionOrder = p.order as PositionOrderInfo;
+      const nextSizeDeltaUsd = sizeDeltaUsd ?? positionOrder.sizeDeltaUsd;
+      const shouldPreserveFullCloseSize =
+        isTriggerDecrease &&
+        isFullPositionCloseSizeDeltaUsd(positionOrder.sizeDeltaUsd) &&
+        existingPosition !== undefined &&
+        nextSizeDeltaUsd >= existingPosition.sizeInUsd;
 
       return {
         createOrderParams: [],
@@ -380,7 +387,7 @@ export function OrderEditor(p: Props) {
             indexTokenAddress: positionOrder.indexToken.address,
             orderKey: p.order.key,
             orderType: p.order.orderType,
-            sizeDeltaUsd: sizeDeltaUsd ?? positionOrder.sizeDeltaUsd,
+            sizeDeltaUsd: shouldPreserveFullCloseSize ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : nextSizeDeltaUsd,
             triggerPrice: triggerPrice ?? positionOrder.triggerPrice,
             acceptablePrice: acceptablePrice ?? positionOrder.acceptablePrice,
             minOutputAmount: minOutputAmount ?? positionOrder.minOutputAmount,
@@ -397,6 +404,8 @@ export function OrderEditor(p: Props) {
     tokensData,
     marketsInfoData,
     p.order,
+    existingPosition,
+    isTriggerDecrease,
     triggerRatio?.ratio,
     triggerPrice,
     chainId,

--- a/src/components/OrderEditor/OrderEditor.tsx
+++ b/src/components/OrderEditor/OrderEditor.tsx
@@ -379,7 +379,7 @@ export function OrderEditor(p: Props) {
       const nextSizeDeltaUsd = sizeDeltaUsd ?? positionOrder.sizeDeltaUsd;
       const shouldPreserveFullCloseSize =
         isTriggerDecrease &&
-        isFullPositionCloseSizeDeltaUsd(positionOrder.sizeDeltaUsd) &&
+        isFullPositionCloseSizeDeltaUsd(positionOrder.sizeDeltaUsd, existingPosition?.sizeInUsd) &&
         existingPosition !== undefined &&
         nextSizeDeltaUsd >= existingPosition.sizeInUsd;
 
@@ -564,6 +564,17 @@ export function OrderEditor(p: Props) {
       };
     }
 
+    if (
+      isTriggerDecrease &&
+      isFullPositionCloseSizeDeltaUsd((p.order as PositionOrderInfo).sizeDeltaUsd) &&
+      !existingPosition
+    ) {
+      return {
+        text: t`Loading position...`,
+        disabled: true,
+      };
+    }
+
     if (isMaxLeverageError) {
       return {
         text: t`Max leverage exceeded`,
@@ -603,10 +614,11 @@ export function OrderEditor(p: Props) {
     error,
     hasOutdatedUi,
     isMaxLeverageError,
-    p.order.orderType,
-    p.order.isTwap,
+    p.order,
     onSubmit,
     detectAndSetAvailableMaxLeverage,
+    isTriggerDecrease,
+    existingPosition,
   ]);
 
   useKey(

--- a/src/components/OrderItem/OrderItem.tsx
+++ b/src/components/OrderItem/OrderItem.tsx
@@ -29,7 +29,6 @@ import {
   isStopIncreaseOrderType,
   isStopLossOrderType,
   isSwapOrderType,
-  isTriggerDecreaseOrderType,
   isTwapOrder,
 } from "domain/synthetics/orders";
 import { useDisabledCancelMarketOrderMessage } from "domain/synthetics/orders/useDisabledCancelMarketOrderMessage";
@@ -37,7 +36,7 @@ import { PositionsInfoData, getNameByOrderType, getPositionKey } from "domain/sy
 import { convertToTokenAmount, convertToUsd, getTokensRatioByPrice } from "domain/synthetics/tokens";
 import { getMarkPrice } from "domain/synthetics/trade";
 import { TokensRatioAndSlippage } from "domain/tokens";
-import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
+import { isFullClosePositionOrder } from "domain/tpsl/utils";
 import { calculateDisplayDecimals, formatAmount, formatBalanceAmount, formatUsd } from "lib/numbers";
 import { getByKey } from "lib/objects";
 import { useIsTruncated } from "lib/useIsTruncated";
@@ -175,9 +174,7 @@ function OrderSize({
       positionOrder.isLong
     )
   );
-  const isFullClose =
-    isTriggerDecreaseOrderType(positionOrder.orderType) &&
-    isFullPositionCloseSizeDeltaUsd(positionOrder.sizeDeltaUsd, position?.sizeInUsd);
+  const isFullClose = isFullClosePositionOrder(order, position?.sizeInUsd);
 
   function getCollateralLabel() {
     if (isDecreaseOrderType(positionOrder.orderType)) {
@@ -329,7 +326,7 @@ function SizeWithIcon({
   }
 
   const { sizeDeltaUsd } = order;
-  if (isTriggerDecreaseOrderType(order.orderType) && isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd, positionSizeUsd)) {
+  if (isFullClosePositionOrder(order, positionSizeUsd)) {
     return (
       <span className={className}>
         <Trans>Full position close</Trans>

--- a/src/components/OrderItem/OrderItem.tsx
+++ b/src/components/OrderItem/OrderItem.tsx
@@ -171,7 +171,7 @@ function OrderSize({
     getPositionKey(
       positionOrder.account,
       positionOrder.marketAddress,
-      positionOrder.initialCollateralTokenAddress,
+      positionOrder.targetCollateralToken.address,
       positionOrder.isLong
     )
   );
@@ -187,14 +187,11 @@ function OrderSize({
   }
 
   function getCollateralText() {
-    const sourceAmount =
-      isFullClose && position ? position.collateralAmount : positionOrder.initialCollateralDeltaAmount;
+    const useLivePositionMargin = isFullClose && position;
+    const sourceAmount = useLivePositionMargin ? position.collateralAmount : positionOrder.initialCollateralDeltaAmount;
+    const sourceToken = useLivePositionMargin ? position.collateralToken : positionOrder.initialCollateralToken;
 
-    const collateralUsd = convertToUsd(
-      sourceAmount,
-      positionOrder.initialCollateralToken.decimals,
-      positionOrder.initialCollateralToken.prices.minPrice
-    )!;
+    const collateralUsd = convertToUsd(sourceAmount, sourceToken.decimals, sourceToken.prices.minPrice)!;
 
     const targetCollateralAmount = convertToTokenAmount(
       collateralUsd,
@@ -218,7 +215,7 @@ function OrderSize({
 
   return (
     <TooltipWithPortal
-      handle={<SizeWithIcon order={order} className={className} />}
+      handle={<SizeWithIcon order={order} className={className} positionSizeUsd={position?.sizeInUsd} />}
       position="bottom-start"
       tooltipClassName={isTwapOrder(order) ? "!p-0" : undefined}
       maxAllowedWidth={400}
@@ -271,7 +268,15 @@ export function TwapOrderProgress({ order, className }: { order: TwapOrderInfo; 
   return <span className={className}>{content}</span>;
 }
 
-function SizeWithIcon({ order, className }: { order: OrderInfo; className?: string }) {
+function SizeWithIcon({
+  order,
+  className,
+  positionSizeUsd,
+}: {
+  order: OrderInfo;
+  className?: string;
+  positionSizeUsd?: bigint;
+}) {
   if (isSwapOrderType(order.orderType)) {
     const { initialCollateralToken, targetCollateralToken, minOutputAmount, initialCollateralDeltaAmount } = order;
 
@@ -324,7 +329,7 @@ function SizeWithIcon({ order, className }: { order: OrderInfo; className?: stri
   }
 
   const { sizeDeltaUsd } = order;
-  if (isTriggerDecreaseOrderType(order.orderType) && isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd)) {
+  if (isTriggerDecreaseOrderType(order.orderType) && isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd, positionSizeUsd)) {
     return (
       <span className={className}>
         <Trans>Full position close</Trans>

--- a/src/components/OrderItem/OrderItem.tsx
+++ b/src/components/OrderItem/OrderItem.tsx
@@ -28,6 +28,7 @@ import {
   isStopIncreaseOrderType,
   isStopLossOrderType,
   isSwapOrderType,
+  isTriggerDecreaseOrderType,
   isTwapOrder,
 } from "domain/synthetics/orders";
 import { useDisabledCancelMarketOrderMessage } from "domain/synthetics/orders/useDisabledCancelMarketOrderMessage";
@@ -35,6 +36,7 @@ import { PositionsInfoData, getNameByOrderType } from "domain/synthetics/positio
 import { convertToTokenAmount, convertToUsd, getTokensRatioByPrice } from "domain/synthetics/tokens";
 import { getMarkPrice } from "domain/synthetics/trade";
 import { TokensRatioAndSlippage } from "domain/tokens";
+import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { calculateDisplayDecimals, formatAmount, formatBalanceAmount, formatUsd } from "lib/numbers";
 import { useIsTruncated } from "lib/useIsTruncated";
 import { getWrappedToken } from "sdk/configs/tokens";
@@ -303,6 +305,14 @@ function SizeWithIcon({ order, className }: { order: OrderInfo; className?: stri
   }
 
   const { sizeDeltaUsd } = order;
+  if (isTriggerDecreaseOrderType(order.orderType) && isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd)) {
+    return (
+      <span className={className}>
+        <Trans>Full position close</Trans>
+      </span>
+    );
+  }
+
   const sizeText = formatUsd(sizeDeltaUsd * (isIncreaseOrderType(order.orderType) ? 1n : -1n), {
     displayPlus: true,
   });

--- a/src/components/OrderItem/OrderItem.tsx
+++ b/src/components/OrderItem/OrderItem.tsx
@@ -10,6 +10,7 @@ import {
   selectChainId,
   selectMarketsInfoData,
   selectOracleSettings,
+  selectPositionsInfoData,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
 import { selectTradeboxSelectedOrderKey } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
@@ -32,12 +33,13 @@ import {
   isTwapOrder,
 } from "domain/synthetics/orders";
 import { useDisabledCancelMarketOrderMessage } from "domain/synthetics/orders/useDisabledCancelMarketOrderMessage";
-import { PositionsInfoData, getNameByOrderType } from "domain/synthetics/positions";
+import { PositionsInfoData, getNameByOrderType, getPositionKey } from "domain/synthetics/positions";
 import { convertToTokenAmount, convertToUsd, getTokensRatioByPrice } from "domain/synthetics/tokens";
 import { getMarkPrice } from "domain/synthetics/trade";
 import { TokensRatioAndSlippage } from "domain/tokens";
 import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { calculateDisplayDecimals, formatAmount, formatBalanceAmount, formatUsd } from "lib/numbers";
+import { getByKey } from "lib/objects";
 import { useIsTruncated } from "lib/useIsTruncated";
 import { getWrappedToken } from "sdk/configs/tokens";
 
@@ -127,6 +129,7 @@ function OrderSize({
   className?: string;
 }) {
   const chainId = useSelector(selectChainId);
+  const positionsInfoData = useSelector(selectPositionsInfoData);
 
   if (isSwapOrderType(order.orderType)) {
     if (showDebugValues) {
@@ -163,6 +166,19 @@ function OrderSize({
 
   const wrappedToken = getWrappedToken(chainId);
 
+  const position = getByKey(
+    positionsInfoData,
+    getPositionKey(
+      positionOrder.account,
+      positionOrder.marketAddress,
+      positionOrder.initialCollateralTokenAddress,
+      positionOrder.isLong
+    )
+  );
+  const isFullClose =
+    isTriggerDecreaseOrderType(positionOrder.orderType) &&
+    isFullPositionCloseSizeDeltaUsd(positionOrder.sizeDeltaUsd, position?.sizeInUsd);
+
   function getCollateralLabel() {
     if (isDecreaseOrderType(positionOrder.orderType)) {
       return t`Margin delta`;
@@ -171,8 +187,11 @@ function OrderSize({
   }
 
   function getCollateralText() {
+    const sourceAmount =
+      isFullClose && position ? position.collateralAmount : positionOrder.initialCollateralDeltaAmount;
+
     const collateralUsd = convertToUsd(
-      positionOrder.initialCollateralDeltaAmount,
+      sourceAmount,
       positionOrder.initialCollateralToken.decimals,
       positionOrder.initialCollateralToken.prices.minPrice
     )!;

--- a/src/components/OrdersModal/AddTPSLModal.tsx
+++ b/src/components/OrdersModal/AddTPSLModal.tsx
@@ -19,6 +19,7 @@ import {
   selectMarketsInfoData,
   selectSrcChainId,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
+import { makeSelectOrdersByPositionKey } from "context/SyntheticsStateContext/selectors/orderSelectors";
 import {
   selectBreakdownNetPriceImpactEnabled,
   selectIsPnlInLeverage,
@@ -28,7 +29,12 @@ import { useSelector } from "context/SyntheticsStateContext/utils";
 import { getIsValidExpressParams } from "domain/synthetics/express/expressOrderUtils";
 import { useExpressOrdersParams } from "domain/synthetics/express/useRelayerFeeHandler";
 import { estimateExecuteDecreaseOrderGasLimit, estimateOrderOraclePriceCount } from "domain/synthetics/fees";
-import { DecreasePositionSwapType } from "domain/synthetics/orders";
+import {
+  DecreasePositionSwapType,
+  isLimitDecreaseOrderType,
+  isStopLossOrderType,
+  isTwapOrder,
+} from "domain/synthetics/orders";
 import { sendBatchOrderTxn } from "domain/synthetics/orders/sendBatchOrderTxn";
 import { useOrderTxnCallbacks } from "domain/synthetics/orders/useOrderTxnCallbacks";
 import {
@@ -52,8 +58,8 @@ import {
 } from "domain/synthetics/trade";
 import { useCloseSizeInput } from "domain/synthetics/trade/useCloseSizeInput";
 import { useMaxAutoCancelOrdersState } from "domain/synthetics/trade/useMaxAutoCancelOrdersState";
-import { buildTpSlCreatePayloads, buildTpSlInputPositionData, getTpSlDecreaseAmounts } from "domain/tpsl/sidecar";
-import { FULL_POSITION_CLOSE_SIZE_DELTA_USD } from "domain/tpsl/utils";
+import { buildTpSlBatchPayloads, buildTpSlInputPositionData, getTpSlDecreaseAmounts } from "domain/tpsl/sidecar";
+import { FULL_POSITION_CLOSE_SIZE_DELTA_USD, isFullClosePositionOrder } from "domain/tpsl/utils";
 import { DUST_USD } from "lib/legacy";
 import { useLocalStorageSerializeKey } from "lib/localStorage";
 import {
@@ -71,11 +77,7 @@ import { getTokenVisualMultiplier } from "sdk/configs/tokens";
 import { bigMath } from "sdk/utils/bigmath";
 import { getCappedPriceImpactPercentageFromFees } from "sdk/utils/fees";
 import { getExecutionFee } from "sdk/utils/fees/executionFee";
-import {
-  CreateOrderTxnParams,
-  DecreasePositionOrderParams,
-  getBatchTotalExecutionFee,
-} from "sdk/utils/orderTransactions";
+import { getBatchTotalExecutionFee } from "sdk/utils/orderTransactions";
 import { SidecarSlTpOrderEntry } from "sdk/utils/sidecarOrders/types";
 import { getIsEquivalentTokens } from "sdk/utils/tokens";
 
@@ -606,27 +608,49 @@ export function AddTPSLModal({
     );
   }, [markPrice, slPriceEntry, sizeUsdEntry, percentageEntry, position.liquidationPrice, position.entryPrice, isLong]);
 
-  const orderPayloads = useMemo((): CreateOrderTxnParams<DecreasePositionOrderParams>[] => {
+  const positionOrders = useSelector(makeSelectOrdersByPositionKey(position.key));
+
+  const existingFullCloseTp = useMemo(() => {
+    return positionOrders.find(
+      (order) =>
+        !isTwapOrder(order) &&
+        isLimitDecreaseOrderType(order.orderType) &&
+        isFullClosePositionOrder(order, position.sizeInUsd)
+    );
+  }, [positionOrders, position.sizeInUsd]);
+
+  const existingFullCloseSl = useMemo(() => {
+    return positionOrders.find(
+      (order) =>
+        !isTwapOrder(order) &&
+        isStopLossOrderType(order.orderType) &&
+        isFullClosePositionOrder(order, position.sizeInUsd)
+    );
+  }, [positionOrders, position.sizeInUsd]);
+
+  const orderPayloads = useMemo(() => {
+    const empty = { createOrderParams: [], updateOrderParams: [] };
+
     if (!account || !marketInfo || !collateralToken) {
-      return [];
+      return empty;
     }
 
     const tpCreateAmounts = tpPriceError ? undefined : tpDecreaseAmounts;
     const slCreateAmounts = slPriceError ? undefined : slDecreaseAmounts;
 
     if (!tpCreateAmounts && !slCreateAmounts) {
-      return [];
+      return empty;
     }
 
     if ((tpCreateAmounts && !tpExecutionFee) || (slCreateAmounts && !slExecutionFee)) {
-      return [];
+      return empty;
     }
 
     const autoCancelOrdersLimitForModal = autoCancelOrdersLimit > 0 ? 2 : 0;
     const tpSizeDeltaUsd = tpCreateAmounts?.isFullClose ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : undefined;
     const slSizeDeltaUsd = slCreateAmounts?.isFullClose ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : undefined;
 
-    return buildTpSlCreatePayloads({
+    return buildTpSlBatchPayloads({
       autoCancelOrdersLimit: autoCancelOrdersLimitForModal,
       chainId,
       account,
@@ -640,12 +664,14 @@ export function AddTPSLModal({
           executionFeeAmount: tpExecutionFee?.feeTokenAmount,
           executionGasLimit: tpExecutionFee?.gasLimit,
           sizeDeltaUsd: tpSizeDeltaUsd,
+          existingFullCloseOrder: existingFullCloseTp,
         },
         {
           amounts: slCreateAmounts,
           executionFeeAmount: slExecutionFee?.feeTokenAmount,
           executionGasLimit: slExecutionFee?.gasLimit,
           sizeDeltaUsd: slSizeDeltaUsd,
+          existingFullCloseOrder: existingFullCloseSl,
         },
       ],
       userReferralCode: userReferralInfo?.referralCodeForTxn,
@@ -664,13 +690,15 @@ export function AddTPSLModal({
     slPriceError,
     tpExecutionFee,
     slExecutionFee,
+    existingFullCloseTp,
+    existingFullCloseSl,
   ]);
 
   const batchParams = useMemo(() => {
-    if (orderPayloads.length === 0) return undefined;
+    if (orderPayloads.createOrderParams.length === 0 && orderPayloads.updateOrderParams.length === 0) return undefined;
     return {
-      createOrderParams: orderPayloads,
-      updateOrderParams: [],
+      createOrderParams: orderPayloads.createOrderParams,
+      updateOrderParams: orderPayloads.updateOrderParams,
       cancelOrderParams: [],
     };
   }, [orderPayloads]);
@@ -705,7 +733,7 @@ export function AddTPSLModal({
     if (slPriceError && slPriceInput) {
       return slPriceError;
     }
-    if (orderPayloads.length === 0) {
+    if (orderPayloads.createOrderParams.length === 0 && orderPayloads.updateOrderParams.length === 0) {
       return t`Unable to calculate order`;
     }
     return undefined;
@@ -714,7 +742,8 @@ export function AddTPSLModal({
     slPriceInput,
     tpPriceError,
     slPriceError,
-    orderPayloads.length,
+    orderPayloads.createOrderParams.length,
+    orderPayloads.updateOrderParams.length,
     editTPSLSize,
     closeSizeInput,
     closeSize.showSizeInTokens,

--- a/src/components/OrdersModal/AddTPSLModal.tsx
+++ b/src/components/OrdersModal/AddTPSLModal.tsx
@@ -623,7 +623,8 @@ export function AddTPSLModal({
     }
 
     const autoCancelOrdersLimitForModal = autoCancelOrdersLimit > 0 ? 2 : 0;
-    const sizeDeltaUsd = !editTPSLSize ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : undefined;
+    const tpSizeDeltaUsd = tpCreateAmounts?.isFullClose ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : undefined;
+    const slSizeDeltaUsd = slCreateAmounts?.isFullClose ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : undefined;
 
     return buildTpSlCreatePayloads({
       autoCancelOrdersLimit: autoCancelOrdersLimitForModal,
@@ -638,13 +639,13 @@ export function AddTPSLModal({
           amounts: tpCreateAmounts,
           executionFeeAmount: tpExecutionFee?.feeTokenAmount,
           executionGasLimit: tpExecutionFee?.gasLimit,
-          sizeDeltaUsd,
+          sizeDeltaUsd: tpSizeDeltaUsd,
         },
         {
           amounts: slCreateAmounts,
           executionFeeAmount: slExecutionFee?.feeTokenAmount,
           executionGasLimit: slExecutionFee?.gasLimit,
-          sizeDeltaUsd,
+          sizeDeltaUsd: slSizeDeltaUsd,
         },
       ],
       userReferralCode: userReferralInfo?.referralCodeForTxn,
@@ -663,7 +664,6 @@ export function AddTPSLModal({
     slPriceError,
     tpExecutionFee,
     slExecutionFee,
-    editTPSLSize,
   ]);
 
   const batchParams = useMemo(() => {

--- a/src/components/OrdersModal/AddTPSLModal.tsx
+++ b/src/components/OrdersModal/AddTPSLModal.tsx
@@ -53,6 +53,7 @@ import {
 import { useCloseSizeInput } from "domain/synthetics/trade/useCloseSizeInput";
 import { useMaxAutoCancelOrdersState } from "domain/synthetics/trade/useMaxAutoCancelOrdersState";
 import { buildTpSlCreatePayloads, buildTpSlInputPositionData, getTpSlDecreaseAmounts } from "domain/tpsl/sidecar";
+import { FULL_POSITION_CLOSE_SIZE_DELTA_USD } from "domain/tpsl/utils";
 import { DUST_USD } from "lib/legacy";
 import { useLocalStorageSerializeKey } from "lib/localStorage";
 import {
@@ -622,6 +623,7 @@ export function AddTPSLModal({
     }
 
     const autoCancelOrdersLimitForModal = autoCancelOrdersLimit > 0 ? 2 : 0;
+    const sizeDeltaUsd = !editTPSLSize ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : undefined;
 
     return buildTpSlCreatePayloads({
       autoCancelOrdersLimit: autoCancelOrdersLimitForModal,
@@ -636,11 +638,13 @@ export function AddTPSLModal({
           amounts: tpCreateAmounts,
           executionFeeAmount: tpExecutionFee?.feeTokenAmount,
           executionGasLimit: tpExecutionFee?.gasLimit,
+          sizeDeltaUsd,
         },
         {
           amounts: slCreateAmounts,
           executionFeeAmount: slExecutionFee?.feeTokenAmount,
           executionGasLimit: slExecutionFee?.gasLimit,
+          sizeDeltaUsd,
         },
       ],
       userReferralCode: userReferralInfo?.referralCodeForTxn,
@@ -659,6 +663,7 @@ export function AddTPSLModal({
     slPriceError,
     tpExecutionFee,
     slExecutionFee,
+    editTPSLSize,
   ]);
 
   const batchParams = useMemo(() => {

--- a/src/components/OrdersModal/TPSLOrdersList.tsx
+++ b/src/components/OrdersModal/TPSLOrdersList.tsx
@@ -21,7 +21,7 @@ import {
 } from "domain/synthetics/orders";
 import { PositionInfo, getIsPositionInfoLoaded } from "domain/synthetics/positions";
 import { getDecreasePositionAmounts } from "domain/synthetics/trade";
-import { DUST_USD } from "lib/legacy";
+import { getPositionCloseSizeDeltaUsdForDisplay, isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { formatDeltaUsd, formatUsd, formatBalanceAmount, formatPercentage } from "lib/numbers";
 import { getPositiveOrNegativeClass } from "lib/utils";
 import { bigMath } from "sdk/utils/bigmath";
@@ -179,7 +179,7 @@ function useTPSLOrderViewModel({
       return <span>-{formatUsd(order.sizeDeltaUsd)}</span>;
     }
 
-    const isFullClose = order.sizeDeltaUsd >= position.sizeInUsd || position.sizeInUsd - order.sizeDeltaUsd < DUST_USD;
+    const isFullClose = isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd, position.sizeInUsd);
 
     if (isFullClose) {
       return <Trans>Full position close</Trans>;
@@ -204,14 +204,15 @@ function useTPSLOrderViewModel({
     const entryPrice = position.entryPrice ?? 0n;
     const priceDiff = order.isLong ? order.triggerPrice - entryPrice : entryPrice - order.triggerPrice;
 
-    const pnlUsd = entryPrice > 0n ? bigMath.mulDiv(priceDiff, order.sizeDeltaUsd, entryPrice) : 0n;
+    const sizeDeltaUsd = getPositionCloseSizeDeltaUsdForDisplay(order.sizeDeltaUsd, position.sizeInUsd);
+    const pnlUsd = entryPrice > 0n ? bigMath.mulDiv(priceDiff, sizeDeltaUsd, entryPrice) : 0n;
     const pnlPercentage = position.collateralUsd > 0n ? bigMath.mulDiv(pnlUsd, 10000n, position.collateralUsd) : 0n;
 
     return { pnlUsd, pnlPercentage };
   }, [order.isLong, order.sizeDeltaUsd, order.triggerPrice, position, isIncrease]);
 
   const shouldKeepLeverage = useMemo(() => {
-    if (!position || order.sizeDeltaUsd >= position.sizeInUsd) {
+    if (!position || isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd, position.sizeInUsd)) {
       return true;
     }
 

--- a/src/components/PositionItem/PositionItemOrders.tsx
+++ b/src/components/PositionItem/PositionItemOrders.tsx
@@ -14,12 +14,11 @@ import {
   PositionOrderInfo,
   isIncreaseOrderType,
   isMarketOrderType,
-  isTriggerDecreaseOrderType,
   isTwapOrder,
 } from "domain/synthetics/orders";
 import { useDisabledCancelMarketOrderMessage } from "domain/synthetics/orders/useDisabledCancelMarketOrderMessage";
 import { getNameByOrderType, getPositionKey } from "domain/synthetics/positions";
-import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
+import { isFullClosePositionOrder } from "domain/tpsl/utils";
 import { calculateDisplayDecimals, formatUsd } from "lib/numbers";
 import { getByKey } from "lib/objects";
 
@@ -191,9 +190,7 @@ function PositionItemOrderText({ order }: { order: PositionOrderInfo }) {
     positionsInfoData,
     getPositionKey(order.account, order.marketAddress, order.targetCollateralToken.address, order.isLong)
   );
-  const isFullClose =
-    isTriggerDecreaseOrderType(order.orderType) &&
-    isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd, position?.sizeInUsd);
+  const isFullClose = isFullClosePositionOrder(order, position?.sizeInUsd);
 
   return (
     <div key={order.key} className="text-start">

--- a/src/components/PositionItem/PositionItemOrders.tsx
+++ b/src/components/PositionItem/PositionItemOrders.tsx
@@ -4,7 +4,10 @@ import { useCallback, useMemo } from "react";
 
 import { useEditingOrderState } from "context/SyntheticsStateContext/hooks/orderEditorHooks";
 import { useCancelOrder, usePositionOrdersWithErrors } from "context/SyntheticsStateContext/hooks/orderHooks";
-import { selectOracleSettings } from "context/SyntheticsStateContext/selectors/globalSelectors";
+import {
+  selectOracleSettings,
+  selectPositionsInfoData,
+} from "context/SyntheticsStateContext/selectors/globalSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import {
   OrderErrors,
@@ -15,9 +18,10 @@ import {
   isTwapOrder,
 } from "domain/synthetics/orders";
 import { useDisabledCancelMarketOrderMessage } from "domain/synthetics/orders/useDisabledCancelMarketOrderMessage";
-import { getNameByOrderType } from "domain/synthetics/positions";
+import { getNameByOrderType, getPositionKey } from "domain/synthetics/positions";
 import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { calculateDisplayDecimals, formatUsd } from "lib/numbers";
+import { getByKey } from "lib/objects";
 
 import Button from "components/Button/Button";
 import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
@@ -179,11 +183,17 @@ function PositionItemOrder({
 }
 
 function PositionItemOrderText({ order }: { order: PositionOrderInfo }) {
+  const positionsInfoData = useSelector(selectPositionsInfoData);
   const triggerThresholdType = order.triggerThresholdType;
   const isIncrease = isIncreaseOrderType(order.orderType);
   const isTwap = isTwapOrder(order);
+  const position = getByKey(
+    positionsInfoData,
+    getPositionKey(order.account, order.marketAddress, order.targetCollateralToken.address, order.isLong)
+  );
   const isFullClose =
-    isTriggerDecreaseOrderType(order.orderType) && isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd);
+    isTriggerDecreaseOrderType(order.orderType) &&
+    isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd, position?.sizeInUsd);
 
   return (
     <div key={order.key} className="text-start">

--- a/src/components/PositionItem/PositionItemOrders.tsx
+++ b/src/components/PositionItem/PositionItemOrders.tsx
@@ -11,10 +11,12 @@ import {
   PositionOrderInfo,
   isIncreaseOrderType,
   isMarketOrderType,
+  isTriggerDecreaseOrderType,
   isTwapOrder,
 } from "domain/synthetics/orders";
 import { useDisabledCancelMarketOrderMessage } from "domain/synthetics/orders/useDisabledCancelMarketOrderMessage";
 import { getNameByOrderType } from "domain/synthetics/positions";
+import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { calculateDisplayDecimals, formatUsd } from "lib/numbers";
 
 import Button from "components/Button/Button";
@@ -180,6 +182,8 @@ function PositionItemOrderText({ order }: { order: PositionOrderInfo }) {
   const triggerThresholdType = order.triggerThresholdType;
   const isIncrease = isIncreaseOrderType(order.orderType);
   const isTwap = isTwapOrder(order);
+  const isFullClose =
+    isTriggerDecreaseOrderType(order.orderType) && isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd);
 
   return (
     <div key={order.key} className="text-start">
@@ -199,8 +203,14 @@ function PositionItemOrderText({ order }: { order: PositionOrderInfo }) {
       )}
       :{" "}
       <span className="numbers">
-        {isIncrease ? "+" : "-"}
-        {formatUsd(order.sizeDeltaUsd)} {isTwapOrder(order) && <TwapOrderProgress order={order} />}
+        {isFullClose ? (
+          <Trans>Full position close</Trans>
+        ) : (
+          <>
+            {isIncrease ? "+" : "-"}
+            {formatUsd(order.sizeDeltaUsd)} {isTwap && <TwapOrderProgress order={order} />}
+          </>
+        )}
       </span>
     </div>
   );

--- a/src/components/StatusNotification/OrderStatusNotification.tsx
+++ b/src/components/StatusNotification/OrderStatusNotification.tsx
@@ -26,6 +26,7 @@ import { cancelOrdersTxn } from "domain/synthetics/orders/cancelOrdersTxn";
 import { getNameByOrderType } from "domain/synthetics/positions";
 import { TokensData } from "domain/synthetics/tokens";
 import { getSwapPathOutputAddresses } from "domain/synthetics/trade";
+import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { useChainId } from "lib/chains";
 import { defined } from "lib/guards";
 import { formatTokenAmount, formatUsd } from "lib/numbers";
@@ -212,10 +213,12 @@ function OrderStatusNotification({
             lower: true,
           })} order for`;
           const sign = isIncreaseOrderType(orderType) ? "+" : "-";
+          const sizeText =
+            isTriggerDecreaseOrderType(orderType) && isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd)
+              ? t`Full position close`
+              : `${sign}${formatUsd(sizeDeltaUsd)}`;
 
-          return t`${orderTypeText} ${visualMultiplierPrefix}${marketInfo?.indexToken?.symbol} ${longShortText}: ${sign}${formatUsd(
-            sizeDeltaUsd
-          )}`;
+          return t`${orderTypeText} ${visualMultiplierPrefix}${marketInfo?.indexToken?.symbol} ${longShortText}: ${sizeText}`;
         }
       }
     }

--- a/src/components/TradeBox/hooks/useSidecarOrderPayloads.ts
+++ b/src/components/TradeBox/hooks/useSidecarOrderPayloads.ts
@@ -8,8 +8,10 @@ import {
   selectTradeboxTradeFlags,
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
+import { MAX_PERCENTAGE } from "domain/synthetics/sidecarOrders/utils";
 import { useMaxAutoCancelOrdersState } from "domain/synthetics/trade/useMaxAutoCancelOrdersState";
 import { buildTpSlCreatePayloads } from "domain/tpsl/sidecar";
+import { getPositionCloseSizeDeltaUsdForPayload } from "domain/tpsl/utils";
 import { useChainId } from "lib/chains";
 import { buildUpdateOrderPayload, CancelOrderTxnParams } from "sdk/utils/orderTransactions";
 
@@ -34,6 +36,17 @@ export function useSidecarOrderPayloads() {
       return undefined;
     }
 
+    const getPayloadSizeDeltaUsd = (entry: (typeof createSltpEntries)[number] | (typeof updateSltpEntries)[number]) => {
+      const amounts = entry.increaseAmounts || entry.decreaseAmounts;
+      const isFullClose = entry.percentage?.value === MAX_PERCENTAGE && Boolean(entry.decreaseAmounts?.isFullClose);
+
+      if (!amounts) {
+        return 0n;
+      }
+
+      return getPositionCloseSizeDeltaUsdForPayload(amounts.sizeDeltaUsd ?? 0n, isFullClose);
+    };
+
     const createPayloads = buildTpSlCreatePayloads({
       autoCancelOrdersLimit,
       chainId,
@@ -45,6 +58,7 @@ export function useSidecarOrderPayloads() {
       entries: createSltpEntries.map((entry) => ({
         amounts: entry.decreaseAmounts,
         executionFeeAmount: getExecutionFeeAmountForEntry(entry) ?? 0n,
+        sizeDeltaUsd: getPayloadSizeDeltaUsd(entry),
       })),
       userReferralCode: userReferralInfo?.referralCodeForTxn,
     });
@@ -58,7 +72,7 @@ export function useSidecarOrderPayloads() {
         indexTokenAddress: marketInfo.indexTokenAddress,
         orderKey: order.key,
         orderType: order.orderType,
-        sizeDeltaUsd: amounts.sizeDeltaUsd ?? 0n,
+        sizeDeltaUsd: getPayloadSizeDeltaUsd(entry),
         triggerPrice: amounts.triggerPrice ?? 0n,
         acceptablePrice: amounts.acceptablePrice ?? 0n,
         minOutputAmount: 0n,

--- a/src/components/TradeBox/hooks/useSidecarOrderPayloads.ts
+++ b/src/components/TradeBox/hooks/useSidecarOrderPayloads.ts
@@ -38,7 +38,7 @@ export function useSidecarOrderPayloads() {
 
     const getPayloadSizeDeltaUsd = (entry: (typeof createSltpEntries)[number] | (typeof updateSltpEntries)[number]) => {
       const amounts = entry.increaseAmounts || entry.decreaseAmounts;
-      const isFullClose = entry.percentage?.value === MAX_PERCENTAGE && Boolean(entry.decreaseAmounts?.isFullClose);
+      const isFullClose = Boolean(entry.decreaseAmounts) && entry.percentage?.value === MAX_PERCENTAGE;
 
       if (!amounts) {
         return 0n;

--- a/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
@@ -1,6 +1,10 @@
 import { i18n } from "@lingui/core";
 import { describe, expect, it } from "vitest";
 
+import { OrderType } from "domain/synthetics/orders";
+import { TradeActionType } from "domain/synthetics/tradeHistory";
+import { MaxUint256 } from "lib/numbers";
+
 import {
   cancelOrderIncreaseLong,
   createOrderDecreaseLong,
@@ -605,5 +609,34 @@ describe("TradeHistoryRow helpers", () => {
         "timestampUTC": "UTC: 2024-02-14 09:33:19",
       }
     `);
+  });
+
+  it("formatPositionMessage renders 'Full position close' for full-close TP/SL actions", () => {
+    const fullCloseCreate = {
+      ...createOrderDecreaseLong,
+      sizeDeltaUsd: MaxUint256,
+    };
+    expect(formatPositionMessage(fullCloseCreate, minCollateralUsd).size).toBe("Full position close");
+
+    const fullCloseUpdate = {
+      ...createOrderDecreaseLong,
+      eventName: TradeActionType.OrderUpdated,
+      sizeDeltaUsd: MaxUint256,
+    };
+    expect(formatPositionMessage(fullCloseUpdate, minCollateralUsd).size).toBe("Full position close");
+
+    const fullCloseCancel = {
+      ...createOrderDecreaseLong,
+      eventName: TradeActionType.OrderCancelled,
+      sizeDeltaUsd: MaxUint256,
+    };
+    expect(formatPositionMessage(fullCloseCancel, minCollateralUsd).size).toBe("Full position close");
+
+    const fullCloseStopLoss = {
+      ...createOrderDecreaseLong,
+      orderType: OrderType.StopLossDecrease,
+      sizeDeltaUsd: MaxUint256,
+    };
+    expect(formatPositionMessage(fullCloseStopLoss, minCollateralUsd).size).toBe("Full position close");
   });
 });

--- a/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -3,9 +3,16 @@ import { t } from "@lingui/macro";
 
 import { isBoundaryAcceptablePrice } from "domain/prices";
 import { getMarketFullName, getMarketIndexName, getMarketPoolName } from "domain/synthetics/markets";
-import { OrderType, isDecreaseOrderType, isIncreaseOrderType, isLiquidationOrderType } from "domain/synthetics/orders";
+import {
+  OrderType,
+  isDecreaseOrderType,
+  isIncreaseOrderType,
+  isLiquidationOrderType,
+  isTriggerDecreaseOrderType,
+} from "domain/synthetics/orders";
 import { convertToUsd, parseContractPrice } from "domain/synthetics/tokens";
 import { getShouldUseMaxPrice } from "domain/synthetics/trade";
+import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { tryDecodeCustomError } from "lib/errors";
 import {
   BN_NEGATIVE_ONE,
@@ -106,9 +113,13 @@ export const formatPositionMessage = (
     triggerPriceInequality = INEQUALITY_GT;
   }
 
-  const sizeDeltaText = formatUsd(sizeDeltaUsd * (isIncrease ? BN_ONE : BN_NEGATIVE_ONE), {
-    displayPlus: true,
-  })!;
+  const isFullClose = isTriggerDecreaseOrderType(ot) && isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd);
+
+  const sizeDeltaText = isFullClose
+    ? t`Full position close`
+    : formatUsd(sizeDeltaUsd * (isIncrease ? BN_ONE : BN_NEGATIVE_ONE), {
+        displayPlus: true,
+      })!;
 
   const indexName = getMarketIndexName({
     indexToken: tradeAction.indexToken,

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
@@ -1618,6 +1618,10 @@ export const selectTradeboxSelectedPosition = createSelector((q) => {
   return getByKey(positionsInfoData, selectedPositionKey);
 });
 
+export const selectTradeboxSelectedPositionSizeInUsd = createSelector((q) => {
+  return q(selectTradeboxSelectedPosition)?.sizeInUsd;
+});
+
 const selectTradeboxExistingOrders = createSelector((q) => {
   const ordersInfoData = q(selectOrdersInfoData);
 

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxSidecarOrders.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxSidecarOrders.ts
@@ -21,6 +21,7 @@ import { selectSelectedMarketVisualMultiplier } from "../shared/marketSelectors"
 import {
   selectTradeboxIncreasePositionAmounts,
   selectTradeboxSelectedPosition,
+  selectTradeboxSelectedPositionSizeInUsd,
   selectTradeboxTradeFlags,
 } from "../tradeboxSelectors";
 
@@ -133,7 +134,7 @@ export const selectTradeboxSidecarOrdersTotalSizeUsd = createSelector((q) => {
 export const selectTradeboxSidecarOrdersExistingSlEntries = createSelector((q) => {
   const existingSlOrders = q(selectTradeboxExistingSlOrders);
   const { isLong } = q(selectTradeboxTradeFlags);
-  const position = q(selectTradeboxSelectedPosition);
+  const positionSizeUsd = q(selectTradeboxSelectedPositionSizeInUsd);
 
   const visualMultiplier = q(selectSelectedMarketVisualMultiplier);
 
@@ -141,7 +142,7 @@ export const selectTradeboxSidecarOrdersExistingSlEntries = createSelector((q) =
     positionOrders: existingSlOrders,
     sort: isLong ? "desc" : "asc",
     visualMultiplier,
-    positionSizeUsd: position?.sizeInUsd,
+    positionSizeUsd,
     onlyFullPositionClose: true,
   });
 });
@@ -149,7 +150,7 @@ export const selectTradeboxSidecarOrdersExistingSlEntries = createSelector((q) =
 export const selectTradeboxSidecarOrdersExistingTpEntries = createSelector((q) => {
   const existingTpOrders = q(selectTradeboxExistingTpOrders);
   const { isLong } = q(selectTradeboxTradeFlags);
-  const position = q(selectTradeboxSelectedPosition);
+  const positionSizeUsd = q(selectTradeboxSelectedPositionSizeInUsd);
 
   const visualMultiplier = q(selectSelectedMarketVisualMultiplier);
 
@@ -157,7 +158,7 @@ export const selectTradeboxSidecarOrdersExistingTpEntries = createSelector((q) =
     positionOrders: existingTpOrders,
     sort: isLong ? "asc" : "desc",
     visualMultiplier,
-    positionSizeUsd: position?.sizeInUsd,
+    positionSizeUsd,
     onlyFullPositionClose: true,
   });
 });

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxSidecarOrders.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxSidecarOrders.ts
@@ -144,7 +144,7 @@ export const selectTradeboxSidecarOrdersExistingSlEntries = createSelector((q) =
     visualMultiplier,
     positionSizeUsd,
     onlyFullPositionClose: true,
-  });
+  })?.slice(0, 1);
 });
 
 export const selectTradeboxSidecarOrdersExistingTpEntries = createSelector((q) => {
@@ -160,7 +160,7 @@ export const selectTradeboxSidecarOrdersExistingTpEntries = createSelector((q) =
     visualMultiplier,
     positionSizeUsd,
     onlyFullPositionClose: true,
-  });
+  })?.slice(0, 1);
 });
 
 export const selectTradeboxSidecarOrdersExistingLimitEntries = createSelector((q) => {

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxSidecarOrders.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxSidecarOrders.ts
@@ -133,6 +133,7 @@ export const selectTradeboxSidecarOrdersTotalSizeUsd = createSelector((q) => {
 export const selectTradeboxSidecarOrdersExistingSlEntries = createSelector((q) => {
   const existingSlOrders = q(selectTradeboxExistingSlOrders);
   const { isLong } = q(selectTradeboxTradeFlags);
+  const position = q(selectTradeboxSelectedPosition);
 
   const visualMultiplier = q(selectSelectedMarketVisualMultiplier);
 
@@ -140,12 +141,15 @@ export const selectTradeboxSidecarOrdersExistingSlEntries = createSelector((q) =
     positionOrders: existingSlOrders,
     sort: isLong ? "desc" : "asc",
     visualMultiplier,
+    positionSizeUsd: position?.sizeInUsd,
+    onlyFullPositionClose: true,
   });
 });
 
 export const selectTradeboxSidecarOrdersExistingTpEntries = createSelector((q) => {
   const existingTpOrders = q(selectTradeboxExistingTpOrders);
   const { isLong } = q(selectTradeboxTradeFlags);
+  const position = q(selectTradeboxSelectedPosition);
 
   const visualMultiplier = q(selectSelectedMarketVisualMultiplier);
 
@@ -153,6 +157,8 @@ export const selectTradeboxSidecarOrdersExistingTpEntries = createSelector((q) =
     positionOrders: existingTpOrders,
     sort: isLong ? "asc" : "desc",
     visualMultiplier,
+    positionSizeUsd: position?.sizeInUsd,
+    onlyFullPositionClose: true,
   });
 });
 

--- a/src/domain/synthetics/orders/getPositionOrderError.tsx
+++ b/src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -10,6 +10,7 @@ import {
 } from "domain/synthetics/orders";
 import { PositionInfoLoaded } from "domain/synthetics/positions";
 import { NextPositionValues } from "domain/synthetics/trade";
+import { getPositionCloseSizeDeltaUsdForDisplay } from "domain/tpsl/utils";
 
 export function getPositionOrderError({
   positionOrder,
@@ -73,8 +74,13 @@ export function getPositionOrderError({
       return t`Loading...`;
     }
 
+    const orderSizeDeltaUsdForCompare = getPositionCloseSizeDeltaUsdForDisplay(
+      positionOrder.sizeDeltaUsd ?? 0n,
+      existingPosition?.sizeInUsd
+    );
+
     if (
-      sizeDeltaUsd === (positionOrder.sizeDeltaUsd ?? 0n) &&
+      sizeDeltaUsd === orderSizeDeltaUsdForCompare &&
       triggerPrice === (positionOrder.triggerPrice ?? 0n) &&
       acceptablePrice === positionOrder.acceptablePrice
     ) {

--- a/src/domain/synthetics/sidecarOrders/__tests__/utils.spec.ts
+++ b/src/domain/synthetics/sidecarOrders/__tests__/utils.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import type { PositionOrderInfo } from "domain/synthetics/orders";
+import { expandDecimals, MaxUint256 } from "lib/numbers";
+
+import { MAX_PERCENTAGE, prepareInitialEntries } from "../utils";
+
+describe("prepareInitialEntries", () => {
+  const positionSizeUsd = expandDecimals(1000, 30);
+  const triggerPrice = expandDecimals(5000, 30);
+
+  function makeOrder(sizeDeltaUsd: bigint) {
+    return {
+      sizeDeltaUsd,
+      triggerPrice,
+    } as unknown as PositionOrderInfo;
+  }
+
+  it("keeps only full-close orders when requested", () => {
+    const entries = prepareInitialEntries({
+      positionOrders: [makeOrder(expandDecimals(500, 30)), makeOrder(MaxUint256)],
+      sort: "desc",
+      positionSizeUsd,
+      onlyFullPositionClose: true,
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries?.[0].sizeUsd.value).toBe(positionSizeUsd);
+    expect(entries?.[0].percentage?.value).toBe(MAX_PERCENTAGE);
+    expect(entries?.[0].mode).toBe("keepPercentage");
+  });
+
+  it("marks current-position-sized orders as percentage-based full close", () => {
+    const entries = prepareInitialEntries({
+      positionOrders: [makeOrder(positionSizeUsd)],
+      sort: "desc",
+      positionSizeUsd,
+      onlyFullPositionClose: true,
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries?.[0].percentage?.value).toBe(MAX_PERCENTAGE);
+    expect(entries?.[0].mode).toBe("keepPercentage");
+  });
+});

--- a/src/domain/synthetics/sidecarOrders/types.ts
+++ b/src/domain/synthetics/sidecarOrders/types.ts
@@ -2,6 +2,7 @@ import { PositionOrderInfo, OrderTxnType } from "domain/synthetics/orders";
 import { DecreasePositionAmounts, IncreasePositionAmounts } from "domain/synthetics/trade";
 
 export type GroupPrefix = "sl" | "tp" | "limit";
+export type SidecarOrderEntryMode = "keepSize" | "keepPercentage" | "fitPercentage";
 
 export type EntryField = {
   input: string;
@@ -13,6 +14,8 @@ export type InitialEntry = {
   order: PositionOrderInfo | null;
   sizeUsd: EntryField;
   price: EntryField;
+  percentage?: EntryField;
+  mode?: SidecarOrderEntryMode;
 };
 
 export type SidecarOrderEntryBase = {
@@ -21,7 +24,7 @@ export type SidecarOrderEntryBase = {
   sizeUsd: EntryField;
   percentage: EntryField;
   txnType: OrderTxnType | null;
-  mode: "keepSize" | "keepPercentage" | "fitPercentage";
+  mode: SidecarOrderEntryMode;
   order: null | PositionOrderInfo;
 };
 

--- a/src/domain/synthetics/sidecarOrders/useSidecarOrders.ts
+++ b/src/domain/synthetics/sidecarOrders/useSidecarOrders.ts
@@ -15,6 +15,8 @@ import {
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
 import {
   selectTradeboxMockPosition,
+  selectTradeboxSidecarOrdersExistingSlEntries,
+  selectTradeboxSidecarOrdersExistingTpEntries,
   selectTradeboxSidecarEntriesSetIsUntouched,
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxSidecarOrders";
 import { useSelector } from "context/SyntheticsStateContext/utils";
@@ -42,6 +44,8 @@ export function useSidecarOrders() {
   const existingPosition = useSelector(selectTradeboxSelectedPosition);
   const nextPositionValues = useSelector(selectTradeboxNextPositionValues);
   const mockPositionInfo = useSelector(selectTradeboxMockPosition);
+  const existingSlEntries = useSelector(selectTradeboxSidecarOrdersExistingSlEntries);
+  const existingTpEntries = useSelector(selectTradeboxSidecarOrdersExistingTpEntries);
 
   const handleSLErrors = useCallback(
     (entry: SidecarSlTpOrderEntry) =>
@@ -74,6 +78,7 @@ export function useSidecarOrders() {
   const takeProfitEntriesInfo = useSidecarOrdersGroup<SidecarSlTpOrderEntry>({
     prefix: "tp",
     errorHandler: handleTPErrors,
+    initialEntries: existingTpEntries,
     canAddEntry: false,
     enablePercentage: true,
   });
@@ -81,6 +86,7 @@ export function useSidecarOrders() {
   const stopLossEntriesInfo = useSidecarOrdersGroup<SidecarSlTpOrderEntry>({
     prefix: "sl",
     errorHandler: handleSLErrors,
+    initialEntries: existingSlEntries,
     canAddEntry: false,
     enablePercentage: true,
   });

--- a/src/domain/synthetics/sidecarOrders/useSidecarOrdersGroup.ts
+++ b/src/domain/synthetics/sidecarOrders/useSidecarOrdersGroup.ts
@@ -13,7 +13,7 @@ import { useSelector } from "context/SyntheticsStateContext/utils";
 import { usePrevious } from "lib/usePrevious";
 import { bigMath } from "sdk/utils/bigmath";
 
-import { EntryField, GroupPrefix, SidecarOrderEntryBase, SidecarOrderEntryGroupBase } from "./types";
+import { EntryField, GroupPrefix, InitialEntry, SidecarOrderEntryBase, SidecarOrderEntryGroupBase } from "./types";
 import { MAX_PERCENTAGE, PERCENTAGE_DECIMALS, getDefaultEntry, getDefaultEntryField } from "./utils";
 
 export function useSidecarOrdersGroup<T extends SidecarOrderEntryBase>({
@@ -25,7 +25,7 @@ export function useSidecarOrdersGroup<T extends SidecarOrderEntryBase>({
 }: {
   prefix: GroupPrefix;
   errorHandler: (entry: T) => T;
-  initialEntries?: (Partial<T> & { price: EntryField; sizeUsd: EntryField })[];
+  initialEntries?: InitialEntry[];
   canAddEntry?: boolean;
   enablePercentage?: boolean;
 }): SidecarOrderEntryGroupBase<T> {
@@ -100,8 +100,9 @@ export function useSidecarOrdersGroup<T extends SidecarOrderEntryBase>({
   const initialState = useMemo(() => {
     if (initialEntries?.length) {
       return initialEntries.map((entry) => {
-        const initialEntry = getDefaultEntry(prefix, { ...entry, mode: "keepSize" });
-        const calculatedEntry = recalculateEntryByField(initialEntry, "sizeUsd");
+        const mode = entry.mode ?? "keepSize";
+        const initialEntry = getDefaultEntry(prefix, { ...entry, mode });
+        const calculatedEntry = recalculateEntryByField(initialEntry, mode === "keepSize" ? "sizeUsd" : "percentage");
         return errorHandler(calculatedEntry);
       });
     }

--- a/src/domain/synthetics/sidecarOrders/utils.ts
+++ b/src/domain/synthetics/sidecarOrders/utils.ts
@@ -3,6 +3,7 @@ import uniqueId from "lodash/uniqueId";
 
 import { USD_DECIMALS } from "config/factors";
 import { PositionOrderInfo } from "domain/synthetics/orders";
+import { isFullPositionCloseSizeDeltaUsd } from "domain/tpsl/utils";
 import { calculateDisplayDecimals, formatAmount, parseValue, removeTrailingZeros } from "lib/numbers";
 
 import type { InitialEntry, EntryField, SidecarOrderEntry, SidecarOrderEntryBase } from "./types";
@@ -67,14 +68,21 @@ export function prepareInitialEntries({
   positionOrders,
   sort = "desc",
   visualMultiplier,
+  positionSizeUsd,
+  onlyFullPositionClose = false,
 }: {
   positionOrders: PositionOrderInfo[] | undefined;
   sort: "desc" | "asc";
   visualMultiplier?: number;
+  positionSizeUsd?: bigint;
+  onlyFullPositionClose?: boolean;
 }): undefined | InitialEntry[] {
   if (!positionOrders) return;
 
-  return positionOrders
+  return [...positionOrders]
+    .filter((order) => {
+      return !onlyFullPositionClose || isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd, positionSizeUsd);
+    })
     .sort((a, b) => {
       const [first, second] = sort === "desc" ? [a, b] : [b, a];
       const diff = first.triggerPrice - second.triggerPrice;
@@ -83,9 +91,13 @@ export function prepareInitialEntries({
       return 0;
     })
     .map((order) => {
+      const isFullClose = isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd, positionSizeUsd);
+      const sizeDeltaUsd = isFullClose && positionSizeUsd !== undefined ? positionSizeUsd : order.sizeDeltaUsd;
       const entry: InitialEntry = {
-        sizeUsd: getDefaultEntryField(USD_DECIMALS, { value: order.sizeDeltaUsd }),
+        sizeUsd: getDefaultEntryField(USD_DECIMALS, { value: sizeDeltaUsd }),
         price: getDefaultEntryField(USD_DECIMALS, { value: order.triggerPrice }, visualMultiplier),
+        percentage: isFullClose ? getDefaultEntryField(PERCENTAGE_DECIMALS, { value: MAX_PERCENTAGE }) : undefined,
+        mode: isFullClose ? "keepPercentage" : "keepSize",
         order,
       };
 

--- a/src/domain/tpsl/__tests__/sidecar.spec.ts
+++ b/src/domain/tpsl/__tests__/sidecar.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import { OrderType, PositionOrderInfo } from "domain/synthetics/orders";
+import { DecreasePositionAmounts } from "domain/synthetics/trade";
+import { expandDecimals, MaxUint256 } from "lib/numbers";
+import { ARBITRUM } from "sdk/configs/chains";
+import { MARKETS } from "sdk/configs/markets";
+import { getTokenBySymbol, getWrappedToken } from "sdk/configs/tokens";
+
+import { buildTpSlBatchPayloads } from "../sidecar";
+
+const CHAIN_ID = ARBITRUM;
+const ACCOUNT = "0x1234567890123456789012345678901234567890";
+const ETH_MARKET = MARKETS[CHAIN_ID]["0x70d95587d40A2caf56bd97485aB3Eec10Bee6336"];
+const USDC = getTokenBySymbol(CHAIN_ID, "USDC");
+const WETH = getWrappedToken(CHAIN_ID);
+
+function makeAmounts(overrides: Partial<DecreasePositionAmounts>): DecreasePositionAmounts {
+  return {
+    isFullClose: false,
+    sizeDeltaUsd: expandDecimals(1000, 30),
+    sizeDeltaInTokens: expandDecimals(1, 18),
+    collateralDeltaAmount: 0n,
+    triggerPrice: expandDecimals(2000, 30),
+    acceptablePrice: expandDecimals(2000, 30),
+    triggerOrderType: OrderType.LimitDecrease,
+    decreaseSwapType: 0,
+    ...overrides,
+  } as unknown as DecreasePositionAmounts;
+}
+
+function makeExistingOrder(overrides: Partial<PositionOrderInfo> = {}): PositionOrderInfo {
+  return {
+    key: "0xexistingorderkey",
+    orderType: OrderType.LimitDecrease,
+    sizeDeltaUsd: MaxUint256,
+    minOutputAmount: 0n,
+    autoCancel: true,
+    indexToken: WETH,
+    ...overrides,
+  } as unknown as PositionOrderInfo;
+}
+
+const baseParams = {
+  autoCancelOrdersLimit: 2,
+  chainId: CHAIN_ID,
+  account: ACCOUNT,
+  marketAddress: ETH_MARKET.marketTokenAddress,
+  indexTokenAddress: WETH.address,
+  collateralTokenAddress: USDC.address,
+  isLong: true,
+  userReferralCode: undefined,
+};
+
+describe("buildTpSlBatchPayloads", () => {
+  it("emits an update payload when a full-close TP already exists", () => {
+    const result = buildTpSlBatchPayloads({
+      ...baseParams,
+      entries: [
+        {
+          amounts: makeAmounts({ isFullClose: true, triggerPrice: expandDecimals(3000, 30) }),
+          executionFeeAmount: 0n,
+          executionGasLimit: 0n,
+          existingFullCloseOrder: makeExistingOrder({ key: "0xtpkey" }),
+        },
+      ],
+    });
+
+    expect(result.createOrderParams).toHaveLength(0);
+    expect(result.updateOrderParams).toHaveLength(1);
+    expect(result.updateOrderParams[0].updatePayload.orderKey).toBe("0xtpkey");
+    expect(result.updateOrderParams[0].updatePayload.sizeDeltaUsd).toBe(MaxUint256);
+    expect(result.updateOrderParams[0].updatePayload.executionFeeTopUp).toBe(0n);
+  });
+
+  it("emits a create payload when no existing full-close order exists", () => {
+    const result = buildTpSlBatchPayloads({
+      ...baseParams,
+      entries: [
+        {
+          amounts: makeAmounts({ isFullClose: true }),
+          executionFeeAmount: 0n,
+          executionGasLimit: 0n,
+          sizeDeltaUsd: MaxUint256,
+        },
+      ],
+    });
+
+    expect(result.createOrderParams).toHaveLength(1);
+    expect(result.updateOrderParams).toHaveLength(0);
+  });
+
+  it("creates a new order for partial close even when a full-close order exists", () => {
+    const result = buildTpSlBatchPayloads({
+      ...baseParams,
+      entries: [
+        {
+          amounts: makeAmounts({ isFullClose: false }),
+          executionFeeAmount: 0n,
+          executionGasLimit: 0n,
+          existingFullCloseOrder: makeExistingOrder(),
+        },
+      ],
+    });
+
+    expect(result.createOrderParams).toHaveLength(1);
+    expect(result.updateOrderParams).toHaveLength(0);
+  });
+
+  it("handles TP and SL independently - update one, create the other", () => {
+    const result = buildTpSlBatchPayloads({
+      ...baseParams,
+      entries: [
+        {
+          amounts: makeAmounts({ isFullClose: true, triggerOrderType: OrderType.LimitDecrease }),
+          executionFeeAmount: 0n,
+          executionGasLimit: 0n,
+          existingFullCloseOrder: makeExistingOrder({ key: "0xtpkey", orderType: OrderType.LimitDecrease }),
+        },
+        {
+          amounts: makeAmounts({ isFullClose: true, triggerOrderType: OrderType.StopLossDecrease }),
+          executionFeeAmount: 0n,
+          executionGasLimit: 0n,
+          sizeDeltaUsd: MaxUint256,
+        },
+      ],
+    });
+
+    expect(result.createOrderParams).toHaveLength(1);
+    expect(result.updateOrderParams).toHaveLength(1);
+    expect(result.updateOrderParams[0].updatePayload.orderKey).toBe("0xtpkey");
+  });
+});

--- a/src/domain/tpsl/__tests__/utils.spec.ts
+++ b/src/domain/tpsl/__tests__/utils.spec.ts
@@ -26,4 +26,9 @@ describe("TPSL full-position close utilities", () => {
     expect(isFullPositionCloseSizeDeltaUsd(expandDecimals(400, 30), positionSizeUsd)).toBe(false);
     expect(getPositionCloseSizeDeltaUsdForPayload(expandDecimals(400, 30), false)).toBe(expandDecimals(400, 30));
   });
+
+  it("never returns the sentinel from the display helper", () => {
+    expect(getPositionCloseSizeDeltaUsdForDisplay(MaxUint256, undefined)).toBe(0n);
+    expect(getPositionCloseSizeDeltaUsdForDisplay(MaxUint256, 0n)).toBe(0n);
+  });
 });

--- a/src/domain/tpsl/__tests__/utils.spec.ts
+++ b/src/domain/tpsl/__tests__/utils.spec.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 
+import type { OrderInfo } from "domain/synthetics/orders";
+import { OrderType } from "domain/synthetics/orders";
 import { expandDecimals, MaxUint256 } from "lib/numbers";
 
 import {
   FULL_POSITION_CLOSE_SIZE_DELTA_USD,
   getPositionCloseSizeDeltaUsdForDisplay,
   getPositionCloseSizeDeltaUsdForPayload,
+  isFullClosePositionOrder,
   isFullPositionCloseSizeDeltaUsd,
 } from "../utils";
 
@@ -30,5 +33,56 @@ describe("TPSL full-position close utilities", () => {
   it("never returns the sentinel from the display helper", () => {
     expect(getPositionCloseSizeDeltaUsdForDisplay(MaxUint256, undefined)).toBe(0n);
     expect(getPositionCloseSizeDeltaUsdForDisplay(MaxUint256, 0n)).toBe(0n);
+  });
+});
+
+describe("isFullClosePositionOrder", () => {
+  const positionSizeUsd = expandDecimals(1000, 30);
+
+  function makeOrder(overrides: { orderType: OrderType; sizeDeltaUsd: bigint; isTwap?: boolean }) {
+    return {
+      orderType: overrides.orderType,
+      sizeDeltaUsd: overrides.sizeDeltaUsd,
+      isTwap: overrides.isTwap ?? false,
+    } as unknown as OrderInfo;
+  }
+
+  it("treats TP/SL trigger decrease orders sized to the position as full close", () => {
+    expect(
+      isFullClosePositionOrder(
+        makeOrder({ orderType: OrderType.LimitDecrease, sizeDeltaUsd: positionSizeUsd }),
+        positionSizeUsd
+      )
+    ).toBe(true);
+    expect(
+      isFullClosePositionOrder(
+        makeOrder({ orderType: OrderType.StopLossDecrease, sizeDeltaUsd: MaxUint256 }),
+        positionSizeUsd
+      )
+    ).toBe(true);
+  });
+
+  it("never treats TWAP decrease orders as full close even when aggregated size matches the position", () => {
+    expect(
+      isFullClosePositionOrder(
+        makeOrder({ orderType: OrderType.LimitDecrease, sizeDeltaUsd: positionSizeUsd, isTwap: true }),
+        positionSizeUsd
+      )
+    ).toBe(false);
+  });
+
+  it("ignores non-trigger-decrease order types", () => {
+    expect(
+      isFullClosePositionOrder(
+        makeOrder({ orderType: OrderType.MarketDecrease, sizeDeltaUsd: positionSizeUsd }),
+        positionSizeUsd
+      )
+    ).toBe(false);
+    expect(
+      isFullClosePositionOrder(
+        makeOrder({ orderType: OrderType.LimitIncrease, sizeDeltaUsd: positionSizeUsd }),
+        positionSizeUsd
+      )
+    ).toBe(false);
   });
 });

--- a/src/domain/tpsl/__tests__/utils.spec.ts
+++ b/src/domain/tpsl/__tests__/utils.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { expandDecimals, MaxUint256 } from "lib/numbers";
+
+import {
+  FULL_POSITION_CLOSE_SIZE_DELTA_USD,
+  getPositionCloseSizeDeltaUsdForDisplay,
+  getPositionCloseSizeDeltaUsdForPayload,
+  isFullPositionCloseSizeDeltaUsd,
+} from "../utils";
+
+describe("TPSL full-position close utilities", () => {
+  const positionSizeUsd = expandDecimals(1000, 30);
+
+  it("recognizes MaxUint256 as semantic full close", () => {
+    expect(FULL_POSITION_CLOSE_SIZE_DELTA_USD).toBe(MaxUint256);
+    expect(isFullPositionCloseSizeDeltaUsd(MaxUint256, positionSizeUsd)).toBe(true);
+  });
+
+  it("uses position size for display while preserving MaxUint256 for payloads", () => {
+    expect(getPositionCloseSizeDeltaUsdForDisplay(MaxUint256, positionSizeUsd)).toBe(positionSizeUsd);
+    expect(getPositionCloseSizeDeltaUsdForPayload(positionSizeUsd, true)).toBe(MaxUint256);
+  });
+
+  it("does not treat smaller explicitly sized orders as full close", () => {
+    expect(isFullPositionCloseSizeDeltaUsd(expandDecimals(400, 30), positionSizeUsd)).toBe(false);
+    expect(getPositionCloseSizeDeltaUsdForPayload(expandDecimals(400, 30), false)).toBe(expandDecimals(400, 30));
+  });
+});

--- a/src/domain/tpsl/sidecar.ts
+++ b/src/domain/tpsl/sidecar.ts
@@ -2,13 +2,21 @@ import { UI_FEE_RECEIVER_ACCOUNT } from "config/ui";
 import type { selectUserReferralInfo } from "context/SyntheticsStateContext/selectors/globalSelectors";
 import type { MarketInfo } from "domain/synthetics/markets";
 import { getMarketIndexName, getMarketPoolName } from "domain/synthetics/markets";
-import { DecreasePositionSwapType, OrderType } from "domain/synthetics/orders";
+import { DecreasePositionSwapType, OrderType, PositionOrderInfo } from "domain/synthetics/orders";
 import type { PositionInfo, PositionInfoLoaded } from "domain/synthetics/positions";
 import { getPendingMockPosition } from "domain/synthetics/positions/usePositions";
 import type { TokenData } from "domain/synthetics/tokens";
 import { getDecreasePositionAmounts } from "domain/synthetics/trade";
 import type { DecreasePositionAmounts } from "domain/synthetics/trade";
-import { buildDecreaseOrderPayload } from "sdk/utils/orderTransactions";
+import {
+  buildDecreaseOrderPayload,
+  buildUpdateOrderPayload,
+  CreateOrderTxnParams,
+  DecreasePositionOrderParams,
+  UpdateOrderTxnParams,
+} from "sdk/utils/orderTransactions";
+
+import { FULL_POSITION_CLOSE_SIZE_DELTA_USD } from "./utils";
 
 export type BuildTpSlPositionInfoParams = {
   positionKey?: string;
@@ -213,6 +221,10 @@ export type TpSlCreatePayloadEntry = {
   sizeDeltaUsd?: bigint;
 };
 
+export type TpSlPayloadEntry = TpSlCreatePayloadEntry & {
+  existingFullCloseOrder?: PositionOrderInfo;
+};
+
 export function buildTpSlCreatePayloads(p: {
   autoCancelOrdersLimit: number;
   chainId: number;
@@ -270,4 +282,62 @@ export function buildTpSlCreatePayloads(p: {
       validFromTime: 0n,
     });
   });
+}
+
+export function buildTpSlBatchPayloads(p: {
+  autoCancelOrdersLimit: number;
+  chainId: number;
+  account: string | undefined;
+  marketAddress: string | undefined;
+  indexTokenAddress: string | undefined;
+  collateralTokenAddress: string | undefined;
+  isLong: boolean | undefined;
+  entries: TpSlPayloadEntry[];
+  userReferralCode: string | undefined;
+}): {
+  createOrderParams: CreateOrderTxnParams<DecreasePositionOrderParams>[];
+  updateOrderParams: UpdateOrderTxnParams[];
+} {
+  const updateOrderParams: UpdateOrderTxnParams[] = [];
+  const createEntries: TpSlCreatePayloadEntry[] = [];
+
+  for (const entry of p.entries) {
+    const replacesExisting = Boolean(entry.amounts?.isFullClose && entry.existingFullCloseOrder);
+
+    if (replacesExisting && entry.amounts && entry.existingFullCloseOrder) {
+      const order = entry.existingFullCloseOrder;
+      updateOrderParams.push(
+        buildUpdateOrderPayload({
+          chainId: p.chainId as any,
+          indexTokenAddress: order.indexToken.address,
+          orderKey: order.key,
+          orderType: order.orderType,
+          sizeDeltaUsd: FULL_POSITION_CLOSE_SIZE_DELTA_USD,
+          triggerPrice: entry.amounts.triggerPrice ?? 0n,
+          acceptablePrice: entry.amounts.acceptablePrice ?? 0n,
+          minOutputAmount: order.minOutputAmount,
+          autoCancel: order.autoCancel,
+          validFromTime: 0n,
+          executionFeeTopUp: 0n,
+        })
+      );
+      createEntries.push({ ...entry, amounts: undefined });
+    } else {
+      createEntries.push(entry);
+    }
+  }
+
+  const createOrderParams = buildTpSlCreatePayloads({
+    autoCancelOrdersLimit: p.autoCancelOrdersLimit,
+    chainId: p.chainId,
+    account: p.account,
+    marketAddress: p.marketAddress,
+    indexTokenAddress: p.indexTokenAddress,
+    collateralTokenAddress: p.collateralTokenAddress,
+    isLong: p.isLong,
+    entries: createEntries,
+    userReferralCode: p.userReferralCode,
+  });
+
+  return { createOrderParams, updateOrderParams };
 }

--- a/src/domain/tpsl/sidecar.ts
+++ b/src/domain/tpsl/sidecar.ts
@@ -210,6 +210,7 @@ export type TpSlCreatePayloadEntry = {
   amounts?: DecreasePositionAmounts;
   executionFeeAmount?: bigint;
   executionGasLimit?: bigint;
+  sizeDeltaUsd?: bigint;
 };
 
 export function buildTpSlCreatePayloads(p: {
@@ -247,7 +248,7 @@ export function buildTpSlCreatePayloads(p: {
       receiver: account,
       collateralDeltaAmount: amounts.collateralDeltaAmount ?? 0n,
       collateralTokenAddress,
-      sizeDeltaUsd: amounts.sizeDeltaUsd,
+      sizeDeltaUsd: item.sizeDeltaUsd ?? amounts.sizeDeltaUsd,
       sizeDeltaInTokens: amounts.sizeDeltaInTokens,
       referralCode: p.userReferralCode,
       uiFeeReceiver: UI_FEE_RECEIVER_ACCOUNT,

--- a/src/domain/tpsl/utils.ts
+++ b/src/domain/tpsl/utils.ts
@@ -23,6 +23,10 @@ export function isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd: bigint | undefined
 }
 
 export function getPositionCloseSizeDeltaUsdForDisplay(sizeDeltaUsd: bigint, positionSizeUsd?: bigint) {
+  if (sizeDeltaUsd === FULL_POSITION_CLOSE_SIZE_DELTA_USD) {
+    return positionSizeUsd ?? 0n;
+  }
+
   return isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd, positionSizeUsd) && positionSizeUsd !== undefined
     ? positionSizeUsd
     : sizeDeltaUsd;

--- a/src/domain/tpsl/utils.ts
+++ b/src/domain/tpsl/utils.ts
@@ -1,6 +1,36 @@
 import type { PositionOrderInfo } from "domain/synthetics/orders";
 import { convertToTokenAmount, convertToUsd } from "domain/synthetics/tokens";
 import type { TokenData } from "domain/synthetics/tokens";
+import { DUST_USD } from "lib/legacy";
+import { MaxUint256 } from "lib/numbers";
+
+export const FULL_POSITION_CLOSE_SIZE_DELTA_USD = MaxUint256;
+
+export function isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd: bigint | undefined, positionSizeUsd?: bigint) {
+  if (sizeDeltaUsd === undefined) {
+    return false;
+  }
+
+  if (sizeDeltaUsd === FULL_POSITION_CLOSE_SIZE_DELTA_USD) {
+    return true;
+  }
+
+  if (positionSizeUsd === undefined || positionSizeUsd <= 0n) {
+    return false;
+  }
+
+  return sizeDeltaUsd >= positionSizeUsd || positionSizeUsd - sizeDeltaUsd < DUST_USD;
+}
+
+export function getPositionCloseSizeDeltaUsdForDisplay(sizeDeltaUsd: bigint, positionSizeUsd?: bigint) {
+  return isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd, positionSizeUsd) && positionSizeUsd !== undefined
+    ? positionSizeUsd
+    : sizeDeltaUsd;
+}
+
+export function getPositionCloseSizeDeltaUsdForPayload(sizeDeltaUsd: bigint, isFullClose: boolean) {
+  return isFullClose ? FULL_POSITION_CLOSE_SIZE_DELTA_USD : sizeDeltaUsd;
+}
 
 export function calculateTotalSizeUsd(p: {
   existingPositionSizeUsd: bigint | undefined;

--- a/src/domain/tpsl/utils.ts
+++ b/src/domain/tpsl/utils.ts
@@ -1,4 +1,5 @@
-import type { PositionOrderInfo } from "domain/synthetics/orders";
+import type { OrderInfo, PositionOrderInfo } from "domain/synthetics/orders";
+import { isTriggerDecreaseOrderType, isTwapOrder } from "domain/synthetics/orders";
 import { convertToTokenAmount, convertToUsd } from "domain/synthetics/tokens";
 import type { TokenData } from "domain/synthetics/tokens";
 import { DUST_USD } from "lib/legacy";
@@ -20,6 +21,16 @@ export function isFullPositionCloseSizeDeltaUsd(sizeDeltaUsd: bigint | undefined
   }
 
   return sizeDeltaUsd >= positionSizeUsd || positionSizeUsd - sizeDeltaUsd < DUST_USD;
+}
+
+export function isFullClosePositionOrder(order: OrderInfo, positionSizeUsd?: bigint) {
+  if (isTwapOrder(order)) {
+    return false;
+  }
+
+  return (
+    isTriggerDecreaseOrderType(order.orderType) && isFullPositionCloseSizeDeltaUsd(order.sizeDeltaUsd, positionSizeUsd)
+  );
 }
 
 export function getPositionCloseSizeDeltaUsdForDisplay(sizeDeltaUsd: bigint, positionSizeUsd?: bigint) {

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>Ungültige Genehmigungssignatur. Versuchen Sie es erneut</0>"
 msgid "Positive factor"
 msgstr "Positiver Faktor"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "Vollständige Positionsschließung"
 
@@ -5808,10 +5811,6 @@ msgstr "GMX APR"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "Geben Sie oben Hex-Fehlerdaten ein, um sie zu decodieren"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "Empfängeradresse"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "Allen Token erlauben, auf das neue Konto übertragen zu werden"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -8779,6 +8779,10 @@ msgstr "Layer 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>Mit 75,5% Mehrheitsstimme hat GMX LayerZero als Messaging-Partner für Multichain-Erweiterung ausgewählt! Die Integration bringt GMX:</0><1><2>Die Fähigkeit, auf 125+ Chains zu erweitern</2><3>Vollständiges Eigentum an allen Verträgen und Sicherheit</3><4>Schnelle, zero-Slippage-Transfers</4><5>Battle-tested Rails, die bereits von Milliarden Dollar an Assets und Hunderten von Anwendungen vertraut werden... <6>mehr sehen</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "Staken..."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4239,6 +4239,7 @@ msgstr "Positiver Faktor"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "Vollständige Positionsschließung"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>Invalid permit signature. Try again</0>"
 msgid "Positive factor"
 msgstr "Positive factor"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "Full position close"
 
@@ -5808,10 +5811,6 @@ msgstr "GMX APR"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "Enter hex error data above to decode it"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "Receiver address"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "Allow all tokens to transfer to the new account"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -8779,6 +8779,10 @@ msgstr "Layer 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr "Loading position..."
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "Staking..."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4239,6 +4239,7 @@ msgstr "Positive factor"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "Full position close"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -8779,6 +8779,10 @@ msgstr "Capa 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>Con un voto mayoritario del 75.5%, GMX ha seleccionado a LayerZero como su socio de mensajería para expansión multicadena! La integración trae a GMX:</0><1><2>La capacidad de expandir a más de 125 cadenas</2><3>Propiedad completa de todos los contratos y seguridad</3><4>Transferencias rápidas, sin slippage</4><5>Rails probados en batalla ya confiados por miles de millones de dólares en activos y cientos de aplicaciones... <6>ver más</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "Stakeando..."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>Firma de permiso no válida. Inténtelo de nuevo</0>"
 msgid "Positive factor"
 msgstr "Factor positivo"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "Cierre total de posición"
 
@@ -5808,10 +5811,6 @@ msgstr "APR de GMX"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "Introduzca los datos de error en hexadecimal arriba para decodificarlos"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "Dirección del destinatario"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "Permitir transferir todos los tokens a la nueva cuenta"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4239,6 +4239,7 @@ msgstr "Factor positivo"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "Cierre total de posición"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -8779,6 +8779,10 @@ msgstr "Couche 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>Avec un vote majoritaire de 75,5 %, GMX a sélectionné LayerZero comme partenaire de messagerie pour l'expansion multichain ! L'intégration apporte à GMX :</0><1><2>La capacité d'expansion à plus de 125 chaînes</2><3>Propriété complète de tous les contrats et sécurité</3><4>Transferts rapides sans slippage</4><5>Rails testés en bataille déjà approuvés par des milliards de dollars en actifs et des centaines d'applications... <6>voir plus</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "Staking en cours..."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>Signature de permis invalide. Veuillez réessayer</0>"
 msgid "Positive factor"
 msgstr "Facteur positif"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "Fermeture complète de la position"
 
@@ -5808,10 +5811,6 @@ msgstr "APR GMX"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "Saisissez les données d'erreur hexadécimales ci-dessus pour les décoder"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText} : {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "Adresse du destinataire"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "Autoriser le transfert de tous les tokens vers le nouveau compte"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4239,6 +4239,7 @@ msgstr "Facteur positif"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "Fermeture complète de la position"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -8779,6 +8779,10 @@ msgstr "レイヤー1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>75.5%の多数決でGMXはマルチチェーン拡張のメッセージングパートナーとしてLayerZeroを選択！統合によりGMXに：</0><1><2>125+チェーンへの拡張能力</2><3>すべてのコントラクトとセキュリティの完全所有</3><4>高速、ゼロスリッページ転送</4><5>数十億ドルの資産と数百のアプリケーションで信頼されたバトルテスト済みレール... <6>もっと見る</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "ステーク中..."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4239,6 +4239,7 @@ msgstr "プラスファクター"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "ポジション全決済"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>パーミット署名が無効です。再度お試しください</0
 msgid "Positive factor"
 msgstr "プラスファクター"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "ポジション全決済"
 
@@ -5808,10 +5811,6 @@ msgstr "GMX APR"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "デコードするには上記にhexエラーデータを入力してください"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "受取人アドレス"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "すべてのトークンの新しいアカウントへの送金を許可する"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -8779,6 +8779,10 @@ msgstr "레이어 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>75.5% 다수 투표로 GMX는 멀티체인 확장을 위한 메시징 파트너로 LayerZero를 선택했습니다! 이 통합은 GMX에:</0><1><2>125+ 체인으로 확장 능력</2><3>모든 계약 및 보안의 완전 소유권</3><4>빠르고 제로 슬리피지 전송</4><5>수십억 달러 자산과 수백 개 애플리케이션에서 이미 신뢰받는 전투 테스트된 레일... <6>더 보기</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "스테이킹 중..."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4239,6 +4239,7 @@ msgstr "양수 팩터"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "포지션 전체 청산"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>유효하지 않은 허가 서명입니다. 다시 시도하십시오
 msgid "Positive factor"
 msgstr "양수 팩터"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "포지션 전체 청산"
 
@@ -5808,10 +5811,6 @@ msgstr "GMX APR"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "위에 16진수 오류 데이터를 입력하여 디코딩하십시오"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "수신자 주소"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "모든 토큰을 새 계정으로 전송 허용"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -8779,6 +8779,10 @@ msgstr ""
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr ""
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr ""

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4239,6 +4239,7 @@ msgstr ""
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr ""
 

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4235,7 +4235,10 @@ msgstr ""
 msgid "Positive factor"
 msgstr ""
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr ""
 
@@ -5807,10 +5810,6 @@ msgstr ""
 
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
-msgstr ""
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 msgstr ""
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
@@ -9309,6 +9308,10 @@ msgstr ""
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
+msgstr ""
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>Недействительная подпись разрешения.
 msgid "Positive factor"
 msgstr "Положительный фактор"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "Полное закрытие позиции"
 
@@ -5808,10 +5811,6 @@ msgstr "Годовая Процентная Ставка GMX"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "Введите hex-данные ошибки выше для декодирования"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "Адрес получателя"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "Разрешить перевод всех токенов на новый аккаунт"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4239,6 +4239,7 @@ msgstr "Положительный фактор"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "Полное закрытие позиции"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -8779,6 +8779,10 @@ msgstr "Слой 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>С большинством голосов 75.5% GMX выбрал LayerZero как партнера по messaging для мультичейн-расширения! Интеграция приносит GMX:</0><1><2>Возможность расширения на 125+ цепей</2><3>Полное владение всеми контрактами и безопасностью</3><4>Быстрые переводы без slippage</4><5>Боевые рельсы, уже доверенные миллиардам долларов в активах и сотням приложений... <6>см. больше</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "Стейкинг..."

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -8779,6 +8779,10 @@ msgstr "Layer 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>以 75.5% 的多數票，GMX 選擇了 LayerZero 作為其多鏈擴展的訊息傳遞夥伴！此整合為 GMX 帶來：</0><1><2>擴展至 125+ 條鏈的能力</2><3>所有合約和安全性的完全所有權</3><4>快速、零滑點的轉帳</4><5>經過實戰檢驗的基礎設施，已獲數十億美元資產和數百個應用程式的信賴⋯⋯<6>查看更多</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "質押中..."

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4239,6 +4239,7 @@ msgstr "正向因子"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "完全平倉"
 

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>無效的許可簽名，請重試</0>"
 msgid "Positive factor"
 msgstr "正向因子"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "完全平倉"
 
@@ -5808,10 +5811,6 @@ msgstr "GMX APR"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "在上方輸入十六進位錯誤資料以進行解碼"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "接收地址"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "允許所有代幣轉移至新帳戶"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4239,6 +4239,7 @@ msgstr "正向因子"
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/PositionItem/PositionItemOrders.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Full position close"
 msgstr "全部平仓"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4235,7 +4235,10 @@ msgstr "<0>无效的授权签名。请重试</0>"
 msgid "Positive factor"
 msgstr "正向因子"
 
+#: src/components/OrderItem/OrderItem.tsx
 #: src/components/OrdersModal/TPSLOrdersList.tsx
+#: src/components/PositionItem/PositionItemOrders.tsx
+#: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Full position close"
 msgstr "全部平仓"
 
@@ -5808,10 +5811,6 @@ msgstr "GMX 年化收益率"
 #: src/pages/DecodeError/DecodeError.tsx
 msgid "Enter hex error data above to decode it"
 msgstr "在上方输入十六进制错误数据以解码"
-
-#: src/components/StatusNotification/OrderStatusNotification.tsx
-msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
-msgstr "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sign}{1}"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Allowed actions"
@@ -9310,6 +9309,10 @@ msgstr "接收地址"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "允许所有代币转移至新账户"
+
+#: src/components/StatusNotification/OrderStatusNotification.tsx
+msgid "{orderTypeText} {visualMultiplierPrefix}{0} {longShortText}: {sizeText}"
+msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Positive funding fees accrued in positions, not yet claimable.<0/><1/>Available after changing position size, adjusting collateral, or clicking \"Settle\"."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -8779,6 +8779,10 @@ msgstr "Layer 1"
 msgid "<0>With a 75.5% majority vote, GMX has selected LayerZero as its messaging partner for multichain expansion! The integration brings GMX:</0><1><2>The ability to expand to 125+ chains</2><3>Full ownership of all contracts and security</3><4>Fast, zero-slippage transfers</4><5>Battle-tested rails already trusted by billions of dollars in assets and hundreds of applications... <6>see more</6></5></1>"
 msgstr "<0>以 75.5% 的多数票，GMX 已选择 LayerZero 作为其多链扩展的消息合作伙伴！该集成为 GMX 带来：</0><1><2>扩展到 125+ 链的能力</2><3>所有合约和安全的完全所有权</3><4>快速、无滑点转移</4><5>已由数十亿美元资产和数百个应用信任的经过战斗测试的轨道... <6>查看更多</6></5></1>"
 
+#: src/components/OrderEditor/OrderEditor.tsx
+msgid "Loading position..."
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Staking..."
 msgstr "质押中..."


### PR DESCRIPTION
## Summary

Fixes [FEDEV-3813](https://linear.app/gmx-io/issue/FEDEV-3813/bug-full-close-tpsl-orders-lose-full-position-semantics-after-size). Basic full-close TP/SL orders previously snapshotted the position size at creation and lost their full-close meaning when the position grew. Re-issuing a full-close order also produced duplicates instead of updating the existing one.

- Use `MaxUint256` as the on-chain `sizeDeltaUsd` for basic full-close TP/SL (`buildTpSlCreatePayloads`, `useSidecarOrderPayloads`, `AddTPSLModal`). The contract caps execution to live position size, so the order continues to mean "close the whole position" after subsequent increases.
- Hydrate sidecar TP/SL groups with existing full-close orders via `selectTradeboxSidecarOrdersExisting{Sl,Tp}Entries` + `prepareInitialEntries({ onlyFullPositionClose: true })` so re-issuing a basic full-close TP or SL updates the existing one rather than spawning a duplicate. Partial orders are unaffected.
- New helpers `FULL_POSITION_CLOSE_SIZE_DELTA_USD`, `isFullPositionCloseSizeDeltaUsd`, `getPositionCloseSizeDeltaUsdForDisplay`, `getPositionCloseSizeDeltaUsdForPayload` centralize the sentinel handling.
- Display "Full position close" instead of a dollar amount in `OrderItem`, `PositionItemOrders`, `OrderStatusNotification`, and `TPSLOrdersList`. PnL and `shouldKeepLeverage` use the live position size for display, but the payload keeps the sentinel so it tracks future increases.
- `OrderEditor` preserves the sentinel when editing a full-close order whose new size still meets the full-close threshold.
- Tests added for the new utilities and `prepareInitialEntries` filtering.

## Test plan
- [x] `vitest` unit tests for new utilities pass
- [x] Manual: open a position with a basic full-close SL from TradeBox, increase the position, confirm Orders tab still shows "Full position close" and the on-chain size matches the larger position
- [x] Manual: re-issue a basic full-close SL from TradeBox — verify it updates the existing order instead of creating a second one; ensure the paired full-close TP is unaffected
- [x] Manual: edit a full-close SL via OrderEditor; price-only edit keeps full-close semantics, shrinking size below the position falls back to a partial size
- [x] Manual: create explicitly partial TP/SL via the advanced flow — confirm dollar size and percentage still display normally and multiple partial orders still allowed