### PR TITLE
[TEST] Net Rates Chart: snapshot rates diverge from live rates by a large margin FEDEV-3792

### DIFF
--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -22,7 +22,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-arbitrum-referrals/master-240506225935-51167d5/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-250410222518-4486206/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@5eaa69/api/graphql",
+    subsquid: "https://gmx-test.squids.live/gmx-synthetics-arbitrum@netrts/api/graphql",
   },
 
   [AVALANCHE]: {

--- a/src/domain/synthetics/markets/useRateSnapshots.ts
+++ b/src/domain/synthetics/markets/useRateSnapshots.ts
@@ -1,19 +1,55 @@
+import { gql } from "@apollo/client";
 import useSWR from "swr";
 
-import { useGmxSdk } from "context/GmxSdkContext/GmxSdkContext";
 import { selectChainId } from "context/SyntheticsStateContext/selectors/globalSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
-import { ApiParameterPeriod, MarketRates, RatesSnapshot } from "sdk/utils/rates/types";
+import { getSubsquidGraphClient } from "lib/indexers";
+import { MarketRates, RatesSnapshot } from "sdk/utils/rates/types";
 
 export type RateTimeframe = "1d" | "7d" | "30d";
 
-const TIMEFRAME_TO_PERIOD: Record<RateTimeframe, ApiParameterPeriod> = {
-  "1d": "1d",
-  "7d": "7d",
-  "30d": "30d",
+const TIMEFRAME_TO_SECONDS: Record<RateTimeframe, number> = {
+  "1d": 86400,
+  "7d": 86400 * 7,
+  "30d": 86400 * 30,
+};
+
+const TIMEFRAME_TO_AVERAGE_BY: Record<RateTimeframe, string | undefined> = {
+  "1d": undefined,
+  "7d": "1d",
+  "30d": "1d",
 };
 
 const REFRESH_INTERVAL = 5 * 60 * 1000;
+
+const MARKETS_NET_RATES_QUERY = gql`
+  query MarketsNetRatesByPeriod(
+    $periodStart: Float!
+    $periodEnd: Float!
+    $marketAddresses: [String!]
+    $averageBy: String
+  ) {
+    marketsNetRatesByPeriod(
+      where: {
+        periodStart: $periodStart
+        periodEnd: $periodEnd
+        marketAddresses: $marketAddresses
+        averageBy: $averageBy
+      }
+    ) {
+      marketAddress
+      ratesSnapshots {
+        netRateLong
+        netRateShort
+        fundingRateLong
+        fundingRateShort
+        borrowingRateLong
+        borrowingRateShort
+        timestamp
+      }
+    }
+  }
+`;
 
 export function useRateSnapshots({
   marketAddress,
@@ -23,22 +59,33 @@ export function useRateSnapshots({
   timeframe: RateTimeframe;
 }) {
   const chainId = useSelector(selectChainId);
-  const sdk = useGmxSdk(chainId);
+  const client = getSubsquidGraphClient(chainId);
 
-  const swrKey = sdk && marketAddress ? ["useRateSnapshots", chainId, marketAddress, timeframe] : null;
+  const swrKey = client && marketAddress ? ["useRateSnapshots", chainId, marketAddress, timeframe] : null;
 
   const { data, isLoading, error } = useSWR<RatesSnapshot[] | undefined>(swrKey, {
     fetcher: async () => {
-      const result: MarketRates[] = await sdk!.fetchRates({
-        period: TIMEFRAME_TO_PERIOD[timeframe],
-        address: marketAddress,
+      if (!client || !marketAddress) return [];
+
+      const periodEnd = Math.floor(Date.now() / 1000);
+      const periodStart = periodEnd - TIMEFRAME_TO_SECONDS[timeframe];
+
+      const response = await client.query<{ marketsNetRatesByPeriod: MarketRates[] }>({
+        query: MARKETS_NET_RATES_QUERY,
+        variables: {
+          periodStart,
+          periodEnd,
+          marketAddresses: [marketAddress],
+          averageBy: TIMEFRAME_TO_AVERAGE_BY[timeframe],
+        },
+        fetchPolicy: "no-cache",
       });
 
-      const marketData = result.find((r) => r.marketAddress.toLowerCase() === marketAddress!.toLowerCase());
+      const marketData = (response.data?.marketsNetRatesByPeriod ?? []).find(
+        (r) => r.marketAddress.toLowerCase() === marketAddress.toLowerCase()
+      );
 
-      if (!marketData) {
-        return [];
-      }
+      if (!marketData) return [];
 
       return [...marketData.ratesSnapshots].reverse();
     },
@@ -47,7 +94,7 @@ export function useRateSnapshots({
 
   return {
     snapshots: data,
-    isLoading: isLoading || (!swrKey && sdk !== undefined),
+    isLoading,
     error,
   };
 }


### PR DESCRIPTION
## Summary
- Switches the Arbitrum subsquid endpoint to a test deployment (`gmx-test.squids.live/gmx-synthetics-arbitrum@netrts`) so we can verify the Squid-side fix for net/funding/borrowing rate snapshot divergence on the Net Rates chart.
- Test-only PR — **do not merge**. Linear: https://linear.app/gmx-io/issue/FEDEV-3792

## Test plan
- [ ] Open the chart on BRENTOIL/USD (and a couple of other markets — at least one crypto and one RWA).
- [ ] Switch to the Net Rate tab, select 1Y, hover the most recent hourly snapshot.
- [ ] Confirm the 1Y long/short values in the hover tooltip are within minor drift (<~1%) of the 365d values in the market dropdown header.
- [ ] Repeat for Funding Rate and Borrowing Rate rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)