### PR TITLE
Hotfix remove Privy backdrop transition

### DIFF
--- a/src/App/App.scss
+++ b/src/App/App.scss
@@ -1071,6 +1071,10 @@ button.App-button {
   max-height: 50vh;
 }
 
+#privy-dialog-backdrop {
+  transition: none !important;
+}
+
 * {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
## Summary
- Adds a forced CSS override for `#privy-dialog-backdrop` to disable backdrop transitions.

## Root cause
Privy owns the generated modal backdrop DOM and styles, so the app needs a global override for the generated backdrop element.

## Impact
The Privy modal backdrop no longer animates its transition while the rest of the modal behavior remains unchanged.

## Validation
- `yarn exec prettier --check src/App/App.scss`
- Commit hook: staged CSS formatter and `yarn tscheck`
- Push hook: app/sdk Vitest suite and Playwright component tests passed
