### PR TITLE
Improve pool price chart y-axis FEDEV-3896

### DIFF
--- a/src/components/MarketStats/MarketGraphs.tsx
+++ b/src/components/MarketStats/MarketGraphs.tsx
@@ -26,6 +26,8 @@ import { AprSnapshot, Price as PriceSnapshot } from "sdk/codegen/subsquid";
 
 import Tabs from "components/Tabs/Tabs";
 
+import { formatPriceGraphYAxisTick, getPriceGraphYAxisDomain } from "./marketGraphUtils";
+import type { MarketGraphYAxisDomain } from "./marketGraphUtils";
 import { FeeApyLabel } from "../GmList/FeeApyLabel";
 import { PerformanceLabel } from "../GmList/PerformanceLabel";
 import { PoolsTabs } from "../PoolsTabs/PoolsTabs";
@@ -213,6 +215,10 @@ const formatPerformanceBps = (performance: number): string => {
   return Number((performance * 100).toFixed(2)) + "%";
 };
 
+const formatPriceTooltipValue = (value: number): string => {
+  return formatUsdPrice(parseValue(value.toFixed(USD_DECIMALS), USD_DECIMALS) ?? 0n) || "";
+};
+
 const valueFormatter = (marketGraphType: MarketGraphType) => (value: number) => {
   if (value === 0) {
     return "0";
@@ -220,26 +226,27 @@ const valueFormatter = (marketGraphType: MarketGraphType) => (value: number) => 
 
   const valueMap: Record<MarketGraphType, string> = {
     performance: formatPerformanceBps(value),
-    price: formatUsdPrice(parseValue(value.toFixed(USD_DECIMALS), USD_DECIMALS) ?? 0n) || "",
+    price: formatPriceTooltipValue(value),
     feeApr: `${Number(value.toFixed(2))}%`,
   };
 
   return valueMap[marketGraphType];
 };
 
-const axisValueFormatter = (marketGraphType: MarketGraphType) => (value: number) => {
-  if (value === 0) {
-    return "0";
-  }
+const axisValueFormatter =
+  (marketGraphType: MarketGraphType, yAxisDomain?: MarketGraphYAxisDomain) => (value: number) => {
+    if (value === 0) {
+      return "0";
+    }
 
-  const valueMap: Record<MarketGraphType, string> = {
-    performance: formatPerformanceBps(value),
-    price: value.toString(),
-    feeApr: `${Number(value.toFixed(2))}%`,
+    const valueMap: Record<MarketGraphType, string> = {
+      performance: formatPerformanceBps(value),
+      price: formatPriceGraphYAxisTick(value, yAxisDomain),
+      feeApr: `${Number(value.toFixed(2))}%`,
+    };
+
+    return valueMap[marketGraphType];
   };
-
-  return valueMap[marketGraphType];
-};
 
 const CHART_CURSOR_PROPS = {
   stroke: "var(--color-slate-500)",
@@ -248,6 +255,7 @@ const CHART_CURSOR_PROPS = {
 };
 
 const AXIS_TICK_PROPS = { fill: "var(--color-slate-100)", fontSize: 12, fontWeight: 500 };
+const Y_AXIS_WIDTH = 56;
 
 const GraphChart = ({
   performanceSnapshots,
@@ -271,16 +279,18 @@ const GraphChart = ({
 
   const priceData = useMemo(
     () =>
-      priceSnapshots.map((snapshot) => ({
-        snapshotTimestamp: new Date((snapshot.snapshotTimestamp ?? 0) * 1000),
-        value: bigintToNumber(
-          getMidPrice({
-            minPrice: BigInt(snapshot.minPrice),
-            maxPrice: BigInt(snapshot.maxPrice),
-          }),
-          USD_DECIMALS
-        ),
-      })),
+      priceSnapshots
+        .map((snapshot) => ({
+          snapshotTimestamp: new Date((snapshot.snapshotTimestamp ?? 0) * 1000),
+          value: bigintToNumber(
+            getMidPrice({
+              minPrice: BigInt(snapshot.minPrice),
+              maxPrice: BigInt(snapshot.maxPrice),
+            }),
+            USD_DECIMALS
+          ),
+        }))
+        .filter((item) => Number.isFinite(item.value) && item.value > 0),
     [priceSnapshots]
   );
 
@@ -294,11 +304,18 @@ const GraphChart = ({
   );
 
   const formatValue = useMemo(() => valueFormatter(marketGraphType), [marketGraphType]);
-  const formatAxisValue = useMemo(() => axisValueFormatter(marketGraphType), [marketGraphType]);
 
   const isMobile = usePoolsIsMobilePage();
 
   const [data, setData] = useState<GraphData[]>([]);
+  const yAxisDomain = useMemo(
+    () => (marketGraphType === "price" ? getPriceGraphYAxisDomain(data) : undefined),
+    [data, marketGraphType]
+  );
+  const formatAxisValue = useMemo(
+    () => axisValueFormatter(marketGraphType, yAxisDomain),
+    [marketGraphType, yAxisDomain]
+  );
 
   const prevMarketGraphType = usePrevious(marketGraphType);
 
@@ -309,10 +326,14 @@ const GraphChart = ({
       feeApr: apyData,
     };
 
-    if (prevMarketGraphType !== marketGraphType || dataMap[marketGraphType].length > 0) {
+    if (
+      prevMarketGraphType !== marketGraphType ||
+      dataMap[marketGraphType].length > 0 ||
+      (marketGraphType === "price" && priceSnapshots.length > 0)
+    ) {
       setData(dataMap[marketGraphType]);
     }
-  }, [performanceData, priceData, apyData, marketGraphType, prevMarketGraphType]);
+  }, [performanceData, priceData, priceSnapshots.length, apyData, marketGraphType, prevMarketGraphType]);
 
   if (data.length === 0) {
     return (
@@ -364,11 +385,12 @@ const GraphChart = ({
           />
           <YAxis
             dataKey="value"
+            domain={yAxisDomain}
             tickFormatter={formatAxisValue}
             tickLine={false}
             axisLine={false}
             tick={AXIS_TICK_PROPS}
-            width={44}
+            width={Y_AXIS_WIDTH}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/src/components/MarketStats/marketGraphUtils.spec.ts
+++ b/src/components/MarketStats/marketGraphUtils.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatPriceGraphYAxisTick,
+  getPriceGraphYAxisDomain,
+  getPriceGraphYAxisTickDecimals,
+} from "./marketGraphUtils";
+
+describe("getPriceGraphYAxisDomain", () => {
+  it("pads the price range without anchoring at zero", () => {
+    expect(getPriceGraphYAxisDomain([{ value: 1 }, { value: 1.1 }])).toEqual([0.99, 1.11]);
+  });
+
+  it("keeps a positive lower bound when the range is much wider than the minimum", () => {
+    expect(getPriceGraphYAxisDomain([{ value: 0.1 }, { value: 10 }])).toEqual([0.0995, 10.99]);
+  });
+
+  it("adds padding for flat price series", () => {
+    expect(getPriceGraphYAxisDomain([{ value: 1 }, { value: 1 }])).toEqual([0.995, 1.005]);
+  });
+
+  it("ignores zero and negative values", () => {
+    expect(getPriceGraphYAxisDomain([{ value: 0 }, { value: -1 }, { value: 1 }, { value: 1.1 }])).toEqual([0.99, 1.11]);
+  });
+
+  it("ignores non-finite values", () => {
+    expect(
+      getPriceGraphYAxisDomain([{ value: Number.NaN }, { value: 1 }, { value: Number.POSITIVE_INFINITY }])
+    ).toEqual([0.995, 1.005]);
+  });
+
+  it("returns undefined when no positive finite values are available", () => {
+    expect(getPriceGraphYAxisDomain([{ value: 0 }, { value: -1 }])).toBeUndefined();
+  });
+
+  it("returns undefined when no finite values are available", () => {
+    expect(getPriceGraphYAxisDomain([{ value: Number.NaN }])).toBeUndefined();
+  });
+});
+
+describe("getPriceGraphYAxisTickDecimals", () => {
+  it("uses two decimals for sub-dollar buckets where cents are enough", () => {
+    expect(getPriceGraphYAxisTickDecimals([0.8307, 0.98616])).toBe(2);
+  });
+
+  it("uses two decimals for one-dollar buckets where cents are enough", () => {
+    expect(getPriceGraphYAxisTickDecimals([1.4883213058441358, 1.8075886097496454])).toBe(2);
+  });
+
+  it("uses more decimals for very tight buckets", () => {
+    expect(getPriceGraphYAxisTickDecimals([0.998, 1.002])).toBe(3);
+  });
+
+  it("uses enough decimals to keep small positive lower bounds from formatting as zero", () => {
+    expect(getPriceGraphYAxisTickDecimals([0.0995, 10.99])).toBe(2);
+  });
+
+  it("uses no decimals for wide buckets without small lower bounds", () => {
+    expect(getPriceGraphYAxisTickDecimals([100, 1000])).toBe(0);
+  });
+});
+
+describe("formatPriceGraphYAxisTick", () => {
+  it("formats price axis ticks without a dollar sign", () => {
+    expect(formatPriceGraphYAxisTick(0.98616, [0.8307, 0.98616])).toBe("0.99");
+  });
+
+  it("formats tighter buckets with more precision", () => {
+    expect(formatPriceGraphYAxisTick(0.9984, [0.998, 1.002])).toBe("0.998");
+  });
+
+  it("does not round small positive lower ticks to zero", () => {
+    expect(formatPriceGraphYAxisTick(0.0995, [0.0995, 10.99])).toBe("0.10");
+  });
+});

--- a/src/components/MarketStats/marketGraphUtils.ts
+++ b/src/components/MarketStats/marketGraphUtils.ts
@@ -1,0 +1,68 @@
+import { formatAmount, numberToBigint, USD_DECIMALS } from "lib/numbers";
+
+const PRICE_GRAPH_Y_AXIS_PADDING_FACTOR = 0.1;
+const PRICE_GRAPH_Y_AXIS_FLAT_PADDING_FACTOR = 0.005;
+const PRICE_GRAPH_Y_AXIS_TICK_COUNT = 5;
+const PRICE_GRAPH_Y_AXIS_MAX_DECIMALS = 8;
+
+export type MarketGraphYAxisDomain = [number, number];
+
+export function getPriceGraphYAxisDomain(data: { value: number }[]): MarketGraphYAxisDomain | undefined {
+  const values = data.map((item) => item.value).filter((value) => Number.isFinite(value) && value > 0);
+
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+
+  if (minValue === maxValue) {
+    const padding = Math.max(Math.abs(minValue) * PRICE_GRAPH_Y_AXIS_FLAT_PADDING_FACTOR, Number.EPSILON);
+
+    return [getPositivePriceLowerBound(minValue - padding, minValue), maxValue + padding];
+  }
+
+  const padding = (maxValue - minValue) * PRICE_GRAPH_Y_AXIS_PADDING_FACTOR;
+
+  return [getPositivePriceLowerBound(minValue - padding, minValue), maxValue + padding];
+}
+
+function getPositivePriceLowerBound(lowerBound: number, minValue: number) {
+  if (lowerBound > 0) {
+    return lowerBound;
+  }
+
+  return minValue * (1 - PRICE_GRAPH_Y_AXIS_FLAT_PADDING_FACTOR);
+}
+
+export function getPriceGraphYAxisTickDecimals(domain: MarketGraphYAxisDomain | undefined): number {
+  if (!domain) {
+    return 2;
+  }
+
+  const [minValue, maxValue] = domain;
+  const bucketSize = Math.abs(maxValue - minValue);
+
+  if (!Number.isFinite(bucketSize) || bucketSize === 0) {
+    return 2;
+  }
+
+  const estimatedTickSize = bucketSize / (PRICE_GRAPH_Y_AXIS_TICK_COUNT - 1);
+  const tickSizeDecimals = Math.ceil(-Math.log10(estimatedTickSize));
+  const minPositiveValue = Math.min(...domain.filter((value) => value > 0));
+  const minValueDecimals = Number.isFinite(minPositiveValue) ? Math.ceil(-Math.log10(minPositiveValue)) : 0;
+  const decimals = Math.max(tickSizeDecimals, minValueDecimals, 0);
+
+  return Math.min(decimals, PRICE_GRAPH_Y_AXIS_MAX_DECIMALS);
+}
+
+export function formatPriceGraphYAxisTick(value: number, domain: MarketGraphYAxisDomain | undefined): string {
+  if (!Number.isFinite(value)) {
+    return "";
+  }
+
+  const decimals = getPriceGraphYAxisTickDecimals(domain);
+
+  return formatAmount(numberToBigint(value, USD_DECIMALS), USD_DECIMALS, decimals, true);
+}


### PR DESCRIPTION
## Summary
- Tighten the pool details price chart Y-axis to a positive data-driven range instead of anchoring it at zero.
- Format price Y-axis ticks as plain numbers without `$`, with decimals derived from the displayed domain.
- Keep chart plot alignment stable by using the same Y-axis width for Performance, Price, and Fee APR modes.
- Add regression coverage for positive-domain padding, zero/non-positive filtering, small lower-bound formatting, and bucket-based decimals.

Linear: [FEDEV-3896](https://linear.app/gmx-io/issue/FEDEV-3896/bug-pool-details-price-chart-hides-small-price-movement)
