### PR TITLE
Fix multichain progress tests

### DIFF
--- a/src/domain/multichain/progress/getOrWaitLogs.ts
+++ b/src/domain/multichain/progress/getOrWaitLogs.ts
@@ -1,6 +1,7 @@
 import { AbiEvent } from "abitype";
 import { MaybeExtractEventArgsFromAbi, GetLogsReturnType } from "viem";
 
+import { getRpcProviders } from "config/rpc";
 import { createAnySignal, createTimeoutSignal } from "lib/abortSignalHelpers";
 import { sleep } from "lib/sleep";
 import { getPublicClientWithRpc } from "lib/wallets/rainbowKitConfig";
@@ -8,6 +9,11 @@ import { getPublicClientWithRpc } from "lib/wallets/rainbowKitConfig";
 const POLLING_INTERVAL = 2_000; // 2 seconds
 const DEFAULT_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 const DEFAULT_FINISH = () => true;
+
+function getLogsPublicClient(chainId: number) {
+  const hasExpressRpc = getRpcProviders(chainId, "express").length > 0;
+  return getPublicClientWithRpc(chainId, hasExpressRpc ? { withExpress: true } : undefined);
+}
 
 export async function getOrWaitLogs<T extends AbiEvent>({
   chainId,
@@ -38,7 +44,7 @@ export async function getOrWaitLogs<T extends AbiEvent>({
 
     while (!combinedSignal.aborted) {
       try {
-        const logs = await getPublicClientWithRpc(chainId).getLogs({
+        const logs = await getLogsPublicClient(chainId).getLogs({
           fromBlock,
           event,
           args,

--- a/src/domain/multichain/progress/watchLzTx.ts
+++ b/src/domain/multichain/progress/watchLzTx.ts
@@ -200,7 +200,7 @@ export async function watchLzTxRpc({
       destinationChainId
     );
 
-    const publicClient = getPublicClientWithRpc(destinationChainId);
+    const publicClient = getPublicClientWithRpc(destinationChainId, { withExpress: true });
     const fromBlock = oftReceivedLogs[0].blockNumber!;
     // This request does not have good filtering, so we need to limit the range so the tests dont break
     // In runtime we only call it for the new tx so the fromBlock-now is small enough


### PR DESCRIPTION
## Summary
- route multichain progress log reads through express RPC when available
- keep default RPC fallback for chains without express providers
- use express RPC for LayerZero compose event lookup

## Root cause
Public Arbitrum Blast RPC started rejecting broad eth_getLogs requests with a 10-block range limit. The progress watchers retried the same invalid request until tests timed out.
