### PR TITLE
Add new tag to pools FEDEV-3868

### DIFF
--- a/src/components/AnimatedGradientText/AnimatedGradientText.scss
+++ b/src/components/AnimatedGradientText/AnimatedGradientText.scss
@@ -1,0 +1,32 @@
+@property --animated-gradient-text-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 160.6deg;
+}
+
+.animated-gradient-text {
+  --animated-gradient-text-angle: 160.6deg;
+  background: linear-gradient(
+    var(--animated-gradient-text-angle),
+    var(--color-blue-100) 0%,
+    var(--color-blue-400) 100%
+  );
+  background-size: 100% 86px;
+  background-position: 0 -15px;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: animated-gradient-text-rotate 4s linear infinite;
+  -webkit-text-fill-color: transparent;
+  stroke-width: 0%;
+}
+
+@keyframes animated-gradient-text-rotate {
+  to {
+    --animated-gradient-text-angle: 520.6deg;
+  }
+}
+
+.image-capture-in-progress .animated-gradient-text {
+  animation: none !important;
+}

--- a/src/components/AnimatedGradientText/AnimatedGradientText.tsx
+++ b/src/components/AnimatedGradientText/AnimatedGradientText.tsx
@@ -1,0 +1,12 @@
+import cx from "classnames";
+
+import "./AnimatedGradientText.scss";
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function AnimatedGradientText({ children, className }: Props) {
+  return <span className={cx("animated-gradient-text", className)}>{children}</span>;
+}

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -446,8 +446,8 @@ function MarketsList() {
         <table className="text-body-small w-full border-separate border-spacing-0">
           <thead>
             <tr>
-              <th></th>
-              <th className={cx(thClassName, "pl-4", isMobile ? "min-w-[18ch]" : "min-w-[28ch]")} colSpan={2}>
+              <th colSpan={1}></th>
+              <th className={cx(thClassName, "pl-4", isMobile ? "min-w-[18ch]" : "min-w-[28ch]")} colSpan={1}>
                 <Trans>MARKET</Trans>
               </th>
               {isSwap ? (

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -50,9 +50,8 @@ import { convertTokenAddress, getTokenVisualMultiplier, isChartAvailableForToken
 
 import Button from "components/Button/Button";
 import { EmptyTableContent } from "components/EmptyTableContent/EmptyTableContent";
-import FavoriteStar from "components/FavoriteStar/FavoriteStar";
 import { FavoriteTabs } from "components/FavoriteTabs/FavoriteTabs";
-import { RecentlyListedBadge } from "components/FavoriteTabs/RecentlyListedBadge";
+import { RecentlyListedFavoriteSlot } from "components/FavoriteTabs/RecentlyListedFavoriteSlot";
 import SearchInput from "components/SearchInput/SearchInput";
 import { Sorter, useSorterHandlers } from "components/Sorter/Sorter";
 import { ButtonRowScrollFadeContainer } from "components/TableScrollFade/TableScrollFade";
@@ -350,7 +349,7 @@ function MarketsList() {
     [chooseSuitableMarket, close, isSwap, tradeType]
   );
 
-  const rowVerticalPadding = cx("px-12 py-10", {
+  const rowVerticalPadding = cx("px-12 py-4", {
     "group-last-of-type/row:pb-8": !isMobile,
   });
   const rowHorizontalPadding = cx("pr-8");
@@ -358,7 +357,8 @@ function MarketsList() {
     "sticky top-0 z-10 whitespace-nowrap bg-slate-900 text-left text-[11px] font-medium uppercase text-typography-secondary",
     "first-of-type:text-left",
     rowVerticalPadding,
-    rowHorizontalPadding
+    rowHorizontalPadding,
+    "!py-10"
   );
 
   const tdClassName = cx(
@@ -446,7 +446,8 @@ function MarketsList() {
         <table className="text-body-small w-full border-separate border-spacing-0">
           <thead>
             <tr>
-              <th className={cx(thClassName, isMobile ? "min-w-[18ch]" : "min-w-[28ch]")} colSpan={2}>
+              <th></th>
+              <th className={cx(thClassName, "pl-4", isMobile ? "min-w-[18ch]" : "min-w-[28ch]")} colSpan={2}>
                 <Trans>MARKET</Trans>
               </th>
               {isSwap ? (
@@ -693,7 +694,7 @@ function MarketListItem({
   const { maxLongLiquidityPool, maxShortLiquidityPool } = getMaxLongShortLiquidityPool(token);
 
   const handleFavoriteClick = useCallback(
-    (e: React.MouseEvent<HTMLTableCellElement>) => {
+    (e: React.MouseEvent) => {
       e.stopPropagation();
       onFavorite(token.address);
     },
@@ -736,15 +737,15 @@ function MarketListItem({
       </div>
     );
   }, [dayPriceDelta]);
+  const isRecentlyListed = isMarketRecentlyListed(listingDate, Date.now());
 
   if (isSwap) {
     return (
       <tr key={token.symbol} className="group/row cursor-pointer hover:bg-fill-surfaceHover">
-        <td
-          className={cx("pl-14 pr-6 text-center text-typography-secondary", rowVerticalPadding)}
-          onClick={handleFavoriteClick}
-        >
-          <FavoriteStar isFavorite={isFavorite} className="!size-12" />
+        <td className={cx("pl-14 pr-0 text-center text-typography-secondary", rowVerticalPadding)}>
+          <Button variant="ghost" className="!h-20 !min-h-32 !w-32 !p-0" onClick={handleFavoriteClick}>
+            <RecentlyListedFavoriteSlot isRecentlyListed={isRecentlyListed} isFavorite={isFavorite} />
+          </Button>
         </td>
         <td
           className={cx("text-body-medium w-full", rowVerticalPadding, rowHorizontalPadding)}
@@ -754,7 +755,6 @@ function MarketListItem({
             <TokenIcon className="ChartToken-list-icon -my-5 mr-6" symbol={token.symbol} displaySize={16} />
             <span>{token.name}</span>
             <span className="font-medium text-typography-secondary">{token.symbol}</span>
-            {isMarketRecentlyListed(listingDate, Date.now()) && <RecentlyListedBadge />}
           </span>
         </td>
         <td className={tdClassName}>
@@ -778,11 +778,10 @@ function MarketListItem({
       className="group/row cursor-pointer hover:bg-fill-surfaceHover"
       onClick={handleSelectLargePosition}
     >
-      <td
-        className={cx("w-0 px-12 text-center text-typography-secondary", rowVerticalPadding)}
-        onClick={handleFavoriteClick}
-      >
-        <FavoriteStar isFavorite={isFavorite} className="!size-12" />
+      <td className={cx("w-0 px-12 pr-0 text-center text-typography-secondary", rowVerticalPadding)}>
+        <Button variant="ghost" className="!h-32 !min-h-32 !w-32 !p-0" onClick={handleFavoriteClick}>
+          <RecentlyListedFavoriteSlot isRecentlyListed={isRecentlyListed} isFavorite={isFavorite} />
+        </Button>
       </td>
       <td className={cx("pl-4 text-[13px]", rowVerticalPadding, isMobile ? "pr-2" : "pr-8")}>
         <div className={cx("flex", isMobile ? "items-start" : "items-center")}>
@@ -794,7 +793,6 @@ function MarketListItem({
             <span className="rounded-full bg-slate-700 px-6 py-[1.5px] text-12 font-medium leading-[1.25] text-typography-secondary numbers">
               {maxLeverage ? `${maxLeverage}x` : "-"}
             </span>
-            {isMarketRecentlyListed(listingDate, Date.now()) && <RecentlyListedBadge />}
           </span>
         </div>
       </td>

--- a/src/components/FavoriteTabs/RecentlyListedBadge.tsx
+++ b/src/components/FavoriteTabs/RecentlyListedBadge.tsx
@@ -1,9 +1,14 @@
 import { Trans } from "@lingui/macro";
+import cx from "classnames";
 
-export function RecentlyListedBadge() {
+import { AnimatedGradientText } from "components/AnimatedGradientText/AnimatedGradientText";
+
+export function RecentlyListedBadge({ className }: { className?: string }) {
   return (
-    <span className="inline-flex items-center gap-3 rounded-4 py-2 text-12 font-medium text-blue-300">
+    <AnimatedGradientText
+      className={cx("inline-flex items-center gap-3 rounded-4 py-2 text-12 font-medium", className)}
+    >
       <Trans>New</Trans>
-    </span>
+    </AnimatedGradientText>
   );
 }

--- a/src/components/FavoriteTabs/RecentlyListedFavoriteSlot.tsx
+++ b/src/components/FavoriteTabs/RecentlyListedFavoriteSlot.tsx
@@ -1,0 +1,30 @@
+import cx from "classnames";
+
+import FavoriteStar from "components/FavoriteStar/FavoriteStar";
+
+import { RecentlyListedBadge } from "./RecentlyListedBadge";
+
+type Props = {
+  isRecentlyListed: boolean;
+  isFavorite: boolean | undefined;
+  starClassName?: string;
+};
+
+export function RecentlyListedFavoriteSlot({ isRecentlyListed, isFavorite, starClassName }: Props) {
+  if (!isRecentlyListed) {
+    return <FavoriteStar isFavorite={isFavorite} className={starClassName} />;
+  }
+
+  return (
+    <span className="relative inline-flex h-16 min-w-32 items-center justify-center">
+      <RecentlyListedBadge className="transition-opacity group-hover/row:opacity-0 group-hover/tr:opacity-0" />
+      <FavoriteStar
+        isFavorite={isFavorite}
+        className={cx(
+          "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/row:opacity-100 group-hover/tr:opacity-100",
+          starClassName
+        )}
+      />
+    </span>
+  );
+}

--- a/src/components/GmList/GmList.tsx
+++ b/src/components/GmList/GmList.tsx
@@ -23,6 +23,7 @@ import { PerformanceData } from "domain/synthetics/markets/usePerformanceAnnuali
 import { PerformanceSnapshotsData } from "domain/synthetics/markets/usePerformanceSnapshots";
 import { useUserEarnings } from "domain/synthetics/markets/useUserEarnings";
 import { useLocalizedMap } from "lib/i18n";
+import { getByKey } from "lib/objects";
 import useWallet from "lib/wallets/useWallet";
 import PoolsCard from "pages/Pools/PoolsCard";
 import { usePoolsIsMobilePage } from "pages/Pools/usePoolsIsMobilePage";
@@ -179,6 +180,14 @@ export function GmList({
   const rows =
     currentData.length > 0 &&
     currentData.map((token) => {
+      const market = getByKey(marketsInfo, token.address);
+      const isRecentlyListed = Boolean(
+        market &&
+          !market.isSpotOnly &&
+          !market.isDisabled &&
+          recentlyListedAddressesSet.has(market.indexTokenAddress.toLowerCase())
+      );
+
       return (
         <GmListItem
           key={token.address}
@@ -192,6 +201,7 @@ export function GmList({
           performance={performance}
           performanceLoading={performanceLoading}
           performanceSnapshots={performanceSnapshots}
+          isRecentlyListed={isRecentlyListed}
           isFavorite={favoriteTokens.includes(token.address)}
           onFavoriteClick={toggleFavoriteToken}
         />

--- a/src/components/GmList/GmListItem.tsx
+++ b/src/components/GmList/GmListItem.tsx
@@ -38,6 +38,8 @@ import { AmountWithUsdHuman } from "components/AmountWithUsd/AmountWithUsd";
 import { AprInfo } from "components/AprInfo/AprInfo";
 import Button from "components/Button/Button";
 import FavoriteStar from "components/FavoriteStar/FavoriteStar";
+import { RecentlyListedBadge } from "components/FavoriteTabs/RecentlyListedBadge";
+import { RecentlyListedFavoriteSlot } from "components/FavoriteTabs/RecentlyListedFavoriteSlot";
 import { TableTdActionable, TableTrActionable } from "components/Table/Table";
 import TokenIcon from "components/TokenIcon/TokenIcon";
 
@@ -61,6 +63,7 @@ export function GmListItem({
   apyLoading,
   isFavorite,
   onFavoriteClick,
+  isRecentlyListed,
   performance,
   performanceLoading,
   performanceSnapshots,
@@ -74,6 +77,7 @@ export function GmListItem({
   apyLoading: boolean;
   isFavorite: boolean | undefined;
   onFavoriteClick: ((address: string) => void) | undefined;
+  isRecentlyListed?: boolean;
   performanceLoading: boolean;
   performance: PerformanceData | undefined;
   performanceSnapshots: PerformanceSnapshotsData | undefined;
@@ -131,6 +135,9 @@ export function GmListItem({
     : getNormalizedTokenSymbol(indexToken.symbol);
 
   const tokenIconBadge = getMarketBadge(chainId, marketOrGlv);
+  const showRecentlyListedBadge = Boolean(
+    isRecentlyListed && !isGlv && !marketOrGlv.isSpotOnly && !marketOrGlv.isDisabled
+  );
 
   const handleFavoriteClick = (event: React.MouseEvent) => {
     event.stopPropagation();
@@ -156,12 +163,13 @@ export function GmListItem({
               />
             </div>
             <div className="flex flex-col">
-              <div className="text-body-medium flex items-center">
+              <div className="text-body-medium flex flex-wrap items-center gap-x-6">
                 <span className="font-medium">
                   {isGlv
                     ? getGlvDisplayName(marketOrGlv)
                     : getMarketIndexName({ indexToken, isSpotOnly: marketOrGlv.isSpotOnly })}
                 </span>
+                {showRecentlyListedBadge && <RecentlyListedBadge />}
 
                 <div className="inline-block">
                   <GmAssetDropdown token={token} marketsInfoData={marketsInfoData} tokensData={tokensData} />
@@ -253,8 +261,8 @@ export function GmListItem({
       <TableTdActionable className="w-[220px] pl-16">
         <div className="flex items-center gap-8">
           {onFavoriteClick && (
-            <Button variant="ghost" className="!p-8" onClick={handleFavoriteClick}>
-              <FavoriteStar isFavorite={isFavorite} />
+            <Button variant="ghost" className="!h-32 !min-h-32 !w-40 !p-0" onClick={handleFavoriteClick}>
+              <RecentlyListedFavoriteSlot isRecentlyListed={showRecentlyListedBadge} isFavorite={isFavorite} />
             </Button>
           )}
 

--- a/src/components/Referrals/shared/cards/ShareReferralCardModal.tsx
+++ b/src/components/Referrals/shared/cards/ShareReferralCardModal.tsx
@@ -10,6 +10,7 @@ import { formatUsd } from "lib/numbers";
 import { getShareURL, uploadElementAsShareImage } from "lib/shareImage";
 import { useBreakpoints } from "lib/useBreakpoints";
 
+import { AnimatedGradientText } from "components/AnimatedGradientText/AnimatedGradientText";
 import Button from "components/Button/Button";
 import { SlideModal } from "components/Modal/SlideModal";
 
@@ -229,11 +230,11 @@ function ScaledReferralCard({
 
           <div>
             <div className="mb-8 inline-block rounded-full bg-blue-300/20 px-6 py-2 text-16 font-medium leading-[20px] text-blue-300">
-              <div className="support-chat-new-badge">{referralCode}</div>
+              <AnimatedGradientText className="block">{referralCode}</AnimatedGradientText>
             </div>
             <h3 className="text-32 font-medium leading-1 text-white">
               <Trans>
-                <span className="support-chat-new-badge">Save up to {traderDiscountPercentageLabel}</span> on every
+                <AnimatedGradientText>Save up to {traderDiscountPercentageLabel}</AnimatedGradientText> on every
                 <br /> trade on GMX
               </Trans>
             </h3>

--- a/src/components/SideNav/SupportChatNavItem.scss
+++ b/src/components/SideNav/SupportChatNavItem.scss
@@ -1,22 +1,3 @@
-@property --gradient-angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 160.6deg;
-}
-
-.support-chat-new-badge {
-  --gradient-angle: 160.6deg;
-  background: linear-gradient(var(--gradient-angle), var(--color-blue-100) 0%, var(--color-blue-400) 100%);
-  background-size: 100% 86px;
-  background-position: 0 -15px;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: gradient-rotate 4s linear infinite;
-  -webkit-text-fill-color: transparent;
-  stroke-width: 0%;
-}
-
 .support-chat-icon-gradient-defs {
   position: absolute;
   width: 0;
@@ -27,12 +8,6 @@
 
 .support-chat-icon-collapsed path {
   fill: url(#support-chat-icon-collapsed-gradient);
-}
-
-@keyframes gradient-rotate {
-  to {
-    --gradient-angle: 520.6deg;
-  }
 }
 
 .image-capture-in-progress,

--- a/src/components/SideNav/SupportChatNavItem.tsx
+++ b/src/components/SideNav/SupportChatNavItem.tsx
@@ -8,6 +8,8 @@ import { useShowSupportChat } from "domain/supportChat/useShowSupportChat";
 import { useSupportChatUnreadCount } from "domain/supportChat/useSupportChatUnreadCount";
 import { useLocalStorageSerializeKey } from "lib/localStorage";
 
+import { AnimatedGradientText } from "components/AnimatedGradientText/AnimatedGradientText";
+
 import SupportChatIcon from "img/ic_support_chat.svg?react";
 
 import { NavItem } from "./SideNav";
@@ -75,9 +77,9 @@ export function SupportChatNavItem({ isCollapsed, onClick }: SupportChatNavItemP
           <Trans>Support</Trans>{" "}
           {!supportChatWasEverClicked && (
             <span className="text-body-small rounded-full bg-blue-300/20 px-6 py-1">
-              <span className="support-chat-new-badge inline-block font-medium">
+              <AnimatedGradientText className="inline-block font-medium">
                 <Trans>New</Trans>
-              </span>
+              </AnimatedGradientText>
             </span>
           )}
         </>


### PR DESCRIPTION
## Summary

Adds the recently listed `New` badge to the Pools list only.

- Marks eligible GM pool rows from the existing recently listed token set
- Shows the badge in the desktop favorite slot, swapping back to the star on row hover
- Shows the badge inline with the pool title on mobile cards
- Mirrors the existing side-nav gradient text treatment for the badge

Linear: [FEDEV-3868](https://linear.app/gmx-io/issue/FEDEV-3868/add-new-tag-on-pools)

