### PR TITLE
Hotfix: Support v2 JIT liquidity info in UI FEDEV-3885

### DIFF
--- a/sdk/src/configs/api.ts
+++ b/sdk/src/configs/api.ts
@@ -1,29 +1,33 @@
 import { ARBITRUM, ARBITRUM_SEPOLIA, AVALANCHE, AVALANCHE_FUJI, BOTANIX, ContractsChainId, MEGAETH } from "./chains";
 
-const API_URLS: Record<ContractsChainId, string | undefined> = {
-  [ARBITRUM]: "https://arbitrum.gmxapi.io/v1",
-  [AVALANCHE]: "https://avalanche.gmxapi.io/v1",
+export type ApiVersion = "v1" | "v2";
+
+const API_BASE_URLS: Record<ContractsChainId, string | undefined> = {
+  [ARBITRUM]: "https://arbitrum.gmxapi.io",
+  [AVALANCHE]: "https://avalanche.gmxapi.io",
   [AVALANCHE_FUJI]: undefined,
-  [BOTANIX]: "https://botanix.gmxapi.io/v1",
-  [ARBITRUM_SEPOLIA]: "https://gmx-api-arbitrum-sepolia-yp6pp.ondigitalocean.app/v1",
-  [MEGAETH]: "https://megaeth.gmxapi.io/v1",
+  [BOTANIX]: "https://botanix.gmxapi.io",
+  [ARBITRUM_SEPOLIA]: "https://gmx-api-arbitrum-sepolia-yp6pp.ondigitalocean.app",
+  [MEGAETH]: "https://megaeth.gmxapi.io",
 };
 
-const API_FALLBACK_URLS: Record<ContractsChainId, string[]> = {
-  [ARBITRUM]: ["https://arbitrum.gmxapi.ai/v1"],
-  [AVALANCHE]: ["https://avalanche.gmxapi.ai/v1"],
+const API_FALLBACK_BASE_URLS: Record<ContractsChainId, string[]> = {
+  [ARBITRUM]: ["https://arbitrum.gmxapi.ai"],
+  [AVALANCHE]: ["https://avalanche.gmxapi.ai"],
   [AVALANCHE_FUJI]: [],
-  [BOTANIX]: ["https://botanix.gmxapi.ai/v1"],
+  [BOTANIX]: ["https://botanix.gmxapi.ai"],
   [ARBITRUM_SEPOLIA]: [],
-  [MEGAETH]: ["https://megaeth.gmxapi.ai/v1"],
+  [MEGAETH]: ["https://megaeth.gmxapi.ai"],
 };
 
-export function getApiUrl(chainId: number) {
-  return API_URLS[chainId];
+export function getApiUrl(chainId: number, apiVersion: ApiVersion = "v1") {
+  const apiBaseUrl = API_BASE_URLS[chainId];
+
+  return apiBaseUrl ? `${apiBaseUrl}/${apiVersion}` : undefined;
 }
 
-export function getApiFallbackUrls(chainId: number): string[] {
-  return API_FALLBACK_URLS[chainId] ?? [];
+export function getApiFallbackUrls(chainId: number, apiVersion: ApiVersion = "v1"): string[] {
+  return (API_FALLBACK_BASE_URLS[chainId] ?? []).map((apiBaseUrl) => `${apiBaseUrl}/${apiVersion}`);
 }
 
 export function isApiSupported(chainId: number) {

--- a/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
+++ b/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
@@ -42,7 +42,7 @@ import { useSelector } from "context/SyntheticsStateContext/utils";
 import { useUserReferralCode } from "domain/referrals";
 import { getIsValidExpressParams } from "domain/synthetics/express/expressOrderUtils";
 import { useExpressOrdersParams } from "domain/synthetics/express/useRelayerFeeHandler";
-import { getJitLiquidityInfo } from "domain/synthetics/jit/utils";
+import { getJitGlvShiftParams } from "domain/synthetics/jit/utils";
 import { getAvailableUsdLiquidityForPosition } from "domain/synthetics/markets/utils";
 import { OrderType } from "domain/synthetics/orders";
 import { createStakeOrUnstakeTxn } from "domain/synthetics/orders/createStakeOrUnStakeTxn";
@@ -323,8 +323,8 @@ export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactions
 
     sendUserAnalyticsOrderConfirmClickEvent(chainId, metricData.metricId);
 
-    const jitLiquidityInfo = marketInfo
-      ? getJitLiquidityInfo(jitLiquidityMap, marketInfo.marketTokenAddress)
+    const jitShiftParamsList = marketInfo
+      ? getJitGlvShiftParams(jitLiquidityMap, marketInfo.marketTokenAddress, isLong)
       : undefined;
     const nativeReserveLiquidity = marketInfo ? getAvailableUsdLiquidityForPosition(marketInfo, isLong) : undefined;
     return sendBatchOrderTxn({
@@ -340,7 +340,7 @@ export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactions
         : {
             tokensData,
             blockTimestampData,
-            jitShiftParamsList: jitLiquidityInfo?.glvShiftParams,
+            jitShiftParamsList,
             // Excludes JIT — determines whether JIT simulation is needed
             nativeReserveLiquidity,
           },

--- a/src/domain/synthetics/jit/useJitLiquidityRequest.ts
+++ b/src/domain/synthetics/jit/useJitLiquidityRequest.ts
@@ -4,15 +4,18 @@ import useSWR from "swr";
 import { getApiUrl } from "sdk/configs/api";
 import type { ContractsChainId } from "sdk/configs/chains";
 
-import { JitLiquidityData, JitLiquidityInfo, safeParseBigInt } from "./utils";
+import { JitLiquidityData, JitLiquidityInfo, parseJitLiquidityResponse } from "./utils";
+import { getIsV2JitLiquidityInfoEnabled, useUiFlagsRequest } from "../uiFlags/useUiFlagsRequest";
 
 const JIT_LIQUIDITY_UPDATE_INTERVAL = 30 * 1000;
 
 export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { enabled?: boolean }): JitLiquidityData {
   const enabled = options?.enabled !== false;
+  const { uiFlags } = useUiFlagsRequest();
+  const isV2JitLiquidityInfoEnabled = getIsV2JitLiquidityInfoEnabled(uiFlags);
 
   const { data } = useSWR<Record<string, JitLiquidityInfo> | undefined>(
-    enabled ? ["jitLiquidity", chainId] : null,
+    enabled ? ["jitLiquidity", chainId, isV2JitLiquidityInfoEnabled ? "v2" : "v1"] : null,
     async () => {
       try {
         const apiUrl = getApiUrl(chainId);
@@ -21,29 +24,11 @@ export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { en
           return undefined;
         }
 
-        const res = await fetch(`${apiUrl}/jit/liquidity_info`);
+        const jitApiUrl = getJitApiUrl(apiUrl, isV2JitLiquidityInfoEnabled);
+        const res = await fetch(`${jitApiUrl}/jit/liquidity_info`);
         const response = await res.json();
 
-        const result: Record<string, JitLiquidityInfo> = {};
-
-        for (const info of response.liquidityInfos) {
-          const marketKey = info.market.toLowerCase();
-
-          result[marketKey] = {
-            maxReservedUsdWithJitLong: safeParseBigInt(info.maxReservedUsdWithJitLong),
-            maxReservedUsdWithJitShort: safeParseBigInt(info.maxReservedUsdWithJitShort),
-            glvShiftParams: (info.glvShiftParams ?? []).map((param: any) => ({
-              glv: param.glv,
-              fromMarket: param.fromMarket,
-              toMarket: param.toMarket,
-              marketTokenAmount: safeParseBigInt(param.marketTokenAmount),
-              minMarketTokens: safeParseBigInt(param.minMarketTokens),
-            })),
-            glv: info.glv,
-          };
-        }
-
-        return result;
+        return parseJitLiquidityResponse(response, isV2JitLiquidityInfoEnabled);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error("Failed to fetch JIT liquidity data", e);
@@ -61,4 +46,12 @@ export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { en
     }),
     [data]
   );
+}
+
+function getJitApiUrl(apiUrl: string, isV2JitLiquidityInfoEnabled: boolean): string {
+  if (!isV2JitLiquidityInfoEnabled) {
+    return apiUrl;
+  }
+
+  return apiUrl.replace(/\/v1\/?$/, "/v2");
 }

--- a/src/domain/synthetics/jit/useJitLiquidityRequest.ts
+++ b/src/domain/synthetics/jit/useJitLiquidityRequest.ts
@@ -18,14 +18,14 @@ export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { en
     enabled ? ["jitLiquidity", chainId, isV2JitLiquidityInfoEnabled ? "v2" : "v1"] : null,
     async () => {
       try {
-        const apiUrl = getApiUrl(chainId);
+        const apiVersion = isV2JitLiquidityInfoEnabled ? "v2" : "v1";
+        const apiUrl = getApiUrl(chainId, apiVersion);
 
         if (!apiUrl) {
           return undefined;
         }
 
-        const jitApiUrl = getJitApiUrl(apiUrl, isV2JitLiquidityInfoEnabled);
-        const res = await fetch(`${jitApiUrl}/jit/liquidity_info`);
+        const res = await fetch(`${apiUrl}/jit/liquidity_info`);
         const response = await res.json();
 
         return parseJitLiquidityResponse(response, isV2JitLiquidityInfoEnabled);
@@ -46,12 +46,4 @@ export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { en
     }),
     [data]
   );
-}
-
-function getJitApiUrl(apiUrl: string, isV2JitLiquidityInfoEnabled: boolean): string {
-  if (!isV2JitLiquidityInfoEnabled) {
-    return apiUrl;
-  }
-
-  return apiUrl.replace(/\/v1\/?$/, "/v2");
 }

--- a/src/domain/synthetics/jit/useJitLiquidityRequest.ts
+++ b/src/domain/synthetics/jit/useJitLiquidityRequest.ts
@@ -4,15 +4,18 @@ import useSWR from "swr";
 import { getApiUrl } from "sdk/configs/api";
 import type { ContractsChainId } from "sdk/configs/chains";
 
-import { JitLiquidityData, JitLiquidityInfo, safeParseBigInt } from "./utils";
+import { JitLiquidityData, JitLiquidityInfo, parseJitLiquidityResponse } from "./utils";
+import { getIsV2JitLiquidityInfoEnabled, useUiFlagsRequest } from "../uiFlags/useUiFlagsRequest";
 
 const JIT_LIQUIDITY_UPDATE_INTERVAL = 30 * 1000;
 
 export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { enabled?: boolean }): JitLiquidityData {
   const enabled = options?.enabled !== false;
+  const { uiFlags } = useUiFlagsRequest(chainId);
+  const isV2JitLiquidityInfoEnabled = getIsV2JitLiquidityInfoEnabled(uiFlags);
 
   const { data } = useSWR<Record<string, JitLiquidityInfo> | undefined>(
-    enabled ? ["jitLiquidity", chainId] : null,
+    enabled ? ["jitLiquidity", chainId, isV2JitLiquidityInfoEnabled ? "v2" : "v1"] : null,
     async () => {
       try {
         const apiUrl = getApiUrl(chainId);
@@ -21,29 +24,11 @@ export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { en
           return undefined;
         }
 
-        const res = await fetch(`${apiUrl}/jit/liquidity_info`);
+        const jitApiUrl = getJitApiUrl(apiUrl, isV2JitLiquidityInfoEnabled);
+        const res = await fetch(`${jitApiUrl}/jit/liquidity_info`);
         const response = await res.json();
 
-        const result: Record<string, JitLiquidityInfo> = {};
-
-        for (const info of response.liquidityInfos) {
-          const marketKey = info.market.toLowerCase();
-
-          result[marketKey] = {
-            maxReservedUsdWithJitLong: safeParseBigInt(info.maxReservedUsdWithJitLong),
-            maxReservedUsdWithJitShort: safeParseBigInt(info.maxReservedUsdWithJitShort),
-            glvShiftParams: (info.glvShiftParams ?? []).map((param: any) => ({
-              glv: param.glv,
-              fromMarket: param.fromMarket,
-              toMarket: param.toMarket,
-              marketTokenAmount: safeParseBigInt(param.marketTokenAmount),
-              minMarketTokens: safeParseBigInt(param.minMarketTokens),
-            })),
-            glv: info.glv,
-          };
-        }
-
-        return result;
+        return parseJitLiquidityResponse(response, isV2JitLiquidityInfoEnabled);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error("Failed to fetch JIT liquidity data", e);
@@ -61,4 +46,12 @@ export function useJitLiquidityRequest(chainId: ContractsChainId, options?: { en
     }),
     [data]
   );
+}
+
+function getJitApiUrl(apiUrl: string, isV2JitLiquidityInfoEnabled: boolean): string {
+  if (!isV2JitLiquidityInfoEnabled) {
+    return apiUrl;
+  }
+
+  return apiUrl.replace(/\/v1\/?$/, "/v2");
 }

--- a/src/domain/synthetics/jit/utils.spec.ts
+++ b/src/domain/synthetics/jit/utils.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { getJitGlvShiftParams, parseJitLiquidityResponse } from "./utils";
+
+describe("parseJitLiquidityResponse", () => {
+  it("parses v1 JIT liquidity info", () => {
+    const result = parseJitLiquidityResponse(
+      {
+        liquidityInfos: [
+          {
+            glv: "0xGlv",
+            market: "0xMarket",
+            maxReservedUsdWithJitLong: "100",
+            maxReservedUsdWithJitShort: "200",
+            glvShiftParams: [
+              {
+                glv: "0xGlv",
+                fromMarket: "0xFrom",
+                toMarket: "0xMarket",
+                marketTokenAmount: "10",
+                minMarketTokens: "9",
+              },
+            ],
+          },
+        ],
+      },
+      false
+    );
+
+    expect(result["0xmarket"]).toEqual({
+      glv: "0xGlv",
+      maxReservedUsdWithJitLong: 100n,
+      maxReservedUsdWithJitShort: 200n,
+      glvShiftParams: [
+        {
+          glv: "0xGlv",
+          fromMarket: "0xFrom",
+          toMarket: "0xMarket",
+          marketTokenAmount: 10n,
+          minMarketTokens: 9n,
+        },
+      ],
+      glvShiftParamsLong: [
+        {
+          glv: "0xGlv",
+          fromMarket: "0xFrom",
+          toMarket: "0xMarket",
+          marketTokenAmount: 10n,
+          minMarketTokens: 9n,
+        },
+      ],
+      glvShiftParamsShort: [
+        {
+          glv: "0xGlv",
+          fromMarket: "0xFrom",
+          toMarket: "0xMarket",
+          marketTokenAmount: 10n,
+          minMarketTokens: 9n,
+        },
+      ],
+    });
+  });
+
+  it("parses v2 JIT liquidity info with direction-specific shift params", () => {
+    const result = parseJitLiquidityResponse(
+      {
+        liquidityInfos: [
+          {
+            glv: "0xGlv",
+            market: "0xMarket",
+            long: {
+              maxReservedUsd: "300",
+              glvShiftParams: {
+                glv: "0xGlv",
+                fromMarket: "0xLongFrom",
+                toMarket: "0xMarket",
+                marketTokenAmount: "30",
+                minMarketTokens: "29",
+              },
+            },
+            short: {
+              maxReservedUsd: "400",
+              glvShiftParams: {
+                glv: "0xGlv",
+                fromMarket: "0xShortFrom",
+                toMarket: "0xMarket",
+                marketTokenAmount: "40",
+                minMarketTokens: "39",
+              },
+            },
+          },
+        ],
+      },
+      true
+    );
+
+    expect(result["0xmarket"].maxReservedUsdWithJitLong).toBe(300n);
+    expect(result["0xmarket"].maxReservedUsdWithJitShort).toBe(400n);
+    expect(getJitGlvShiftParams(result, "0xMarket", true)).toEqual([
+      {
+        glv: "0xGlv",
+        fromMarket: "0xLongFrom",
+        toMarket: "0xMarket",
+        marketTokenAmount: 30n,
+        minMarketTokens: 29n,
+      },
+    ]);
+    expect(getJitGlvShiftParams(result, "0xMarket", false)).toEqual([
+      {
+        glv: "0xGlv",
+        fromMarket: "0xShortFrom",
+        toMarket: "0xMarket",
+        marketTokenAmount: 40n,
+        minMarketTokens: 39n,
+      },
+    ]);
+  });
+});

--- a/src/domain/synthetics/jit/utils.spec.ts
+++ b/src/domain/synthetics/jit/utils.spec.ts
@@ -27,7 +27,7 @@ describe("parseJitLiquidityResponse", () => {
       false
     );
 
-    expect(result["0xmarket"]).toEqual({
+    expect(result["0xMarket"]).toEqual({
       glv: "0xGlv",
       maxReservedUsdWithJitLong: 100n,
       maxReservedUsdWithJitShort: 200n,
@@ -94,8 +94,8 @@ describe("parseJitLiquidityResponse", () => {
       true
     );
 
-    expect(result["0xmarket"].maxReservedUsdWithJitLong).toBe(300n);
-    expect(result["0xmarket"].maxReservedUsdWithJitShort).toBe(400n);
+    expect(result["0xMarket"].maxReservedUsdWithJitLong).toBe(300n);
+    expect(result["0xMarket"].maxReservedUsdWithJitShort).toBe(400n);
     expect(getJitGlvShiftParams(result, "0xMarket", true)).toEqual([
       {
         glv: "0xGlv",

--- a/src/domain/synthetics/jit/utils.ts
+++ b/src/domain/synthetics/jit/utils.ts
@@ -9,6 +9,8 @@ export type GlvShiftParam = {
 export type JitLiquidityInfo = {
   maxReservedUsdWithJitLong: bigint;
   maxReservedUsdWithJitShort: bigint;
+  glvShiftParamsLong: GlvShiftParam[];
+  glvShiftParamsShort: GlvShiftParam[];
   glvShiftParams: GlvShiftParam[];
   glv: string;
 };
@@ -33,7 +35,138 @@ export function getJitMaxReservedUsd(
   return isLong ? info?.maxReservedUsdWithJitLong : info?.maxReservedUsdWithJitShort;
 }
 
+export function getJitGlvShiftParams(
+  jitLiquidityMap: Record<string, JitLiquidityInfo> | undefined,
+  marketTokenAddress: string,
+  isLong: boolean
+): GlvShiftParam[] | undefined {
+  const info = getJitLiquidityInfo(jitLiquidityMap, marketTokenAddress);
+
+  if (!info) {
+    return undefined;
+  }
+
+  return isLong ? info.glvShiftParamsLong : info.glvShiftParamsShort;
+}
+
 export function safeParseBigInt(value: string): bigint {
   const parsed = BigInt(value);
   return parsed < 0n ? 0n : parsed;
+}
+
+export function parseJitLiquidityResponse(
+  response: unknown,
+  isV2JitLiquidityInfoEnabled: boolean
+): Record<string, JitLiquidityInfo> {
+  const liquidityInfos = getLiquidityInfos(response);
+  const result: Record<string, JitLiquidityInfo> = {};
+
+  for (const rawInfo of liquidityInfos) {
+    if (!isRecord(rawInfo)) {
+      continue;
+    }
+
+    const market = getString(rawInfo.market);
+
+    if (!market) {
+      continue;
+    }
+
+    if (isV2JitLiquidityInfoEnabled) {
+      result[market.toLowerCase()] = parseV2JitLiquidityInfo(rawInfo);
+      continue;
+    }
+
+    result[market.toLowerCase()] = parseV1JitLiquidityInfo(rawInfo);
+  }
+
+  return result;
+}
+
+function parseV1JitLiquidityInfo(rawInfo: Record<string, unknown>): JitLiquidityInfo {
+  const glvShiftParams = parseGlvShiftParams(rawInfo.glvShiftParams);
+
+  return {
+    maxReservedUsdWithJitLong: parseBigIntField(rawInfo.maxReservedUsdWithJitLong),
+    maxReservedUsdWithJitShort: parseBigIntField(rawInfo.maxReservedUsdWithJitShort),
+    glvShiftParamsLong: glvShiftParams,
+    glvShiftParamsShort: glvShiftParams,
+    glvShiftParams,
+    glv: getString(rawInfo.glv) ?? "",
+  };
+}
+
+function parseV2JitLiquidityInfo(rawInfo: Record<string, unknown>): JitLiquidityInfo {
+  const longInfo = getRecord(rawInfo.long);
+  const shortInfo = getRecord(rawInfo.short);
+
+  if (!longInfo && !shortInfo) {
+    return parseV1JitLiquidityInfo(rawInfo);
+  }
+
+  const glvShiftParamsLong = parseGlvShiftParams(longInfo?.glvShiftParams ?? rawInfo.glvShiftParams);
+  const glvShiftParamsShort = parseGlvShiftParams(shortInfo?.glvShiftParams ?? rawInfo.glvShiftParams);
+
+  return {
+    maxReservedUsdWithJitLong: parseBigIntField(longInfo?.maxReservedUsd ?? rawInfo.maxReservedUsdWithJitLong),
+    maxReservedUsdWithJitShort: parseBigIntField(shortInfo?.maxReservedUsd ?? rawInfo.maxReservedUsdWithJitShort),
+    glvShiftParamsLong,
+    glvShiftParamsShort,
+    glvShiftParams: [...glvShiftParamsLong, ...glvShiftParamsShort],
+    glv: getString(rawInfo.glv) ?? "",
+  };
+}
+
+function getLiquidityInfos(response: unknown): unknown[] {
+  if (!isRecord(response)) {
+    return [];
+  }
+
+  const liquidityInfos = response.liquidityInfos ?? response.v2JitLiquidityInfos ?? response.v2JITLiquidityInfos;
+
+  return Array.isArray(liquidityInfos) ? liquidityInfos : [];
+}
+
+function parseGlvShiftParams(value: unknown): GlvShiftParam[] {
+  const rawParams = Array.isArray(value) ? value : value ? [value] : [];
+
+  return rawParams.map(parseGlvShiftParam).filter((param): param is GlvShiftParam => param !== undefined);
+}
+
+function parseGlvShiftParam(value: unknown): GlvShiftParam | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const glv = getString(value.glv);
+  const fromMarket = getString(value.fromMarket);
+  const toMarket = getString(value.toMarket);
+
+  if (!glv || !fromMarket || !toMarket) {
+    return undefined;
+  }
+
+  return {
+    glv,
+    fromMarket,
+    toMarket,
+    marketTokenAmount: parseBigIntField(value.marketTokenAmount),
+    minMarketTokens: parseBigIntField(value.minMarketTokens),
+  };
+}
+
+function parseBigIntField(value: unknown): bigint {
+  return typeof value === "string" ? safeParseBigInt(value) : 0n;
+}
+
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/src/domain/synthetics/jit/utils.ts
+++ b/src/domain/synthetics/jit/utils.ts
@@ -49,7 +49,11 @@ export function getJitGlvShiftParams(
   return isLong ? info.glvShiftParamsLong : info.glvShiftParamsShort;
 }
 
-export function safeParseBigInt(value: string): bigint {
+export function safeParseBigInt(value: unknown): bigint {
+  if (typeof value !== "string") {
+    return 0n;
+  }
+
   const parsed = BigInt(value);
   return parsed < 0n ? 0n : parsed;
 }
@@ -87,8 +91,8 @@ function parseV1JitLiquidityInfo(rawInfo: Record<string, unknown>): JitLiquidity
   const glvShiftParams = parseGlvShiftParams(rawInfo.glvShiftParams);
 
   return {
-    maxReservedUsdWithJitLong: parseBigIntField(rawInfo.maxReservedUsdWithJitLong),
-    maxReservedUsdWithJitShort: parseBigIntField(rawInfo.maxReservedUsdWithJitShort),
+    maxReservedUsdWithJitLong: safeParseBigInt(rawInfo.maxReservedUsdWithJitLong),
+    maxReservedUsdWithJitShort: safeParseBigInt(rawInfo.maxReservedUsdWithJitShort),
     glvShiftParamsLong: glvShiftParams,
     glvShiftParamsShort: glvShiftParams,
     glvShiftParams,
@@ -108,8 +112,8 @@ function parseV2JitLiquidityInfo(rawInfo: Record<string, unknown>): JitLiquidity
   const glvShiftParamsShort = parseGlvShiftParams(shortInfo?.glvShiftParams ?? rawInfo.glvShiftParams);
 
   return {
-    maxReservedUsdWithJitLong: parseBigIntField(longInfo?.maxReservedUsd ?? rawInfo.maxReservedUsdWithJitLong),
-    maxReservedUsdWithJitShort: parseBigIntField(shortInfo?.maxReservedUsd ?? rawInfo.maxReservedUsdWithJitShort),
+    maxReservedUsdWithJitLong: safeParseBigInt(longInfo?.maxReservedUsd ?? rawInfo.maxReservedUsdWithJitLong),
+    maxReservedUsdWithJitShort: safeParseBigInt(shortInfo?.maxReservedUsd ?? rawInfo.maxReservedUsdWithJitShort),
     glvShiftParamsLong,
     glvShiftParamsShort,
     glvShiftParams: [...glvShiftParamsLong, ...glvShiftParamsShort],
@@ -150,13 +154,9 @@ function parseGlvShiftParam(value: unknown): GlvShiftParam | undefined {
     glv,
     fromMarket,
     toMarket,
-    marketTokenAmount: parseBigIntField(value.marketTokenAmount),
-    minMarketTokens: parseBigIntField(value.minMarketTokens),
+    marketTokenAmount: safeParseBigInt(value.marketTokenAmount),
+    minMarketTokens: safeParseBigInt(value.minMarketTokens),
   };
-}
-
-function parseBigIntField(value: unknown): bigint {
-  return typeof value === "string" ? safeParseBigInt(value) : 0n;
 }
 
 function getRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/domain/synthetics/jit/utils.ts
+++ b/src/domain/synthetics/jit/utils.ts
@@ -23,7 +23,7 @@ export function getJitLiquidityInfo(
   jitLiquidityMap: Record<string, JitLiquidityInfo> | undefined,
   marketTokenAddress: string
 ): JitLiquidityInfo | undefined {
-  return jitLiquidityMap?.[marketTokenAddress.toLowerCase()];
+  return jitLiquidityMap?.[marketTokenAddress];
 }
 
 export function getJitMaxReservedUsd(
@@ -76,12 +76,7 @@ export function parseJitLiquidityResponse(
       continue;
     }
 
-    if (isV2JitLiquidityInfoEnabled) {
-      result[market.toLowerCase()] = parseV2JitLiquidityInfo(rawInfo);
-      continue;
-    }
-
-    result[market.toLowerCase()] = parseV1JitLiquidityInfo(rawInfo);
+    result[market] = isV2JitLiquidityInfoEnabled ? parseV2JitLiquidityInfo(rawInfo) : parseV1JitLiquidityInfo(rawInfo);
   }
 
   return result;

--- a/src/domain/synthetics/uiFlags/useUiFlagsRequest.ts
+++ b/src/domain/synthetics/uiFlags/useUiFlagsRequest.ts
@@ -6,6 +6,12 @@ import { CONFIG_UPDATE_INTERVAL } from "lib/timeConstants";
 
 export type UiFlags = Record<string, boolean>;
 
+export const IS_V2_JIT_LIQUIDITY_INFO_ENABLED_UI_FLAG = "isV2JitLiquidityInfoEnabled";
+
+export function getIsV2JitLiquidityInfoEnabled(uiFlags: UiFlags | undefined): boolean {
+  return uiFlags?.[IS_V2_JIT_LIQUIDITY_INFO_ENABLED_UI_FLAG] === true;
+}
+
 export function useUiFlagsRequest() {
   const { chainId } = useChainId();
   const oracleKeeperFetcher = useOracleKeeperFetcher(chainId);

--- a/src/domain/synthetics/uiFlags/useUiFlagsRequest.ts
+++ b/src/domain/synthetics/uiFlags/useUiFlagsRequest.ts
@@ -9,7 +9,7 @@ export type UiFlags = Record<string, boolean>;
 export const IS_V2_JIT_LIQUIDITY_INFO_ENABLED_UI_FLAG = "isV2JitLiquidityInfoEnabled";
 
 export function getIsV2JitLiquidityInfoEnabled(uiFlags: UiFlags | undefined): boolean {
-  return uiFlags?.[IS_V2_JIT_LIQUIDITY_INFO_ENABLED_UI_FLAG] === true;
+  return uiFlags?.[IS_V2_JIT_LIQUIDITY_INFO_ENABLED_UI_FLAG] !== false;
 }
 
 export function useUiFlagsRequest() {

--- a/src/domain/synthetics/uiFlags/useUiFlagsRequest.ts
+++ b/src/domain/synthetics/uiFlags/useUiFlagsRequest.ts
@@ -1,17 +1,25 @@
 import useSWR from "swr";
 
+import type { ContractsChainId } from "config/chains";
 import { useChainId } from "lib/chains";
 import { useOracleKeeperFetcher } from "lib/oracleKeeperFetcher";
 import { CONFIG_UPDATE_INTERVAL } from "lib/timeConstants";
 
 export type UiFlags = Record<string, boolean>;
 
-export function useUiFlagsRequest() {
+export const IS_V2_JIT_LIQUIDITY_INFO_ENABLED_UI_FLAG = "isV2JitLiquidityInfoEnabled";
+
+export function getIsV2JitLiquidityInfoEnabled(uiFlags: UiFlags | undefined): boolean {
+  return uiFlags?.[IS_V2_JIT_LIQUIDITY_INFO_ENABLED_UI_FLAG] === true;
+}
+
+export function useUiFlagsRequest(chainIdOverride?: ContractsChainId) {
   const { chainId } = useChainId();
-  const oracleKeeperFetcher = useOracleKeeperFetcher(chainId);
+  const requestChainId = chainIdOverride ?? chainId;
+  const oracleKeeperFetcher = useOracleKeeperFetcher(requestChainId);
 
   const { data: uiFlags } = useSWR<UiFlags>(
-    ["uiFlags", chainId],
+    ["uiFlags", requestChainId],
     async () => {
       return oracleKeeperFetcher.fetchUiFlags();
     },


### PR DESCRIPTION
## Summary
- Add UI flag control for `isV2JitLiquidityInfoEnabled`.
- Switch JIT liquidity fetching from `/v1/jit/liquidity_info` to `/v2/jit/liquidity_info` when the flag is enabled.
- Parse v2 direction-specific `long` / `short` liquidity info and pass the matching JIT GLV shift params into order simulation.
- Cover v1 and v2 JIT liquidity parsing with unit tests.

## Root Cause
The UI only understood the v1 JIT liquidity response shape. The v2 endpoint nests liquidity and shift params by direction, so the parser and transaction simulation path needed to become version-aware.

Ticket: [FEDEV-3885](https://linear.app/gmx-io/issue/FEDEV-3885/support-v2jitliquidity-info-in-ui)
