### PR TITLE
Set Privy wallet timeout to max safe integer

### DIFF
--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -14,6 +14,7 @@ import {
   getSupportedChains,
   PRIVY_APP_ID,
   PRIVY_LOGIN_METHODS,
+  PRIVY_SIGNATURE_REQUEST_TIMEOUTS,
   PRIVY_WALLET_LIST,
 } from "./walletConfig";
 
@@ -43,6 +44,9 @@ export default function WalletProvider({ children }: { children: React.ReactNode
       globalDisablePasskeys: true,
       defaultChain: arbitrum,
       supportedChains: [...supportedChains],
+      externalWallets: {
+        signatureRequestTimeouts: PRIVY_SIGNATURE_REQUEST_TIMEOUTS,
+      },
       embeddedWallets: {
         ethereum: {
           createOnLogin: "users-without-wallets" as const,

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -38,6 +38,14 @@ export const PRIVY_WALLET_LIST = [
 
 export const PRIVY_LOGIN_METHODS = ["wallet", "email", "google", "twitter", "discord"] as const;
 
+const PRIVY_WALLET_REQUEST_TIMEOUT_MS = Number.MAX_SAFE_INTEGER;
+
+// Privy looks this up by walletClientType and has no wildcard/default timeout setting.
+export const PRIVY_SIGNATURE_REQUEST_TIMEOUTS = new Proxy({} as Record<string, number>, {
+  get: (_target, walletClientType) =>
+    typeof walletClientType === "string" ? PRIVY_WALLET_REQUEST_TIMEOUT_MS : undefined,
+});
+
 export function getSupportedChains(): [Chain, ...Chain[]] {
   return Object.values(VIEM_CHAIN_BY_CHAIN_ID).filter((chain) => isDevelopment() || !isTestnetChain(chain.id)) as [
     Chain,


### PR DESCRIPTION
## Summary

Sets Privy's wallet request timeout override to `Number.MAX_SAFE_INTEGER` for external wallet RPC/signature requests.

Privy's SDK defaults these requests to 120000 ms and only supports wallet-client keyed timeout overrides. This change provides a proxy-backed timeout map so any wallet client key resolves to the max safe integer without hardcoding Privy's wallet client list.

## Impact

Users should no longer hit Privy's 2 minute wallet request timeout while waiting on wallet confirmation flows.
