### PR TITLE
FEDEV-3706 fix derived leverage with limit price

### DIFF
--- a/src/components/TradeboxMarginFields/TradeboxMarginFields.tsx
+++ b/src/components/TradeboxMarginFields/TradeboxMarginFields.tsx
@@ -65,6 +65,8 @@ export function TradeboxMarginFields({
   const { toTokenAddress, marketAddress } = useSelector(selectTradeboxState);
 
   const prevSizeSyncContextRef = useRef<string>();
+  // null sentinel = "uninitialized"; bigint | undefined = previously seen value (undefined means no triggerPrice)
+  const prevTriggerPriceRef = useRef<bigint | undefined | null>(null);
   const shouldForceSizeUsdSyncRef = useRef(false);
 
   const toToken = getByKey(tokensData, toTokenAddress);
@@ -124,6 +126,30 @@ export function TradeboxMarginFields({
       prevSizeSyncContextRef.current = nextContext;
     }
   }, [marketAddress, toTokenAddress]);
+
+  // For limit orders in USD mode, the user-typed USD is the anchor: when the
+  // trigger price changes, re-derive toTokenInputValue from sizeInputValue so
+  // sizeDeltaUsd (which uses triggerPrice) stays consistent with the typed USD.
+  // Without this, leverage = sizeDeltaUsd / collateralUsd would diverge from
+  // the displayed Size USD whenever triggerPrice differs from the price used
+  // when the user originally typed the size.
+  useEffect(() => {
+    if (!isLimit) {
+      prevTriggerPriceRef.current = triggerPrice;
+      return;
+    }
+
+    if (prevTriggerPriceRef.current === null) {
+      prevTriggerPriceRef.current = triggerPrice;
+      return;
+    }
+
+    if (prevTriggerPriceRef.current !== triggerPrice && sizeDisplayMode === "usd") {
+      shouldForceSizeUsdSyncRef.current = true;
+    }
+
+    prevTriggerPriceRef.current = triggerPrice;
+  }, [isLimit, triggerPrice, sizeDisplayMode]);
 
   useEffect(() => {
     if (sizeDisplayMode !== "usd" || !canConvert) return;

--- a/src/components/TradeboxMarginFields/__tests__/TradeboxMarginFieldsIntegration.ct.spec.tsx
+++ b/src/components/TradeboxMarginFields/__tests__/TradeboxMarginFieldsIntegration.ct.spec.tsx
@@ -241,6 +241,32 @@ test.describe("TradeboxMarginFields Integration", () => {
       const priceInput = page.locator(getDataQALocator("trigger-price-input"));
       await expect(priceInput).toHaveValue("1800");
     });
+
+    // FEDEV-3706: with manual leverage off, the displayed leverage must be
+    // derived from the displayed size/margin. Re-deriving toTokenInputValue
+    // from sizeInputValue (the typed USD value) on triggerPrice change is what
+    // keeps sizeDeltaUsd consistent with the user-facing Size USD.
+    test("limit order: typing size before limit price re-derives token amount on limit change", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<IntegrationStory tradeMode={TradeMode.Limit} initialFromValue="" initialToValue="" />);
+
+      // Type Size = 4000 USD with no triggerPrice yet (mark price = $2000)
+      // Expected token amount at this stage: 4000 / 2000 = 2 ETH
+      const sizeInput = page.locator(getDataQALocator("position-size-input"));
+      await sizeInput.fill("4000");
+      await expect(page.getByTestId("to-value")).toHaveText("2");
+
+      // Then type Limit price = $1000 — token amount should now reflect typed Size
+      // at the new conversion price: 4000 / 1000 = 4 ETH (anchor is the typed USD)
+      const priceInput = page.locator(getDataQALocator("trigger-price-input"));
+      await priceInput.fill("1000");
+
+      await expect(page.getByTestId("to-value")).toHaveText("4");
+      // Size USD input stays at user-typed value
+      await expect(sizeInput).toHaveValue("4000");
+    });
   });
 
   test.describe("Passive USD sync", () => {


### PR DESCRIPTION
## Summary

Fixes [FEDEV-3706](https://linear.app/gmx-io/issue/FEDEV-3706/bug-displayed-leverage-is-incorrect-when-manual-leverage-is-disabled). With manual leverage disabled and a limit order set, the auto-derived leverage shown in the leverage field could diverge from `displayedSize / displayedMargin` because `sizeDeltaUsd` was computed from a stale `toTokenInputValue` that had been derived using a different conversion price than the current trigger price.

## Root cause

In USD display mode the user-typed Size USD is stored in `sizeInputValue`; `toTokenInputValue` is derived via `usdToTokens` using the current `sizeConversionPrice`:

- For market orders, `sizeConversionPrice = markPrice`.
- For limit orders, `sizeConversionPrice = triggerPrice`.

The selector then computes `sizeDeltaUsd = indexTokenAmount × indexPrice` (where `indexPrice = triggerPrice` for limit orders).

When a user typed Size before setting a limit price (or before changing it), `toTokenInputValue` was derived using the old conversion price. After the trigger price changed, the existing passive sync effect bailed out when `focusedInput === "to"`, so the stale token amount remained — and `sizeDeltaUsd` (and the auto-derived leverage built from it) no longer matched the displayed Size USD.

## Fix

Treat the user-typed Size USD as the anchor for limit orders. When `triggerPrice` changes in USD mode, set the existing `shouldForceSizeUsdSyncRef` flag so the next sync pass re-derives `toTokenInputValue` from `sizeInputValue` using the new conversion price — overriding the focus guard the way other forced syncs (market/token swaps) already do. The user-typed Size USD remains untouched.

The behaviour is scoped to limit/stop orders in USD display mode; market mode and token mode are not affected.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Added Playwright CT regression test in `TradeboxMarginFieldsIntegration.ct.spec.tsx` covering: type Size USD with no trigger price, then set a limit price, and assert the token amount re-derives from the typed USD
- [ ] Manual: with manual leverage off, Long, Limit, GMX-USDC, collateral GMX, Margin = 150 GMX, Size = 1500, Limit = 1 — leverage matches displayed size/margin
- [ ] Manual: same flow in token display mode — leverage and displayed values stay consistent
- [ ] Manual: Short side reproduces the same correct behaviour
- [ ] Manual: Stop / market modes unchanged
- [ ] Manual: liquidation price and fees still align with the displayed leverage