### PR TITLE
Hotfix add WalletConnect QR option

### DIFF
--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -28,13 +28,13 @@ export const PRIVY_WALLET_LIST = [
   "detected_ethereum_wallets",
   "metamask",
   "rabby_wallet",
+  "wallet_connect_qr",
   "coinbase_wallet",
   "safe",
   "binance",
   "base_account",
   "okx_wallet",
   "phantom",
-  "wallet_connect_qr",
   "wallet_connect",
 ] as const;
 

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -34,6 +34,7 @@ export const PRIVY_WALLET_LIST = [
   "base_account",
   "okx_wallet",
   "phantom",
+  "wallet_connect_qr",
   "wallet_connect",
 ] as const;
 


### PR DESCRIPTION
## Summary

- Add `wallet_connect_qr` immediately after `rabby_wallet` in the Privy wallet list.
- Keep the existing WalletConnect registry option so users still see supported wallet entries.

## Why

The existing `wallet_connect` entry enables WalletConnect-backed wallet listings, but it does not guarantee a standalone generic WalletConnect QR option. Adding `wallet_connect_qr` exposes that QR entry explicitly.
