### PR TITLE
FEDEV-3785 fix margin/size sync on focus change

### DIFF
--- a/src/components/TradeBox/TradeBox.tsx
+++ b/src/components/TradeBox/TradeBox.tsx
@@ -392,6 +392,17 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
 
   const prevIsISwap = usePrevious(isSwap);
 
+  // Tracks the last focusedInput / input values seen by updateInputAmounts so we
+  // can skip the backfill when the user only changed focus (clicking/tabbing
+  // between Margin and Size). Without this guard, a focus toggle alone causes
+  // the leverage strategy selector to switch direction (leverageByCollateral ↔
+  // leverageBySize), which feeds the previously-backfilled value through the
+  // opposite formula — re-applying fee math each toggle and inflating both
+  // values (FEDEV-3785).
+  const prevFocusedInputRef = useRef(focusedInput);
+  const prevFromTokenInputValueRef = useRef(fromTokenInputValue);
+  const prevToTokenInputValueRef = useRef(toTokenInputValue);
+
   useEffect(
     function updateInputAmounts() {
       if (!fromToken || !toToken || (!isSwap && !isIncrease)) {
@@ -403,6 +414,26 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
         setFocusedInput("from");
 
         setFromTokenInputValue("", true);
+        prevFocusedInputRef.current = "from";
+        prevFromTokenInputValueRef.current = "";
+        prevToTokenInputValueRef.current = toTokenInputValue;
+        return;
+      }
+
+      // FEDEV-3785: skip backfill when only focus changed. Mere focus toggles
+      // must not mutate the inputs — the backfill should run on actual user
+      // edits (typing, slider, max) and on external recomputes (price,
+      // leverage, market). Those all change either an input value or a
+      // non-focus dep that re-renders this effect.
+      const focusChanged = prevFocusedInputRef.current !== focusedInput;
+      const fromInputChanged = prevFromTokenInputValueRef.current !== fromTokenInputValue;
+      const toInputChanged = prevToTokenInputValueRef.current !== toTokenInputValue;
+
+      prevFocusedInputRef.current = focusedInput;
+      prevFromTokenInputValueRef.current = fromTokenInputValue;
+      prevToTokenInputValueRef.current = toTokenInputValue;
+
+      if (focusChanged && !fromInputChanged && !toInputChanged) {
         return;
       }
 
@@ -448,6 +479,7 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
       focusedInput,
       fromToken,
       fromTokenAmount,
+      fromTokenInputValue,
       increaseAmounts,
       isIncrease,
       isSwap,
@@ -457,6 +489,7 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
       setToTokenInputValue,
       swapAmounts,
       toToken,
+      toTokenInputValue,
     ]
   );
 


### PR DESCRIPTION
## Summary

Fixes [FEDEV-3785](https://linear.app/gmx-io/issue/FEDEV-3785/bug-switching-focus-between-margin-and-size-fields-repeatedly). Reported as item 4 in FEDEV-3705. Repeatedly clicking or tabbing between the Margin and Size inputs in the increase tradebox caused both values to drift upward.

## Root cause

`updateInputAmounts` in `TradeBox.tsx` re-runs whenever `focusedInput` toggles. The leverage strategy selector reads `focusedInput` to choose between `leverageByCollateral` (margin-anchored) and `leverageBySize` (size-anchored). When the user clicked between fields without typing:

1. Click Size: strategy flips to `leverageBySize`. `getIncreasePositionAmounts` recomputes `initialCollateralAmount` from the just-backfilled `indexTokenAmount` plus all the position/swap/borrowing/funding/UI fees → slightly more than the user's typed margin.
2. Click Margin: strategy flips to `leverageByCollateral`. `sizeDeltaUsd` is recomputed from the new (inflated) collateral minus fees, then multiplied by leverage → slightly more than the previously backfilled size.

Each toggle pushed the backfilled value through the inverse formula, re-applying fee math and inflating both inputs.

## Fix

Track previous `focusedInput`, `fromTokenInputValue`, and `toTokenInputValue` in refs inside `updateInputAmounts`. When the effect fires solely because `focusedInput` flipped (no input string changed), skip the backfill. Real edits — typing, slider, max, percentage — and external recomputes (price, leverage, market, token) all change either an input value or a non-focus dep, so they continue to trigger the backfill normally. The existing slider snap-back guard and the swap/position tab reset path are preserved (the reset path now also seeds the prev-refs).

## Test plan

- [x] `eslint` clean on `TradeBox.tsx`
- [x] Existing `TradeboxMarginFields` Playwright CT suite passes (101/101 — change is in the parent `TradeBox` only)
- [ ] Manual repro: open increase flow, type margin, click between Margin and Size repeatedly — values stay put
- [ ] Manual: typing in either field still backfills the dependent value
- [ ] Manual: percentage slider, Max button, leverage slider, market change still drive backfills
- [ ] Manual: limit order trigger price edits still recompute size on the backfilled side
- [ ] Manual: works for USD and token size display modes
- [ ] Manual: works with manual leverage on and off