### PR TITLE
(test-only) trading costs dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ CLAUDE.md
 .serena
 .claude
 claude.md
+.superpowers/

--- a/docs/superpowers/plans/2026-05-24-trading-costs-dashboard.md
+++ b/docs/superpowers/plans/2026-05-24-trading-costs-dashboard.md
@@ -1,0 +1,2062 @@
+# Trading Costs Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `#/costs` internal analytics page for current round-trip GMX trading costs compared with Hyperliquid through a venue-agnostic model.
+
+**Architecture:** Add a new `src/domain/tradingCosts/` domain that owns shared types, pure cost math, market matching, provider adapters, and row composition. Add a dedicated `src/pages/TradingCosts/` page that consumes normalized rows and keeps visible UI labels generic so future venues can reuse the same surface.
+
+**Tech Stack:** React 18, TypeScript, SWR, Vitest, Playwright component tests, existing GMX synthetics fee utilities, Hyperliquid Info API.
+
+---
+
+## File Structure
+
+- Create `src/domain/tradingCosts/types.ts`: scenario, provider, component, breakdown, row, venue market, and Hyperliquid assumption types.
+- Create `src/domain/tradingCosts/costs.ts`: shared pure helpers for USD conversion, component totals, delta, row status, search filtering, and default volume sorting.
+- Create `src/domain/tradingCosts/marketMatching.ts`: venue-agnostic symbol normalization and GMX-to-venue market matching.
+- Create `src/domain/tradingCosts/hyperliquid/types.ts`: typed Hyperliquid response and normalized market/book types.
+- Create `src/domain/tradingCosts/hyperliquid/book.ts`: L2 book fill and cost/funding math.
+- Create `src/domain/tradingCosts/hyperliquid/api.ts`: Hyperliquid `POST /info` fetchers.
+- Create `src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts`: SWR hooks for market context and L2 books.
+- Create `src/domain/tradingCosts/gmx/gmxCost.ts`: GMX round-trip cost adapter using existing fee/gas utilities.
+- Create `src/domain/tradingCosts/buildTradingCostRows.ts`: row composition from GMX markets, Hyperliquid data, and scenario inputs.
+- Create `src/domain/tradingCosts/useTradingCosts.ts`: React hook that reads synthetics context and Hyperliquid hooks, then builds rows.
+- Create `src/pages/TradingCosts/TradingCosts.tsx`: context-connected page container.
+- Create `src/pages/TradingCosts/TradingCostsView.tsx`: pure presentational view for controls, table, and selected-row details.
+- Create `src/pages/TradingCosts/TradingCosts.scss`: compact internal analytics layout styles.
+- Create tests under `src/domain/tradingCosts/**/__tests__/` and `src/pages/TradingCosts/__tests__/`.
+- Modify `src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx`: add `tradingCosts` page type.
+- Modify `src/App/MainRoutes.tsx`: add the `#/costs` route.
+- Modify `src/components/SideNav/SideNav.tsx`: add `Costs` navigation item.
+
+## Task 1: Shared Types And Cost Helpers
+
+**Files:**
+- Create: `src/domain/tradingCosts/types.ts`
+- Create: `src/domain/tradingCosts/costs.ts`
+- Test: `src/domain/tradingCosts/__tests__/costs.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateDeltaUsd,
+  filterTradingCostRows,
+  getCombinedStatus,
+  numberToUsd,
+  sortTradingCostRowsByVenueVolume,
+  sumTradingCostComponents,
+  usdToNumber,
+} from "../costs";
+import type { TradingCostRow } from "../types";
+
+const readyBreakdown = {
+  providerId: "gmx" as const,
+  totalUsd: 0n,
+  components: [],
+  timestamp: 1,
+  status: "ready" as const,
+  warnings: [],
+};
+
+function row(overrides: Partial<TradingCostRow>): TradingCostRow {
+  return {
+    marketKey: "ETH:0x1",
+    displayName: "ETH/USD [WETH-USDC]",
+    indexSymbol: "ETH",
+    venueVolume24hUsd: 0n,
+    gmx: readyBreakdown,
+    venue: { ...readyBreakdown, providerId: "hyperliquid" },
+    deltaUsd: 0n,
+    status: "ready",
+    ...overrides,
+  };
+}
+
+describe("trading cost helpers", () => {
+  it("uses positive values as costs and negative values as rebates", () => {
+    expect(
+      sumTradingCostComponents([
+        { key: "protocolFee", label: "Protocol fee", usd: 100n },
+        { key: "openPriceImpact", label: "Open price impact", usd: -25n },
+        { key: "networkFee", label: "Network fee", usd: 5n },
+      ])
+    ).toBe(80n);
+  });
+
+  it("calculates positive delta when GMX costs more than the venue", () => {
+    expect(calculateDeltaUsd(150n, 90n)).toBe(60n);
+    expect(calculateDeltaUsd(undefined, 90n)).toBeUndefined();
+    expect(calculateDeltaUsd(150n, undefined)).toBeUndefined();
+  });
+
+  it("preserves USD values through number conversion within six decimal places", () => {
+    const usd = numberToUsd(12.345678);
+    expect(usdToNumber(usd)).toBeCloseTo(12.345678, 6);
+  });
+
+  it("combines statuses by severity", () => {
+    expect(getCombinedStatus("ready", "ready")).toBe("ready");
+    expect(getCombinedStatus("ready", "insufficientDepth")).toBe("insufficientDepth");
+    expect(getCombinedStatus("providerError", "insufficientDepth")).toBe("providerError");
+  });
+
+  it("filters rows by market display name and symbol", () => {
+    const rows = [
+      row({ displayName: "ETH/USD [WETH-USDC]", indexSymbol: "ETH" }),
+      row({ displayName: "BTC/USD [BTC-USDC]", indexSymbol: "BTC", marketKey: "BTC:0x2" }),
+    ];
+
+    expect(filterTradingCostRows(rows, "eth").map((r) => r.indexSymbol)).toEqual(["ETH"]);
+    expect(filterTradingCostRows(rows, "btc-usd").map((r) => r.indexSymbol)).toEqual(["BTC"]);
+    expect(filterTradingCostRows(rows, "").length).toBe(2);
+  });
+
+  it("sorts rows by selected venue 24h volume descending and puts unknown volume last", () => {
+    const rows = [
+      row({ indexSymbol: "ETH", venueVolume24hUsd: numberToUsd(100) }),
+      row({ indexSymbol: "BTC", venueVolume24hUsd: numberToUsd(300), marketKey: "BTC:0x2" }),
+      row({ indexSymbol: "SOL", venueVolume24hUsd: undefined, marketKey: "SOL:0x3" }),
+    ];
+
+    expect(sortTradingCostRowsByVenueVolume(rows).map((r) => r.indexSymbol)).toEqual(["BTC", "ETH", "SOL"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest run src/domain/tradingCosts/__tests__/costs.spec.ts`
+
+Expected: FAIL because `src/domain/tradingCosts/costs.ts` does not exist.
+
+- [ ] **Step 3: Add shared types**
+
+Create `src/domain/tradingCosts/types.ts`:
+
+```ts
+import type { MarketInfo } from "domain/synthetics/markets";
+
+export type TradingCostProviderId = "gmx" | "hyperliquid";
+export type TradingCostSide = "long" | "short";
+export type ComparisonVenueId = "hyperliquid";
+
+export type HyperliquidVenueAssumptions = {
+  takerFeeRate: number;
+};
+
+export type TradingCostScenario = {
+  sizeUsd: bigint;
+  side: TradingCostSide;
+  holdingPeriodHours: number;
+  comparisonVenue: ComparisonVenueId;
+  venueAssumptions: {
+    hyperliquid: HyperliquidVenueAssumptions;
+  };
+};
+
+export type TradingCostComponentKey =
+  | "protocolFee"
+  | "openPriceImpact"
+  | "closePriceImpact"
+  | "netRate"
+  | "networkFee"
+  | "venueExecutionImpact"
+  | "funding";
+
+export type TradingCostComponent = {
+  key: TradingCostComponentKey;
+  label: string;
+  usd: bigint;
+};
+
+export type TradingCostStatus =
+  | "ready"
+  | "loading"
+  | "unmatched"
+  | "insufficientDepth"
+  | "providerError"
+  | "stale";
+
+export type TradingCostBreakdown = {
+  providerId: TradingCostProviderId;
+  totalUsd: bigint | undefined;
+  components: TradingCostComponent[];
+  timestamp: number | undefined;
+  status: TradingCostStatus;
+  warnings: string[];
+};
+
+export type TradingCostRow = {
+  marketKey: string;
+  displayName: string;
+  indexSymbol: string;
+  venueVolume24hUsd: bigint | undefined;
+  gmx: TradingCostBreakdown;
+  venue: TradingCostBreakdown;
+  deltaUsd: bigint | undefined;
+  status: TradingCostStatus;
+};
+
+export type ComparisonVenueMarket = {
+  providerId: Exclude<TradingCostProviderId, "gmx">;
+  symbol: string;
+  displayName: string;
+  volume24hUsd: bigint | undefined;
+  isDisabled?: boolean;
+};
+
+export type MatchedTradingMarket = {
+  gmxMarket: MarketInfo;
+  venueMarket: ComparisonVenueMarket;
+};
+```
+
+- [ ] **Step 4: Add cost helpers**
+
+Create `src/domain/tradingCosts/costs.ts`:
+
+```ts
+import type { TradingCostComponent, TradingCostRow, TradingCostStatus } from "./types";
+
+export const USD_DECIMALS = 30n;
+export const USD_PRECISION = 10n ** USD_DECIMALS;
+const NUMBER_CONVERSION_DECIMALS = 6n;
+const NUMBER_CONVERSION_PRECISION = 10n ** NUMBER_CONVERSION_DECIMALS;
+
+const STATUS_SEVERITY: Record<TradingCostStatus, number> = {
+  ready: 0,
+  loading: 1,
+  stale: 2,
+  unmatched: 3,
+  insufficientDepth: 4,
+  providerError: 5,
+};
+
+export function numberToUsd(value: number): bigint {
+  if (!Number.isFinite(value)) {
+    return 0n;
+  }
+
+  return BigInt(Math.round(value * Number(NUMBER_CONVERSION_PRECISION))) * 10n ** (USD_DECIMALS - NUMBER_CONVERSION_DECIMALS);
+}
+
+export function usdToNumber(value: bigint | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Number(value) / Number(USD_PRECISION);
+}
+
+export function sumTradingCostComponents(components: TradingCostComponent[]): bigint {
+  return components.reduce((sum, component) => sum + component.usd, 0n);
+}
+
+export function calculateDeltaUsd(gmxTotalUsd: bigint | undefined, venueTotalUsd: bigint | undefined) {
+  if (gmxTotalUsd === undefined || venueTotalUsd === undefined) {
+    return undefined;
+  }
+
+  return gmxTotalUsd - venueTotalUsd;
+}
+
+export function getCombinedStatus(...statuses: TradingCostStatus[]): TradingCostStatus {
+  return statuses.reduce<TradingCostStatus>((highest, status) => {
+    return STATUS_SEVERITY[status] > STATUS_SEVERITY[highest] ? status : highest;
+  }, "ready");
+}
+
+export function filterTradingCostRows(rows: TradingCostRow[], query: string): TradingCostRow[] {
+  const normalizedQuery = query.trim().toLowerCase().replace(/\//g, "-");
+
+  if (!normalizedQuery) {
+    return rows;
+  }
+
+  return rows.filter((row) => {
+    const haystack = `${row.displayName} ${row.indexSymbol}`.toLowerCase().replace(/\//g, "-");
+    return haystack.includes(normalizedQuery);
+  });
+}
+
+export function sortTradingCostRowsByVenueVolume(rows: TradingCostRow[]): TradingCostRow[] {
+  return [...rows].sort((a, b) => {
+    if (a.venueVolume24hUsd === undefined && b.venueVolume24hUsd === undefined) return 0;
+    if (a.venueVolume24hUsd === undefined) return 1;
+    if (b.venueVolume24hUsd === undefined) return -1;
+    if (a.venueVolume24hUsd === b.venueVolume24hUsd) return a.indexSymbol.localeCompare(b.indexSymbol);
+    return a.venueVolume24hUsd > b.venueVolume24hUsd ? -1 : 1;
+  });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn vitest run src/domain/tradingCosts/__tests__/costs.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/tradingCosts/types.ts src/domain/tradingCosts/costs.ts src/domain/tradingCosts/__tests__/costs.spec.ts
+git commit -m "feat: add trading cost core helpers"
+```
+
+## Task 2: Market Matching
+
+**Files:**
+- Create: `src/domain/tradingCosts/marketMatching.ts`
+- Test: `src/domain/tradingCosts/__tests__/marketMatching.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+
+import { matchGmxMarketsToVenueMarkets, normalizeMarketSymbol } from "../marketMatching";
+import type { ComparisonVenueMarket } from "../types";
+
+const hyperliquidEth: ComparisonVenueMarket = {
+  providerId: "hyperliquid",
+  symbol: "ETH",
+  displayName: "ETH",
+  volume24hUsd: 100n,
+};
+
+describe("market matching", () => {
+  it("normalizes wrapped symbols to venue symbols", () => {
+    expect(normalizeMarketSymbol("WETH")).toBe("ETH");
+    expect(normalizeMarketSymbol("WBTC")).toBe("BTC");
+    expect(normalizeMarketSymbol("kPEPE")).toBe("KPEPE");
+  });
+
+  it("matches every enabled non-spot GMX market with a venue symbol", () => {
+    const ethMarket = createMockMarketInfo();
+    const secondEthMarket = { ...ethMarket, marketTokenAddress: "0x222", name: "ETH/USD [ETH-USDT]" };
+
+    const result = matchGmxMarketsToVenueMarkets([ethMarket, secondEthMarket], [hyperliquidEth]);
+
+    expect(result.matched.map((item) => item.gmxMarket.marketTokenAddress)).toEqual([
+      ethMarket.marketTokenAddress,
+      "0x222",
+    ]);
+    expect(result.unmatched).toEqual([]);
+  });
+
+  it("excludes disabled, spot-only, and disabled venue markets from matched rows", () => {
+    const enabledMarket = createMockMarketInfo();
+    const disabledMarket = { ...createMockMarketInfo(), marketTokenAddress: "0xdisabled", isDisabled: true };
+    const spotMarket = { ...createMockMarketInfo(), marketTokenAddress: "0xspot", isSpotOnly: true };
+
+    const disabledVenue: ComparisonVenueMarket = { ...hyperliquidEth, isDisabled: true };
+
+    expect(matchGmxMarketsToVenueMarkets([enabledMarket, disabledMarket, spotMarket], [disabledVenue]).matched).toEqual(
+      []
+    );
+    expect(matchGmxMarketsToVenueMarkets([enabledMarket, disabledMarket, spotMarket], [hyperliquidEth]).matched).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest run src/domain/tradingCosts/__tests__/marketMatching.spec.ts`
+
+Expected: FAIL because `marketMatching.ts` does not exist.
+
+- [ ] **Step 3: Add market matching implementation**
+
+Create `src/domain/tradingCosts/marketMatching.ts`:
+
+```ts
+import type { MarketInfo } from "domain/synthetics/markets";
+
+import type { ComparisonVenueMarket, MatchedTradingMarket } from "./types";
+
+const SYMBOL_ALIASES: Record<string, string> = {
+  WETH: "ETH",
+  WBTC: "BTC",
+};
+
+export function normalizeMarketSymbol(symbol: string | undefined): string {
+  const normalized = (symbol ?? "").trim().toUpperCase().replace(/[^A-Z0-9]/g, "");
+  return SYMBOL_ALIASES[normalized] ?? normalized;
+}
+
+export function matchGmxMarketsToVenueMarkets(
+  gmxMarkets: MarketInfo[],
+  venueMarkets: ComparisonVenueMarket[]
+): { matched: MatchedTradingMarket[]; unmatched: MarketInfo[] } {
+  const venueBySymbol = new Map(
+    venueMarkets.filter((market) => !market.isDisabled).map((market) => [normalizeMarketSymbol(market.symbol), market])
+  );
+
+  const matched: MatchedTradingMarket[] = [];
+  const unmatched: MarketInfo[] = [];
+
+  for (const gmxMarket of gmxMarkets) {
+    if (gmxMarket.isDisabled || gmxMarket.isSpotOnly) {
+      continue;
+    }
+
+    const symbol = normalizeMarketSymbol(gmxMarket.indexToken?.symbol);
+    const venueMarket = venueBySymbol.get(symbol);
+
+    if (!venueMarket) {
+      unmatched.push(gmxMarket);
+      continue;
+    }
+
+    matched.push({ gmxMarket, venueMarket });
+  }
+
+  return { matched, unmatched };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn vitest run src/domain/tradingCosts/__tests__/marketMatching.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/tradingCosts/marketMatching.ts src/domain/tradingCosts/__tests__/marketMatching.spec.ts
+git commit -m "feat: match trading cost markets"
+```
+
+## Task 3: Hyperliquid Book And Funding Math
+
+**Files:**
+- Create: `src/domain/tradingCosts/hyperliquid/types.ts`
+- Create: `src/domain/tradingCosts/hyperliquid/book.ts`
+- Test: `src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { numberToUsd, usdToNumber } from "../../costs";
+import {
+  getHyperliquidExecutionImpactUsd,
+  getHyperliquidFundingCostUsd,
+  simulateL2BookFill,
+} from "../book";
+import type { HyperliquidBookLevel } from "../types";
+
+const asks: HyperliquidBookLevel[] = [
+  { px: "100", sz: "1", n: 1 },
+  { px: "110", sz: "2", n: 1 },
+];
+
+const bids: HyperliquidBookLevel[] = [
+  { px: "99", sz: "1", n: 1 },
+  { px: "98", sz: "2", n: 1 },
+];
+
+describe("Hyperliquid L2 book math", () => {
+  it("fills a USD notional across multiple levels", () => {
+    const fill = simulateL2BookFill({ levels: asks, sizeUsd: numberToUsd(210) });
+
+    expect(fill.status).toBe("filled");
+    expect(fill.averagePrice).toBeCloseTo(105, 6);
+    expect(usdToNumber(fill.filledUsd)).toBeCloseTo(210, 6);
+  });
+
+  it("marks insufficient depth when returned levels cannot fill requested notional", () => {
+    const fill = simulateL2BookFill({ levels: asks.slice(0, 1), sizeUsd: numberToUsd(250) });
+
+    expect(fill.status).toBe("insufficientDepth");
+    expect(usdToNumber(fill.filledUsd)).toBeCloseTo(100, 6);
+  });
+
+  it("calculates ask-side and bid-side execution impact as trader cost", () => {
+    expect(usdToNumber(getHyperliquidExecutionImpactUsd({ sizeUsd: numberToUsd(1000), referencePrice: 100, averagePrice: 101, side: "ask" }))).toBeCloseTo(10, 6);
+    expect(usdToNumber(getHyperliquidExecutionImpactUsd({ sizeUsd: numberToUsd(1000), referencePrice: 100, averagePrice: 99, side: "bid" }))).toBeCloseTo(10, 6);
+    expect(usdToNumber(getHyperliquidExecutionImpactUsd({ sizeUsd: numberToUsd(1000), referencePrice: 100, averagePrice: 99.5, side: "ask" }))).toBeCloseTo(-5, 6);
+  });
+
+  it("projects funding cost with positive rates paid by longs and received by shorts", () => {
+    expect(usdToNumber(getHyperliquidFundingCostUsd({ sizeUsd: numberToUsd(10_000), side: "long", hourlyFundingRate: 0.0001, holdingPeriodHours: 8 }))).toBeCloseTo(8, 6);
+    expect(usdToNumber(getHyperliquidFundingCostUsd({ sizeUsd: numberToUsd(10_000), side: "short", hourlyFundingRate: 0.0001, holdingPeriodHours: 8 }))).toBeCloseTo(-8, 6);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest run src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts`
+
+Expected: FAIL because `book.ts` does not exist.
+
+- [ ] **Step 3: Add Hyperliquid types**
+
+Create `src/domain/tradingCosts/hyperliquid/types.ts`:
+
+```ts
+import type { TradingCostSide } from "../types";
+
+export type HyperliquidAssetMeta = {
+  name: string;
+  szDecimals: number;
+  maxLeverage: number;
+  marginTableId: number;
+  isDelisted?: boolean;
+};
+
+export type HyperliquidAssetCtx = {
+  dayNtlVlm?: string;
+  funding?: string;
+  markPx?: string;
+  midPx?: string;
+  oraclePx?: string;
+  premium?: string;
+};
+
+export type HyperliquidMetaAndAssetCtxsResponse = [
+  { universe: HyperliquidAssetMeta[] },
+  HyperliquidAssetCtx[],
+];
+
+export type HyperliquidBookLevel = {
+  px: string;
+  sz: string;
+  n: number;
+};
+
+export type HyperliquidL2BookResponse = {
+  coin: string;
+  time: number;
+  levels: [HyperliquidBookLevel[], HyperliquidBookLevel[]];
+};
+
+export type HyperliquidNormalizedMarket = {
+  symbol: string;
+  displayName: string;
+  isDisabled: boolean;
+  volume24hUsd: bigint | undefined;
+  markPrice: number | undefined;
+  midPrice: number | undefined;
+  hourlyFundingRate: number | undefined;
+  timestamp: number;
+};
+
+export type BookSide = "ask" | "bid";
+
+export type HyperliquidLeg = {
+  bookSide: BookSide;
+  tradingSide: TradingCostSide;
+};
+```
+
+- [ ] **Step 4: Add Hyperliquid book math implementation**
+
+Create `src/domain/tradingCosts/hyperliquid/book.ts`:
+
+```ts
+import { numberToUsd, usdToNumber } from "../costs";
+import type { TradingCostSide } from "../types";
+import type { BookSide, HyperliquidBookLevel } from "./types";
+
+export type BookFillResult = {
+  status: "filled" | "insufficientDepth";
+  averagePrice: number | undefined;
+  filledUsd: bigint;
+};
+
+export function simulateL2BookFill({
+  levels,
+  sizeUsd,
+}: {
+  levels: HyperliquidBookLevel[];
+  sizeUsd: bigint;
+}): BookFillResult {
+  const targetUsd = usdToNumber(sizeUsd) ?? 0;
+  let remainingUsd = targetUsd;
+  let filledUsd = 0;
+  let filledBase = 0;
+
+  for (const level of levels) {
+    if (remainingUsd <= 0) break;
+
+    const price = Number(level.px);
+    const size = Number(level.sz);
+    const levelUsd = price * size;
+    const takeUsd = Math.min(levelUsd, remainingUsd);
+    const takeBase = takeUsd / price;
+
+    filledUsd += takeUsd;
+    filledBase += takeBase;
+    remainingUsd -= takeUsd;
+  }
+
+  return {
+    status: remainingUsd > 0.000001 ? "insufficientDepth" : "filled",
+    averagePrice: filledBase > 0 ? filledUsd / filledBase : undefined,
+    filledUsd: numberToUsd(filledUsd),
+  };
+}
+
+export function getHyperliquidExecutionImpactUsd({
+  sizeUsd,
+  referencePrice,
+  averagePrice,
+  side,
+}: {
+  sizeUsd: bigint;
+  referencePrice: number;
+  averagePrice: number;
+  side: BookSide;
+}) {
+  if (referencePrice <= 0) {
+    return 0n;
+  }
+
+  const size = usdToNumber(sizeUsd) ?? 0;
+  const direction = side === "ask" ? 1 : -1;
+  return numberToUsd(size * ((averagePrice - referencePrice) / referencePrice) * direction);
+}
+
+export function getBookSideForLeg({
+  tradingSide,
+  isOpen,
+}: {
+  tradingSide: TradingCostSide;
+  isOpen: boolean;
+}): BookSide {
+  if (tradingSide === "long") {
+    return isOpen ? "ask" : "bid";
+  }
+
+  return isOpen ? "bid" : "ask";
+}
+
+export function getHyperliquidFundingCostUsd({
+  sizeUsd,
+  side,
+  hourlyFundingRate,
+  holdingPeriodHours,
+}: {
+  sizeUsd: bigint;
+  side: TradingCostSide;
+  hourlyFundingRate: number;
+  holdingPeriodHours: number;
+}) {
+  const signedRate = side === "long" ? hourlyFundingRate : -hourlyFundingRate;
+  return numberToUsd((usdToNumber(sizeUsd) ?? 0) * signedRate * holdingPeriodHours);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn vitest run src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/tradingCosts/hyperliquid src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts
+git commit -m "feat: add hyperliquid book cost math"
+```
+
+## Task 4: Hyperliquid Fetching And Normalization
+
+**Files:**
+- Create: `src/domain/tradingCosts/hyperliquid/api.ts`
+- Create: `src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts`
+- Test: `src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { usdToNumber } from "../../costs";
+import { normalizeHyperliquidMarkets } from "../api";
+import type { HyperliquidMetaAndAssetCtxsResponse } from "../types";
+
+describe("Hyperliquid API normalization", () => {
+  it("combines meta and asset contexts and excludes delisted markets", () => {
+    const response: HyperliquidMetaAndAssetCtxsResponse = [
+      {
+        universe: [
+          { name: "ETH", szDecimals: 4, maxLeverage: 25, marginTableId: 1 },
+          { name: "MATIC", szDecimals: 1, maxLeverage: 20, marginTableId: 2, isDelisted: true },
+        ],
+      },
+      [
+        { dayNtlVlm: "12345.67", markPx: "2100", midPx: "2100.5", funding: "0.0000125" },
+        { dayNtlVlm: "999", markPx: "1", funding: "0" },
+      ],
+    ];
+
+    const markets = normalizeHyperliquidMarkets(response, 123);
+
+    expect(markets).toHaveLength(1);
+    expect(markets[0]).toMatchObject({
+      symbol: "ETH",
+      displayName: "ETH",
+      isDisabled: false,
+      markPrice: 2100,
+      midPrice: 2100.5,
+      hourlyFundingRate: 0.0000125,
+      timestamp: 123,
+    });
+    expect(usdToNumber(markets[0].volume24hUsd)).toBeCloseTo(12345.67, 6);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest run src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts`
+
+Expected: FAIL because `api.ts` does not exist.
+
+- [ ] **Step 3: Add API and normalization implementation**
+
+Create `src/domain/tradingCosts/hyperliquid/api.ts`:
+
+```ts
+import { numberToUsd } from "../costs";
+import type {
+  HyperliquidL2BookResponse,
+  HyperliquidMetaAndAssetCtxsResponse,
+  HyperliquidNormalizedMarket,
+} from "./types";
+
+const HYPERLIQUID_INFO_URL = "https://api.hyperliquid.xyz/info";
+
+async function postHyperliquidInfo<T>(body: Record<string, string>): Promise<T> {
+  const response = await fetch(HYPERLIQUID_INFO_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Hyperliquid info request failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function parseOptionalNumber(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function normalizeHyperliquidMarkets(
+  response: HyperliquidMetaAndAssetCtxsResponse,
+  timestamp: number
+): HyperliquidNormalizedMarket[] {
+  const [meta, contexts] = response;
+
+  return meta.universe.flatMap((asset, index) => {
+    const ctx = contexts[index];
+
+    if (!ctx || asset.isDelisted) {
+      return [];
+    }
+
+    const volume = parseOptionalNumber(ctx.dayNtlVlm);
+
+    return {
+      symbol: asset.name,
+      displayName: asset.name,
+      isDisabled: false,
+      volume24hUsd: volume === undefined ? undefined : numberToUsd(volume),
+      markPrice: parseOptionalNumber(ctx.markPx),
+      midPrice: parseOptionalNumber(ctx.midPx),
+      hourlyFundingRate: parseOptionalNumber(ctx.funding),
+      timestamp,
+    };
+  });
+}
+
+export async function fetchHyperliquidMetaAndAssetCtxs(): Promise<HyperliquidNormalizedMarket[]> {
+  const timestamp = Date.now();
+  const response = await postHyperliquidInfo<HyperliquidMetaAndAssetCtxsResponse>({ type: "metaAndAssetCtxs" });
+  return normalizeHyperliquidMarkets(response, timestamp);
+}
+
+export async function fetchHyperliquidL2Book(coin: string): Promise<HyperliquidL2BookResponse> {
+  return postHyperliquidInfo<HyperliquidL2BookResponse>({ type: "l2Book", coin });
+}
+
+export async function fetchHyperliquidL2Books(coins: string[]): Promise<Record<string, HyperliquidL2BookResponse | Error>> {
+  const entries = await Promise.all(
+    coins.map(async (coin) => {
+      try {
+        return [coin, await fetchHyperliquidL2Book(coin)] as const;
+      } catch (error) {
+        return [coin, error instanceof Error ? error : new Error(String(error))] as const;
+      }
+    })
+  );
+
+  return Object.fromEntries(entries);
+}
+```
+
+- [ ] **Step 4: Add SWR hook implementation**
+
+Create `src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts`:
+
+```ts
+import { useMemo } from "react";
+import useSWR from "swr";
+
+import { FREQUENT_UPDATE_INTERVAL } from "lib/timeConstants";
+
+import { fetchHyperliquidL2Books, fetchHyperliquidMetaAndAssetCtxs } from "./api";
+import type { HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
+
+export type HyperliquidMarketsResult = {
+  markets: HyperliquidNormalizedMarket[] | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+};
+
+export type HyperliquidBooksResult = {
+  booksByCoin: Record<string, HyperliquidL2BookResponse | Error> | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+};
+
+export function useHyperliquidMarkets(): HyperliquidMarketsResult {
+  const marketsRequest = useSWR(["tradingCosts", "hyperliquid", "metaAndAssetCtxs"], fetchHyperliquidMetaAndAssetCtxs, {
+    refreshInterval: FREQUENT_UPDATE_INTERVAL,
+  });
+
+  return {
+    markets: marketsRequest.data,
+    isLoading: marketsRequest.isLoading,
+    error: marketsRequest.error as Error | undefined,
+  };
+}
+
+export function useHyperliquidL2Books(coins: string[] | undefined): HyperliquidBooksResult {
+  const sortedCoins = useMemo(() => {
+    return coins?.filter(Boolean).sort() ?? [];
+  }, [coins]);
+
+  const booksRequest = useSWR(
+    sortedCoins.length ? ["tradingCosts", "hyperliquid", "l2Books", sortedCoins.join(",")] : null,
+    () => fetchHyperliquidL2Books(sortedCoins),
+    { refreshInterval: FREQUENT_UPDATE_INTERVAL }
+  );
+
+  return {
+    booksByCoin: booksRequest.data,
+    isLoading: booksRequest.isLoading,
+    error: booksRequest.error as Error | undefined,
+  };
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn vitest run src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/tradingCosts/hyperliquid/api.ts src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts
+git commit -m "feat: fetch hyperliquid trading cost data"
+```
+
+## Task 5: GMX Round-Trip Cost Adapter
+
+**Files:**
+- Create: `src/domain/tradingCosts/gmx/gmxCost.ts`
+- Test: `src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { expandDecimals } from "lib/numbers";
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+
+import { getGmxTradingCostBreakdown } from "../gmxCost";
+
+const feeFactor = expandDecimals(5, 25);
+
+describe("GMX trading cost adapter", () => {
+  it("includes protocol fees on both open and close legs", () => {
+    const marketInfo = {
+      ...createMockMarketInfo(),
+      positionFeeFactorForBalanceWasImproved: feeFactor,
+      positionFeeFactorForBalanceWasNotImproved: feeFactor,
+      positionImpactFactorPositive: 0n,
+      positionImpactFactorNegative: 0n,
+      fundingFactorPerSecond: 0n,
+      borrowingFactorPerSecondForLongs: 0n,
+      borrowingFactorPerSecondForShorts: 0n,
+    };
+
+    const sizeUsd = expandDecimals(10_000, 30);
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd,
+      side: "long",
+      holdingPeriodHours: 8,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+
+    expect(breakdown.status).toBe("ready");
+    expect(breakdown.components.find((item) => item.key === "protocolFee")?.usd).toBe(expandDecimals(10, 30));
+    expect(breakdown.components.find((item) => item.key === "openPriceImpact")?.usd).toBe(0n);
+    expect(breakdown.components.find((item) => item.key === "closePriceImpact")?.usd).toBe(0n);
+    expect(breakdown.warnings).toContain("Collateral swap routing is not included.");
+  });
+
+  it("converts positive price impact into a negative cost", () => {
+    const marketInfo = {
+      ...createMockMarketInfo(),
+      longInterestUsd: expandDecimals(100_000, 30),
+      shortInterestUsd: expandDecimals(1_000_000, 30),
+      positionFeeFactorForBalanceWasImproved: 0n,
+      positionFeeFactorForBalanceWasNotImproved: 0n,
+      borrowingFactorPerSecondForLongs: 0n,
+      borrowingFactorPerSecondForShorts: 0n,
+      fundingFactorPerSecond: 0n,
+    };
+
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd: expandDecimals(10_000, 30),
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+
+    expect(breakdown.components.find((item) => item.key === "openPriceImpact")!.usd).toBeLessThanOrEqual(0n);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest run src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts`
+
+Expected: FAIL because `gmxCost.ts` does not exist.
+
+- [ ] **Step 3: Add GMX cost adapter**
+
+Create `src/domain/tradingCosts/gmx/gmxCost.ts`:
+
+```ts
+import { DecreasePositionSwapType } from "domain/synthetics/orders";
+import {
+  getBorrowingFeeRateUsd,
+  getCappedPositionImpactUsd,
+  getFundingFeeRateUsd,
+  getPositionFee,
+  type GasLimitsConfig,
+} from "domain/synthetics/fees";
+import { bigMath } from "sdk/utils/bigmath";
+import {
+  estimateExecuteDecreaseOrderGasLimit,
+  estimateExecuteIncreaseOrderGasLimit,
+  getExecutionFee,
+} from "sdk/utils/fees/executionFee";
+import type { MarketInfo } from "sdk/utils/markets/types";
+import type { TokensData } from "sdk/utils/tokens/types";
+
+import { sumTradingCostComponents } from "../costs";
+import type { TradingCostBreakdown, TradingCostComponent, TradingCostSide } from "../types";
+
+const SECONDS_PER_HOUR = 60n * 60n;
+
+function estimateGmxNetworkFeeUsd({
+  chainId,
+  gasLimits,
+  gasPrice,
+  tokensData,
+}: {
+  chainId: number;
+  gasLimits: GasLimitsConfig | undefined;
+  gasPrice: bigint | undefined;
+  tokensData: TokensData | undefined;
+}) {
+  if (!gasLimits || gasPrice === undefined || !tokensData) {
+    return 0n;
+  }
+
+  const increaseGasLimit = estimateExecuteIncreaseOrderGasLimit(gasLimits, { swapsCount: 0, callbackGasLimit: 0n });
+  const decreaseGasLimit = estimateExecuteDecreaseOrderGasLimit(gasLimits, {
+    swapsCount: 0,
+    callbackGasLimit: 0n,
+    decreaseSwapType: DecreasePositionSwapType.NoSwap,
+  });
+
+  const increaseFee = getExecutionFee(chainId, gasLimits, tokensData, increaseGasLimit, gasPrice, 2n)?.feeUsd ?? 0n;
+  const decreaseFee = getExecutionFee(chainId, gasLimits, tokensData, decreaseGasLimit, gasPrice, 2n)?.feeUsd ?? 0n;
+
+  return increaseFee + decreaseFee;
+}
+
+export function getGmxTradingCostBreakdown({
+  marketInfo,
+  sizeUsd,
+  side,
+  holdingPeriodHours,
+  chainId = 42161,
+  gasLimits,
+  gasPrice,
+  tokensData,
+  timestamp,
+}: {
+  marketInfo: MarketInfo;
+  sizeUsd: bigint;
+  side: TradingCostSide;
+  holdingPeriodHours: number;
+  chainId?: number;
+  gasLimits: GasLimitsConfig | undefined;
+  gasPrice: bigint | undefined;
+  tokensData: TokensData | undefined;
+  timestamp: number;
+}): TradingCostBreakdown {
+  const isLong = side === "long";
+  const openImpact = getCappedPositionImpactUsd(marketInfo, sizeUsd, isLong, true, {
+    fallbackToZero: true,
+    shouldCapNegativeImpact: true,
+  });
+  const closeImpact = getCappedPositionImpactUsd(marketInfo, sizeUsd, isLong, false, {
+    fallbackToZero: true,
+    shouldCapNegativeImpact: true,
+  });
+
+  const openPositionFee = getPositionFee(marketInfo, sizeUsd, openImpact.balanceWasImproved, undefined).positionFeeUsd;
+  const closePositionFee = getPositionFee(marketInfo, sizeUsd, closeImpact.balanceWasImproved, undefined).positionFeeUsd;
+  const periodSeconds = BigInt(Math.round(holdingPeriodHours * 3600));
+  const borrowingFeeUsd = getBorrowingFeeRateUsd(marketInfo, isLong, sizeUsd, periodSeconds);
+  const fundingRateUsd = getFundingFeeRateUsd(marketInfo, isLong, sizeUsd, periodSeconds);
+  const networkFeeUsd = estimateGmxNetworkFeeUsd({ chainId, gasLimits, gasPrice, tokensData });
+
+  const components: TradingCostComponent[] = [
+    { key: "protocolFee", label: "Protocol fee", usd: openPositionFee + closePositionFee },
+    { key: "openPriceImpact", label: "Open price impact", usd: -openImpact.priceImpactDeltaUsd },
+    { key: "closePriceImpact", label: "Close price impact", usd: -closeImpact.priceImpactDeltaUsd },
+    { key: "netRate", label: "Net-rate cost", usd: borrowingFeeUsd - fundingRateUsd },
+    { key: "networkFee", label: "Network fee", usd: networkFeeUsd },
+  ];
+
+  return {
+    providerId: "gmx",
+    totalUsd: sumTradingCostComponents(components),
+    components,
+    timestamp,
+    status: "ready",
+    warnings: [
+      "Collateral swap routing is not included.",
+      "Account-specific referral discounts are not included.",
+      "Results are current estimates, not guaranteed execution quotes.",
+    ],
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn vitest run src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/tradingCosts/gmx src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts
+git commit -m "feat: estimate gmx trading costs"
+```
+
+## Task 6: Row Composition
+
+**Files:**
+- Create: `src/domain/tradingCosts/buildTradingCostRows.ts`
+- Create: `src/domain/tradingCosts/useTradingCosts.ts`
+- Test: `src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { expandDecimals } from "lib/numbers";
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+
+import { numberToUsd, usdToNumber } from "../costs";
+import { buildTradingCostRows } from "../buildTradingCostRows";
+import type { TradingCostBreakdown, TradingCostScenario } from "../types";
+
+const scenario: TradingCostScenario = {
+  sizeUsd: expandDecimals(10_000, 30),
+  side: "long",
+  holdingPeriodHours: 8,
+  comparisonVenue: "hyperliquid",
+  venueAssumptions: { hyperliquid: { takerFeeRate: 0.00045 } },
+};
+
+function breakdown(providerId: "gmx" | "hyperliquid", totalUsd: bigint | undefined): TradingCostBreakdown {
+  return { providerId, totalUsd, components: [], timestamp: 1, status: totalUsd === undefined ? "providerError" : "ready", warnings: [] };
+}
+
+describe("buildTradingCostRows", () => {
+  it("builds matched rows, calculates delta, and sorts by venue volume", () => {
+    const eth = createMockMarketInfo();
+    const btc = { ...createMockMarketInfo(), marketTokenAddress: "0xbtc", name: "BTC/USD [BTC-USDC]", indexToken: { ...createMockMarketInfo().indexToken, symbol: "BTC" } };
+
+    const rows = buildTradingCostRows({
+      scenario,
+      gmxMarkets: [eth, btc],
+      venueMarkets: [
+        { providerId: "hyperliquid", symbol: "ETH", displayName: "ETH", volume24hUsd: numberToUsd(100) },
+        { providerId: "hyperliquid", symbol: "BTC", displayName: "BTC", volume24hUsd: numberToUsd(200) },
+      ],
+      buildGmxBreakdown: (market) => breakdown("gmx", market.marketTokenAddress === "0xbtc" ? numberToUsd(12) : numberToUsd(20)),
+      buildVenueBreakdown: (match) => breakdown("hyperliquid", match.venueMarket.symbol === "BTC" ? numberToUsd(10) : numberToUsd(15)),
+    });
+
+    expect(rows.map((row) => row.indexSymbol)).toEqual(["BTC", "ETH"]);
+    expect(usdToNumber(rows[0].deltaUsd)).toBeCloseTo(2, 6);
+    expect(usdToNumber(rows[1].deltaUsd)).toBeCloseTo(5, 6);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest run src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts`
+
+Expected: FAIL because `buildTradingCostRows.ts` does not exist.
+
+- [ ] **Step 3: Add row composition**
+
+Create `src/domain/tradingCosts/buildTradingCostRows.ts`:
+
+```ts
+import type { MarketInfo } from "domain/synthetics/markets";
+
+import { calculateDeltaUsd, getCombinedStatus, sortTradingCostRowsByVenueVolume } from "./costs";
+import { matchGmxMarketsToVenueMarkets } from "./marketMatching";
+import type {
+  ComparisonVenueMarket,
+  MatchedTradingMarket,
+  TradingCostBreakdown,
+  TradingCostRow,
+  TradingCostScenario,
+} from "./types";
+
+export function buildTradingCostRows({
+  scenario,
+  gmxMarkets,
+  venueMarkets,
+  buildGmxBreakdown,
+  buildVenueBreakdown,
+}: {
+  scenario: TradingCostScenario;
+  gmxMarkets: MarketInfo[];
+  venueMarkets: ComparisonVenueMarket[];
+  buildGmxBreakdown: (market: MarketInfo, scenario: TradingCostScenario) => TradingCostBreakdown;
+  buildVenueBreakdown: (match: MatchedTradingMarket, scenario: TradingCostScenario) => TradingCostBreakdown;
+}): TradingCostRow[] {
+  const { matched } = matchGmxMarketsToVenueMarkets(gmxMarkets, venueMarkets);
+  const rows = matched.map((match) => {
+    const gmx = buildGmxBreakdown(match.gmxMarket, scenario);
+    const venue = buildVenueBreakdown(match, scenario);
+    const deltaUsd = calculateDeltaUsd(gmx.totalUsd, venue.totalUsd);
+
+    return {
+      marketKey: `${match.venueMarket.providerId}:${match.venueMarket.symbol}:${match.gmxMarket.marketTokenAddress}`,
+      displayName: match.gmxMarket.name,
+      indexSymbol: match.gmxMarket.indexToken.symbol,
+      venueVolume24hUsd: match.venueMarket.volume24hUsd,
+      gmx,
+      venue,
+      deltaUsd,
+      status: getCombinedStatus(gmx.status, venue.status),
+    };
+  });
+
+  return sortTradingCostRowsByVenueVolume(rows);
+}
+```
+
+- [ ] **Step 4: Add Hyperliquid breakdown helper used by the hook**
+
+Create `src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts`:
+
+```ts
+import { sumTradingCostComponents } from "../costs";
+import type {
+  ComparisonVenueMarket,
+  MatchedTradingMarket,
+  TradingCostBreakdown,
+  TradingCostComponent,
+  TradingCostScenario,
+} from "../types";
+import { getBookSideForLeg, getHyperliquidExecutionImpactUsd, getHyperliquidFundingCostUsd, simulateL2BookFill } from "./book";
+import type { HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
+
+export function getHyperliquidVenueMarkets(markets: HyperliquidNormalizedMarket[]): ComparisonVenueMarket[] {
+  return markets.map((market) => ({
+    providerId: "hyperliquid",
+    symbol: market.symbol,
+    displayName: market.displayName,
+    volume24hUsd: market.volume24hUsd,
+    isDisabled: market.isDisabled,
+  }));
+}
+
+export function buildHyperliquidBreakdown({
+  scenario,
+  match,
+  market,
+  book,
+}: {
+  scenario: TradingCostScenario;
+  match: MatchedTradingMarket;
+  market: HyperliquidNormalizedMarket | undefined;
+  book: HyperliquidL2BookResponse | Error | undefined;
+}): TradingCostBreakdown {
+  if (!market) {
+    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: undefined, status: "loading", warnings: [] };
+  }
+
+  if (book instanceof Error) {
+    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: market.timestamp, status: "providerError", warnings: [book.message] };
+  }
+
+  if (!book) {
+    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: market.timestamp, status: "loading", warnings: [] };
+  }
+
+  const referencePrice = market.midPrice ?? market.markPrice;
+  const hourlyFundingRate = market.hourlyFundingRate;
+
+  if (!referencePrice || hourlyFundingRate === undefined) {
+    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: market.timestamp, status: "providerError", warnings: ["Hyperliquid market context is missing price or funding data."] };
+  }
+
+  const openBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: true });
+  const closeBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: false });
+  const openLevels = openBookSide === "bid" ? book.levels[0] : book.levels[1];
+  const closeLevels = closeBookSide === "bid" ? book.levels[0] : book.levels[1];
+  const openFill = simulateL2BookFill({ levels: openLevels, sizeUsd: scenario.sizeUsd });
+  const closeFill = simulateL2BookFill({ levels: closeLevels, sizeUsd: scenario.sizeUsd });
+
+  if (openFill.status === "insufficientDepth" || closeFill.status === "insufficientDepth" || openFill.averagePrice === undefined || closeFill.averagePrice === undefined) {
+    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: book.time, status: "insufficientDepth", warnings: ["Hyperliquid L2 levels cannot fill the requested round-trip size."] };
+  }
+
+  const feeRate = scenario.venueAssumptions.hyperliquid.takerFeeRate;
+  const protocolFeeUsd = (scenario.sizeUsd * BigInt(Math.round(feeRate * 1_000_000)) * 2n) / 1_000_000n;
+  const openImpactUsd = getHyperliquidExecutionImpactUsd({ sizeUsd: scenario.sizeUsd, referencePrice, averagePrice: openFill.averagePrice, side: openBookSide });
+  const closeImpactUsd = getHyperliquidExecutionImpactUsd({ sizeUsd: scenario.sizeUsd, referencePrice, averagePrice: closeFill.averagePrice, side: closeBookSide });
+  const fundingUsd = getHyperliquidFundingCostUsd({
+    sizeUsd: scenario.sizeUsd,
+    side: scenario.side,
+    hourlyFundingRate,
+    holdingPeriodHours: scenario.holdingPeriodHours,
+  });
+
+  const components: TradingCostComponent[] = [
+    { key: "protocolFee", label: "Venue fee", usd: protocolFeeUsd },
+    { key: "venueExecutionImpact", label: "Open execution impact", usd: openImpactUsd },
+    { key: "venueExecutionImpact", label: "Close execution impact", usd: closeImpactUsd },
+    { key: "funding", label: "Funding", usd: fundingUsd },
+    { key: "networkFee", label: "Network fee", usd: 0n },
+  ];
+
+  return {
+    providerId: "hyperliquid",
+    totalUsd: sumTradingCostComponents(components),
+    components,
+    timestamp: book.time,
+    status: "ready",
+    warnings: [],
+  };
+}
+```
+
+- [ ] **Step 5: Add trading costs hook**
+
+Create `src/domain/tradingCosts/useTradingCosts.ts`:
+
+```ts
+import { useMemo } from "react";
+
+import {
+  selectChainId,
+  selectGasLimits,
+  selectGasPrice,
+  selectMarketsInfoData,
+  selectTokensData,
+} from "context/SyntheticsStateContext/selectors/globalSelectors";
+import { useSelector } from "context/SyntheticsStateContext/utils";
+import { getGmxTradingCostBreakdown } from "domain/tradingCosts/gmx/gmxCost";
+
+import { buildTradingCostRows } from "./buildTradingCostRows";
+import { filterTradingCostRows } from "./costs";
+import { buildHyperliquidBreakdown, getHyperliquidVenueMarkets } from "./hyperliquid/buildHyperliquidBreakdown";
+import { useHyperliquidL2Books, useHyperliquidMarkets } from "./hyperliquid/useHyperliquidData";
+import type { TradingCostScenario } from "./types";
+
+export function useTradingCosts({ scenario, search }: { scenario: TradingCostScenario; search: string }) {
+  const chainId = useSelector(selectChainId);
+  const marketsInfoData = useSelector(selectMarketsInfoData);
+  const gasLimits = useSelector(selectGasLimits);
+  const gasPrice = useSelector(selectGasPrice);
+  const tokensData = useSelector(selectTokensData);
+
+  const gmxMarkets = useMemo(() => Object.values(marketsInfoData ?? {}), [marketsInfoData]);
+  const hyperliquidMarkets = useHyperliquidMarkets();
+  const venueMarkets = useMemo(
+    () => getHyperliquidVenueMarkets(hyperliquidMarkets.markets ?? []),
+    [hyperliquidMarkets.markets]
+  );
+  const coins = useMemo(() => venueMarkets.map((market) => market.symbol), [venueMarkets]);
+  const hyperliquidBooks = useHyperliquidL2Books(coins);
+
+  const rows = useMemo(() => {
+    const builtRows = buildTradingCostRows({
+      scenario,
+      gmxMarkets,
+      venueMarkets,
+      buildGmxBreakdown: (marketInfo) =>
+        getGmxTradingCostBreakdown({
+          marketInfo,
+          sizeUsd: scenario.sizeUsd,
+          side: scenario.side,
+          holdingPeriodHours: scenario.holdingPeriodHours,
+          chainId,
+          gasLimits,
+          gasPrice,
+          tokensData,
+          timestamp: Date.now(),
+        }),
+      buildVenueBreakdown: (match) =>
+        buildHyperliquidBreakdown({
+          match,
+          scenario,
+          market: hyperliquidMarkets.markets?.find((item) => item.symbol === match.venueMarket.symbol),
+          book: hyperliquidBooks.booksByCoin?.[match.venueMarket.symbol],
+        }),
+    });
+
+    return filterTradingCostRows(builtRows, search);
+  }, [
+    chainId,
+    gasLimits,
+    gasPrice,
+    gmxMarkets,
+    hyperliquidBooks.booksByCoin,
+    hyperliquidMarkets.markets,
+    scenario,
+    search,
+    tokensData,
+    venueMarkets,
+  ]);
+
+  return {
+    rows,
+    isLoading: hyperliquidMarkets.isLoading || hyperliquidBooks.isLoading || !marketsInfoData,
+    error: hyperliquidMarkets.error ?? hyperliquidBooks.error,
+  };
+}
+```
+
+- [ ] **Step 6: Run row composition test**
+
+Run: `yarn vitest run src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/domain/tradingCosts/buildTradingCostRows.ts src/domain/tradingCosts/useTradingCosts.ts src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts
+git commit -m "feat: compose trading cost rows"
+```
+
+## Task 7: Trading Costs View And Page
+
+**Files:**
+- Create: `src/pages/TradingCosts/TradingCosts.tsx`
+- Create: `src/pages/TradingCosts/TradingCostsView.tsx`
+- Create: `src/pages/TradingCosts/TradingCosts.scss`
+- Test: `src/pages/TradingCosts/__tests__/TradingCostsView.ct.stories.tsx`
+- Test: `src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx`
+
+- [ ] **Step 1: Write the component test**
+
+```tsx
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { numberToUsd } from "domain/tradingCosts/costs";
+import type { TradingCostRow } from "domain/tradingCosts/types";
+
+import { TradingCostsView } from "../TradingCostsView";
+
+const baseBreakdown = {
+  providerId: "gmx" as const,
+  totalUsd: numberToUsd(20),
+  components: [
+    { key: "protocolFee" as const, label: "Protocol fee", usd: numberToUsd(10) },
+    { key: "openPriceImpact" as const, label: "Open price impact", usd: numberToUsd(3) },
+  ],
+  timestamp: 1,
+  status: "ready" as const,
+  warnings: [],
+};
+
+const rows: TradingCostRow[] = [
+  {
+    marketKey: "hyperliquid:ETH:0x1",
+    displayName: "ETH/USD [WETH-USDC]",
+    indexSymbol: "ETH",
+    venueVolume24hUsd: numberToUsd(1_000_000),
+    gmx: baseBreakdown,
+    venue: { ...baseBreakdown, providerId: "hyperliquid", totalUsd: numberToUsd(15) },
+    deltaUsd: numberToUsd(5),
+    status: "ready",
+  },
+];
+
+test("renders generic venue labels and selected market details", async ({ mount }) => {
+  const component = await mount(
+    <TradingCostsView
+      rows={rows}
+      isLoading={false}
+      search=""
+      setSearch={() => undefined}
+      sizeUsdInput="10000"
+      setSizeUsdInput={() => undefined}
+      side="long"
+      setSide={() => undefined}
+      holdingPeriodPreset="8"
+      setHoldingPeriodPreset={() => undefined}
+      customHoldingHoursInput=""
+      setCustomHoldingHoursInput={() => undefined}
+      takerFeeInput="0.045"
+      setTakerFeeInput={() => undefined}
+    />
+  );
+
+  await expect(component.getByText("Trading Costs")).toBeVisible();
+  await expect(component.getByText("Venue total")).toBeVisible();
+  await expect(component.getByText("Venue assumptions")).toBeVisible();
+  await expect(component.getByText("ETH/USD [WETH-USDC]")).toBeVisible();
+  await expect(component.getByText("Selected market")).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run component test to verify it fails**
+
+Run: `yarn test:ct src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx --project=chromium`
+
+Expected: FAIL because `TradingCostsView.tsx` does not exist.
+
+- [ ] **Step 3: Add presentational view**
+
+Create `src/pages/TradingCosts/TradingCostsView.tsx`:
+
+```tsx
+import { Trans } from "@lingui/macro";
+import { useMemo, useState } from "react";
+
+import type { TradingCostRow, TradingCostSide } from "domain/tradingCosts/types";
+import { formatUsd } from "lib/numbers";
+
+import NumberInput from "components/NumberInput/NumberInput";
+import SearchInput from "components/SearchInput/SearchInput";
+import Select from "components/Select/Select";
+import { Table, TableTd, TableTh, TableTheadTr, TableTr } from "components/Table/Table";
+import Tabs from "components/Tabs/Tabs";
+
+export type HoldingPeriodPreset = "1" | "8" | "24" | "custom";
+
+export function TradingCostsView({
+  rows,
+  isLoading,
+  search,
+  setSearch,
+  sizeUsdInput,
+  setSizeUsdInput,
+  side,
+  setSide,
+  holdingPeriodPreset,
+  setHoldingPeriodPreset,
+  customHoldingHoursInput,
+  setCustomHoldingHoursInput,
+  takerFeeInput,
+  setTakerFeeInput,
+}: {
+  rows: TradingCostRow[];
+  isLoading: boolean;
+  search: string;
+  setSearch: (value: string) => void;
+  sizeUsdInput: string;
+  setSizeUsdInput: (value: string) => void;
+  side: TradingCostSide;
+  setSide: (value: TradingCostSide) => void;
+  holdingPeriodPreset: HoldingPeriodPreset;
+  setHoldingPeriodPreset: (value: HoldingPeriodPreset) => void;
+  customHoldingHoursInput: string;
+  setCustomHoldingHoursInput: (value: string) => void;
+  takerFeeInput: string;
+  setTakerFeeInput: (value: string) => void;
+}) {
+  const [selectedMarketKey, setSelectedMarketKey] = useState<string | undefined>();
+  const selectedRow = useMemo(() => rows.find((row) => row.marketKey === selectedMarketKey) ?? rows[0], [rows, selectedMarketKey]);
+
+  return (
+    <div className="TradingCosts">
+      <div className="TradingCosts-header">
+        <div>
+          <h1><Trans>Trading Costs</Trans></h1>
+          <p><Trans>Round-trip current cost comparison across matched perps markets.</Trans></p>
+        </div>
+        <div className="TradingCosts-provider">Compare venue: Hyperliquid</div>
+      </div>
+
+      <div className="TradingCosts-controls">
+        <SearchInput value={search} setValue={setSearch} placeholder="Search market" />
+        <label>
+          <span>Size, USD</span>
+          <NumberInput value={sizeUsdInput} onValueChange={(event) => setSizeUsdInput(event.target.value)} className="TradingCosts-input" />
+        </label>
+        <Tabs
+          type="inline"
+          selectedValue={side}
+          onChange={(value) => setSide(value as TradingCostSide)}
+          options={[
+            { value: "long", label: "Long" },
+            { value: "short", label: "Short" },
+          ]}
+        />
+        <Select
+          value={holdingPeriodPreset}
+          onChange={(event) => setHoldingPeriodPreset(event.target.value as HoldingPeriodPreset)}
+          options={[
+            { value: "1", label: "1h" },
+            { value: "8", label: "8h" },
+            { value: "24", label: "24h" },
+            { value: "custom", label: "Custom" },
+          ]}
+        />
+        {holdingPeriodPreset === "custom" && (
+          <label>
+            <span>Custom hours</span>
+            <NumberInput value={customHoldingHoursInput} onValueChange={(event) => setCustomHoldingHoursInput(event.target.value)} className="TradingCosts-input" />
+          </label>
+        )}
+        <label>
+          <span>Venue assumptions</span>
+          <NumberInput value={takerFeeInput} onValueChange={(event) => setTakerFeeInput(event.target.value)} className="TradingCosts-input" />
+        </label>
+      </div>
+
+      <div className="TradingCosts-layout">
+        <div className="TradingCosts-tableWrap">
+          <Table>
+            <thead>
+              <TableTheadTr>
+                <TableTh>Market</TableTh>
+                <TableTh>Venue volume</TableTh>
+                <TableTh>GMX total</TableTh>
+                <TableTh>Venue total</TableTh>
+                <TableTh>Delta</TableTh>
+                <TableTh>Status</TableTh>
+              </TableTheadTr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <TableTr key={row.marketKey} hoverable onClick={() => setSelectedMarketKey(row.marketKey)}>
+                  <TableTd>{row.displayName}</TableTd>
+                  <TableTd>{formatUsd(row.venueVolume24hUsd)}</TableTd>
+                  <TableTd>{formatUsd(row.gmx.totalUsd)}</TableTd>
+                  <TableTd>{formatUsd(row.venue.totalUsd)}</TableTd>
+                  <TableTd>{formatUsd(row.deltaUsd)}</TableTd>
+                  <TableTd>{row.status}</TableTd>
+                </TableTr>
+              ))}
+            </tbody>
+          </Table>
+          {!rows.length && <div className="TradingCosts-empty">{isLoading ? "Loading..." : "No matched markets"}</div>}
+        </div>
+
+        <aside className="TradingCosts-details">
+          <h2>Selected market</h2>
+          {selectedRow ? (
+            <>
+              <div className="TradingCosts-detailTitle">{selectedRow.displayName}</div>
+              <Breakdown title="GMX" row={selectedRow} provider="gmx" />
+              <Breakdown title="Venue" row={selectedRow} provider="venue" />
+            </>
+          ) : (
+            <p>No market selected</p>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function Breakdown({ title, row, provider }: { title: string; row: TradingCostRow; provider: "gmx" | "venue" }) {
+  const breakdown = row[provider];
+  return (
+    <div className="TradingCosts-breakdown">
+      <h3>{title}</h3>
+      {breakdown.components.map((component, index) => (
+        <div key={`${component.key}-${index}`} className="TradingCosts-breakdownRow">
+          <span>{component.label}</span>
+          <span>{formatUsd(component.usd)}</span>
+        </div>
+      ))}
+      <div className="TradingCosts-breakdownTotal">
+        <span>Total</span>
+        <span>{formatUsd(breakdown.totalUsd)}</span>
+      </div>
+      {!!breakdown.warnings.length && (
+        <ul>
+          {breakdown.warnings.map((warning) => (
+            <li key={warning}>{warning}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Add page container**
+
+Create `src/pages/TradingCosts/TradingCosts.tsx`:
+
+```tsx
+import { useMemo, useState } from "react";
+
+import { numberToUsd } from "domain/tradingCosts/costs";
+import { useTradingCosts } from "domain/tradingCosts/useTradingCosts";
+import type { TradingCostScenario, TradingCostSide } from "domain/tradingCosts/types";
+
+import AppPageLayout from "components/AppPageLayout/AppPageLayout";
+
+import { HoldingPeriodPreset, TradingCostsView } from "./TradingCostsView";
+import "./TradingCosts.scss";
+
+const DEFAULT_SIZE_USD = "10000";
+const DEFAULT_HYPERLIQUID_TAKER_FEE_PERCENT = "0.045";
+
+export function TradingCostsPage() {
+  const [search, setSearch] = useState("");
+  const [sizeUsdInput, setSizeUsdInput] = useState(DEFAULT_SIZE_USD);
+  const [side, setSide] = useState<TradingCostSide>("long");
+  const [holdingPeriodPreset, setHoldingPeriodPreset] = useState<HoldingPeriodPreset>("8");
+  const [customHoldingHoursInput, setCustomHoldingHoursInput] = useState("");
+  const [takerFeeInput, setTakerFeeInput] = useState(DEFAULT_HYPERLIQUID_TAKER_FEE_PERCENT);
+
+  const holdingPeriodHours = holdingPeriodPreset === "custom" ? Number(customHoldingHoursInput || "0") : Number(holdingPeriodPreset);
+  const scenario = useMemo<TradingCostScenario>(
+    () => ({
+      sizeUsd: numberToUsd(Number(sizeUsdInput || "0")),
+      side,
+      holdingPeriodHours,
+      comparisonVenue: "hyperliquid",
+      venueAssumptions: {
+        hyperliquid: { takerFeeRate: Number(takerFeeInput || "0") / 100 },
+      },
+    }),
+    [holdingPeriodHours, side, sizeUsdInput, takerFeeInput]
+  );
+
+  const { rows, isLoading } = useTradingCosts({ scenario, search });
+
+  return (
+    <AppPageLayout title="Trading Costs" contentClassName="!max-w-[1760px]">
+      <TradingCostsView
+        rows={rows}
+        isLoading={isLoading}
+        search={search}
+        setSearch={setSearch}
+        sizeUsdInput={sizeUsdInput}
+        setSizeUsdInput={setSizeUsdInput}
+        side={side}
+        setSide={setSide}
+        holdingPeriodPreset={holdingPeriodPreset}
+        setHoldingPeriodPreset={setHoldingPeriodPreset}
+        customHoldingHoursInput={customHoldingHoursInput}
+        setCustomHoldingHoursInput={setCustomHoldingHoursInput}
+        takerFeeInput={takerFeeInput}
+        setTakerFeeInput={setTakerFeeInput}
+      />
+    </AppPageLayout>
+  );
+}
+```
+
+- [ ] **Step 5: Add styles**
+
+Create `src/pages/TradingCosts/TradingCosts.scss`:
+
+```scss
+.TradingCosts {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.TradingCosts-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+
+  h1 {
+    margin: 0;
+    font-size: 24px;
+    line-height: 32px;
+  }
+
+  p {
+    margin: 4px 0 0;
+    color: var(--color-typography-secondary);
+  }
+}
+
+.TradingCosts-provider,
+.TradingCosts-details,
+.TradingCosts-tableWrap,
+.TradingCosts-controls {
+  border: 1px solid var(--color-slate-600);
+  border-radius: 8px;
+  background: var(--color-slate-900);
+}
+
+.TradingCosts-provider {
+  padding: 8px 12px;
+  white-space: nowrap;
+}
+
+.TradingCosts-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.4fr) repeat(5, minmax(120px, 1fr));
+  gap: 10px;
+  padding: 12px;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--color-typography-secondary);
+  }
+}
+
+.TradingCosts-input {
+  height: 32px;
+  border: 1px solid var(--color-slate-600);
+  border-radius: 8px;
+  background: var(--color-slate-800);
+  padding: 0 10px;
+}
+
+.TradingCosts-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 16px;
+  align-items: start;
+}
+
+.TradingCosts-tableWrap {
+  overflow-x: auto;
+}
+
+.TradingCosts-details {
+  padding: 16px;
+}
+
+.TradingCosts-detailTitle {
+  margin-bottom: 12px;
+  font-weight: 600;
+}
+
+.TradingCosts-breakdown {
+  border-top: 1px solid var(--color-slate-600);
+  padding-top: 12px;
+  margin-top: 12px;
+}
+
+.TradingCosts-breakdownRow,
+.TradingCosts-breakdownTotal {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.TradingCosts-breakdownTotal {
+  font-weight: 600;
+}
+
+.TradingCosts-empty {
+  padding: 20px;
+  color: var(--color-typography-secondary);
+}
+
+@media (max-width: 1100px) {
+  .TradingCosts-controls,
+  .TradingCosts-layout {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+- [ ] **Step 6: Add component test story export**
+
+Create `src/pages/TradingCosts/__tests__/TradingCostsView.ct.stories.tsx`:
+
+```tsx
+import { useState } from "react";
+
+import { numberToUsd } from "domain/tradingCosts/costs";
+import type { TradingCostRow, TradingCostSide } from "domain/tradingCosts/types";
+
+import { HoldingPeriodPreset, TradingCostsView } from "../TradingCostsView";
+import "../TradingCosts.scss";
+
+const baseBreakdown = {
+  providerId: "gmx" as const,
+  totalUsd: numberToUsd(20),
+  components: [{ key: "protocolFee" as const, label: "Protocol fee", usd: numberToUsd(10) }],
+  timestamp: 1,
+  status: "ready" as const,
+  warnings: [],
+};
+
+export function TradingCostsViewStory() {
+  const [search, setSearch] = useState("");
+  const [sizeUsdInput, setSizeUsdInput] = useState("10000");
+  const [side, setSide] = useState<TradingCostSide>("long");
+  const [holdingPeriodPreset, setHoldingPeriodPreset] = useState<HoldingPeriodPreset>("8");
+  const [customHoldingHoursInput, setCustomHoldingHoursInput] = useState("");
+  const [takerFeeInput, setTakerFeeInput] = useState("0.045");
+
+  const rows: TradingCostRow[] = [
+    {
+      marketKey: "hyperliquid:ETH:0x1",
+      displayName: "ETH/USD [WETH-USDC]",
+      indexSymbol: "ETH",
+      venueVolume24hUsd: numberToUsd(1_000_000),
+      gmx: baseBreakdown,
+      venue: { ...baseBreakdown, providerId: "hyperliquid", totalUsd: numberToUsd(15) },
+      deltaUsd: numberToUsd(5),
+      status: "ready",
+    },
+  ];
+
+  return (
+    <TradingCostsView
+      rows={rows}
+      isLoading={false}
+      search={search}
+      setSearch={setSearch}
+      sizeUsdInput={sizeUsdInput}
+      setSizeUsdInput={setSizeUsdInput}
+      side={side}
+      setSide={setSide}
+      holdingPeriodPreset={holdingPeriodPreset}
+      setHoldingPeriodPreset={setHoldingPeriodPreset}
+      customHoldingHoursInput={customHoldingHoursInput}
+      setCustomHoldingHoursInput={setCustomHoldingHoursInput}
+      takerFeeInput={takerFeeInput}
+      setTakerFeeInput={setTakerFeeInput}
+    />
+  );
+}
+```
+
+- [ ] **Step 7: Run component test**
+
+Run: `yarn test:ct src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx --project=chromium`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/TradingCosts
+git commit -m "feat: add trading costs page view"
+```
+
+## Task 8: Route, Page Type, And Side Nav
+
+**Files:**
+- Modify: `src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx`
+- Modify: `src/App/MainRoutes.tsx`
+- Modify: `src/components/SideNav/SideNav.tsx`
+
+- [ ] **Step 1: Run TypeScript before edits to establish baseline**
+
+Run: `yarn tsc -p tsconfig.json --noEmit --incremental`
+
+Expected: PASS before route wiring.
+
+- [ ] **Step 2: Add page type**
+
+Modify `src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx` in `SyntheticsPageType`:
+
+```ts
+export type SyntheticsPageType =
+  | "accounts"
+  | "trade"
+  | "pools"
+  | "leaderboard"
+  | "competitions"
+  | "stats"
+  | "tradingCosts"
+  | "earn"
+  | "buy"
+  | "home"
+  | "gmxAccount"
+  | "referrals"
+  | "rpcDebug";
+```
+
+- [ ] **Step 3: Add route**
+
+Modify `src/App/MainRoutes.tsx` imports:
+
+```ts
+import { TradingCostsPage } from "pages/TradingCosts/TradingCosts";
+```
+
+Add route after `/monitor`:
+
+```tsx
+<Route exact path="/costs">
+  <SyntheticsStateContextProvider skipLocalReferralCode pageType="tradingCosts">
+    <TradingCostsPage />
+  </SyntheticsStateContextProvider>
+</Route>
+```
+
+- [ ] **Step 4: Add side navigation item**
+
+Modify `src/components/SideNav/SideNav.tsx` in `mainNavItems` after Stats:
+
+```tsx
+{ icon: <DashboardIcon className="size-20" />, label: t`Costs`, key: "costs", to: "/costs" },
+```
+
+- [ ] **Step 5: Run TypeScript**
+
+Run: `yarn tsc -p tsconfig.json --noEmit --incremental`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx src/App/MainRoutes.tsx src/components/SideNav/SideNav.tsx
+git commit -m "feat: route trading costs dashboard"
+```
+
+## Task 9: Final Verification And UX Check
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+yarn vitest run \
+  src/domain/tradingCosts/__tests__/costs.spec.ts \
+  src/domain/tradingCosts/__tests__/marketMatching.spec.ts \
+  src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts \
+  src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts \
+  src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts \
+  src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run component test**
+
+Run: `yarn test:ct src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx --project=chromium`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run TypeScript**
+
+Run: `yarn tsc -p tsconfig.json --noEmit --incremental`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run app server**
+
+Run: `yarn start-app`
+
+Expected: Vite starts and prints a local URL, usually `http://localhost:3011/`.
+
+- [ ] **Step 5: Open and inspect the page**
+
+Open `http://localhost:3011/#/costs`.
+
+Expected:
+
+- Page title says `Trading Costs`.
+- Controls show generic `Compare venue` and `Venue assumptions` language.
+- Table rows are sorted by venue volume descending after Hyperliquid data loads.
+- Selecting a row updates the detail panel.
+- Custom holding period reveals the custom hours input.
+
+- [ ] **Step 6: Stop dev server**
+
+Stop the `yarn start-app` process with `Ctrl-C`.
+
+- [ ] **Step 7: Commit verification fixes when they exist**
+
+When verification requires small fixes, commit them:
+
+```bash
+git add src/domain/tradingCosts src/pages/TradingCosts src/App/MainRoutes.tsx src/components/SideNav/SideNav.tsx src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx
+git commit -m "fix: polish trading costs dashboard"
+```
+
+When no fixes were required, skip this commit.
+
+## Self-Review Notes
+
+- Spec coverage: Tasks cover the venue-agnostic model, GMX cost components, Hyperliquid data and L2 impact, all matched markets sorted by venue volume, generic UI labels, route/nav, status handling, and current snapshot timestamps.
+- Plan hygiene: The implementation steps contain no unresolved markers, missing paths, or vague test instructions.
+- Type consistency: `TradingCostScenario`, `TradingCostRow`, `TradingCostBreakdown`, and `TradingCostStatus` names are consistent across tasks.

--- a/docs/superpowers/specs/2026-05-24-trading-costs-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-24-trading-costs-dashboard-design.md
@@ -1,0 +1,257 @@
+# Trading Costs Dashboard Design
+
+## Summary
+
+Build a dedicated internal app page at `#/costs` for comparing current GMX perps trading costs against other perps venues. V1 implements GMX vs Hyperliquid, but the UI and data model must be venue-agnostic so Lighter, Ostium, Aster, GMTrade, and other venues can be added later.
+
+The page is a market screener: one global trade scenario is applied across all matched markets, rows are sorted by selected venue 24h volume, and a selected-market panel shows the cost breakdown and data-source audit details.
+
+## Goals
+
+- Compare current round-trip expected cost by market, trade size, side, and holding period.
+- Include GMX costs that matter for a round trip: protocol position fees, open price impact, close price impact, net-rate cost, and network fees.
+- Include Hyperliquid costs using current venue data: taker/protocol fee, live L2 order book depth impact, and projected funding over the holding period.
+- Default to all GMX markets that have a matching market on the selected comparison venue.
+- Sort the screener by selected venue 24h volume. For V1, this is Hyperliquid volume.
+- Provide search/filter by market symbol or name.
+- Keep all visible UI labels generic: `Compare venue`, `Venue assumptions`, `Venue total`, `Venue volume`.
+- Make current snapshot outputs timestamped and provider-labeled so future historical comparison can reuse the same normalized model.
+
+## Non-Goals For V1
+
+- Historical charts or persisted historical snapshots.
+- More comparison venues beyond Hyperliquid.
+- Maker order simulation.
+- Wallet/account-specific discounts unless already available without adding account assumptions.
+- Collateral swap routing costs for GMX round-trip position simulation.
+- Automated routing recommendations or trade execution.
+
+## UX Design
+
+The page uses `AppPageLayout` and is styled as an internal analytics surface: dense, scannable, and auditable.
+
+Top controls:
+
+- Search market.
+- Trade size in USD.
+- Side selector: `Long` or `Short`.
+- Holding period selector: `1h`, `8h`, `24h`, and `Custom`.
+- Compare venue selector. V1 has only `Hyperliquid`.
+- Venue assumptions control. V1 exposes Hyperliquid's editable taker fee here, defaulting to the base taker fee of `0.045%` (`0.00045` decimal).
+
+Main table:
+
+- Market.
+- Venue 24h volume.
+- GMX total cost.
+- Venue total cost.
+- Delta, where positive means GMX costs more than the selected venue.
+- GMX price impact total.
+- Status.
+
+Rows are sorted by selected venue 24h volume descending by default. Search filters the table but does not change the selected scenario inputs.
+
+Selecting a row opens or updates a right-side details panel with:
+
+- Scenario summary.
+- GMX cost breakdown.
+- Selected venue cost breakdown.
+- Data timestamps per provider.
+- Status and warning details, including omitted assumptions.
+
+The route is available at `#/costs`. Add the page to the side navigation as `Costs`.
+
+## Architecture
+
+Create a venue-agnostic domain area:
+
+- `src/domain/tradingCosts/`
+
+This domain owns shared types, pure cost math, market matching, filtering, sorting, and provider adapter boundaries. Page components consume normalized cost rows and must not depend on Hyperliquid-specific response shapes.
+
+Core modules:
+
+- `types.ts`: scenario inputs, provider ids, cost components, row statuses, normalized rows.
+- `costs.ts`: pure helpers for summing components, calculating deltas, converting signs, filtering, and sorting.
+- `marketMatching.ts`: maps GMX index symbols to selected venue markets and records unmatched markets.
+- `gmxCostAdapter.ts`: computes GMX round-trip costs from current GMX market data and existing synthetics fee utilities.
+- `comparisonVenueAdapter.ts`: common interface for external perps venue adapters.
+- `hyperliquid/`: Hyperliquid fetchers, response normalization, L2 book depth simulation, and adapter implementation.
+
+The app route wraps the page in `SyntheticsStateContextProvider` with a new `tradingCosts` page type. This page type uses the existing provider behavior that fetches tokens, markets, market info, gas limits, and gas price without enabling trade-page-only account workflows.
+
+## Normalized Types
+
+The normalized model represents every row independently of venue:
+
+```ts
+type TradingCostProviderId = "gmx" | "hyperliquid";
+
+type TradingCostScenario = {
+  sizeUsd: bigint;
+  side: "long" | "short";
+  holdingPeriodHours: number;
+  comparisonVenue: "hyperliquid";
+  venueAssumptions: {
+    hyperliquid?: {
+      takerFeeRate: number;
+    };
+  };
+};
+
+type TradingCostComponent = {
+  key:
+    | "protocolFee"
+    | "openPriceImpact"
+    | "closePriceImpact"
+    | "netRate"
+    | "networkFee"
+    | "venueExecutionImpact"
+    | "funding";
+  label: string;
+  usd: bigint;
+};
+
+type TradingCostStatus =
+  | "ready"
+  | "loading"
+  | "unmatched"
+  | "insufficientDepth"
+  | "providerError"
+  | "stale";
+
+type TradingCostBreakdown = {
+  providerId: TradingCostProviderId;
+  totalUsd: bigint | undefined;
+  components: TradingCostComponent[];
+  timestamp: number | undefined;
+  status: TradingCostStatus;
+  warnings: string[];
+};
+
+type TradingCostRow = {
+  marketKey: string;
+  displayName: string;
+  indexSymbol: string;
+  venueVolume24hUsd: bigint | undefined;
+  gmx: TradingCostBreakdown;
+  venue: TradingCostBreakdown;
+  deltaUsd: bigint | undefined;
+  status: TradingCostStatus;
+};
+```
+
+Positive component values are costs to the trader. Negative component values are rebates or benefits.
+
+## GMX Cost Model
+
+For each matched GMX market, estimate an immediate open and immediate close for the same USD size and side.
+
+Include:
+
+- Open protocol position fee.
+- Open position price impact.
+- Close protocol position fee.
+- Close position price impact.
+- Net-rate cost over the selected holding period.
+- Network fee estimate for open plus close orders.
+
+Use existing GMX utilities where possible:
+
+- Position fee and fee item helpers from synthetics fee utilities.
+- Position price impact helpers from existing fee utilities.
+- Funding and borrowing factor helpers for net-rate projection.
+- Execution fee helpers with current gas limits and gas price.
+
+The GMX model exposes warnings for V1 omissions:
+
+- Collateral swap routing is not included.
+- Account-specific referral discounts are not included unless already available in context without additional assumptions.
+- Results are current estimates, not guaranteed execution quotes.
+
+## Hyperliquid Adapter
+
+Hyperliquid is the first comparison venue implementation.
+
+Data sources:
+
+- `metaAndAssetCtxs` from the Hyperliquid Info endpoint for market metadata, current context, 24h volume, mark/oracle context, and funding context.
+- `l2Book` from the Hyperliquid Info endpoint for live book depth simulation.
+- Fee schedule reference from Hyperliquid docs for the default base taker fee.
+
+The adapter normalizes Hyperliquid markets by coin symbol and matches them to GMX index symbols. Delisted Hyperliquid markets are excluded from default matched rows.
+
+Round-trip execution impact:
+
+- Long open consumes asks.
+- Long close consumes bids.
+- Short open consumes bids.
+- Short close consumes asks.
+- For each leg, walk returned L2 levels until the requested USD size is filled.
+- If returned levels cannot fill the requested size, set the venue breakdown to `insufficientDepth`.
+
+Costs:
+
+- Taker fee applies to both open and close notional using the selected venue assumptions.
+- Execution impact is calculated from the difference between average fill price and reference mid/mark price.
+- Funding is projected from current funding over the selected holding period.
+- Network fee is `0` for Hyperliquid V1.
+
+## Error Handling
+
+The page remains usable with partial data.
+
+Statuses:
+
+- `ready`: all required data for the row is available.
+- `loading`: provider request is in progress.
+- `unmatched`: GMX market has no selected venue match or selected venue market has no GMX match.
+- `insufficientDepth`: selected venue book levels cannot fill the requested size.
+- `providerError`: a provider request failed.
+- `stale`: provider data exists but is older than the accepted freshness window.
+
+Provider errors appear in row status and the details panel. A failed row or failed venue call must not blank the whole page.
+
+## Testing
+
+Use TDD for implementation.
+
+Unit tests cover:
+
+- Cost component sign convention.
+- Total and delta calculation.
+- GMX round-trip fee summing with open and close price impact.
+- Net-rate projection over `1h`, `8h`, `24h`, and custom periods.
+- Hyperliquid L2 book fill simulation for asks and bids.
+- `insufficientDepth` when book levels cannot fill the requested USD size.
+- Market matching by normalized symbol.
+- Search filtering and venue-volume sorting.
+
+Component tests cover:
+
+- Default controls.
+- Custom holding period behavior.
+- Generic venue assumptions UI.
+- Row status rendering.
+- Selected-market detail panel rendering.
+
+## Future Historical Support
+
+V1 keeps the current snapshot model compatible with historical inputs:
+
+- Every provider breakdown includes a timestamp and provider id.
+- Scenario inputs are serializable.
+- Cost math is pure and can accept current or historical provider snapshots.
+- Provider adapters are separate from cost aggregation.
+
+Future historical work can add:
+
+- Snapshot persistence.
+- Historical GMX market info and gas snapshots.
+- Historical comparison venue books, funding, and fee schedule snapshots.
+- Time-series charts for GMX total, venue total, deltas, and component breakdowns.
+
+## References
+
+- Hyperliquid Info endpoint docs: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals
+- Hyperliquid fee docs: https://hyperliquid.gitbook.io/hyperliquid-docs/trading/fees

--- a/src/App/MainRoutes.spec.tsx
+++ b/src/App/MainRoutes.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { ARBITRUM, ARBITRUM_SEPOLIA } from "config/chains";
+
+vi.mock("lib/chains", () => ({
+  useChainId: () => ({ chainId: ARBITRUM_SEPOLIA }),
+}));
+
+vi.mock("context/SyntheticsStateContext/SyntheticsStateContextProvider", () => ({
+  SyntheticsStateContextProvider: ({
+    children,
+    overrideChainId,
+    pageType,
+  }: {
+    children: React.ReactNode;
+    overrideChainId?: number;
+    pageType: string;
+  }) => (
+    <div data-override-chain-id={overrideChainId ?? ""} data-page-type={pageType} data-testid="synthetics-provider">
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("pages/TradingCosts/TradingCosts", () => ({
+  TradingCostsPage: () => <div>Trading Costs Page</div>,
+}));
+
+import { MainRoutes } from "./MainRoutes";
+
+const COSTS_ROUTE_ENTRIES = ["/costs"];
+
+describe("MainRoutes", () => {
+  it("renders the trading costs dashboard against Arbitrum production markets", () => {
+    render(
+      <MemoryRouter initialEntries={COSTS_ROUTE_ENTRIES}>
+        <MainRoutes openSettings={() => undefined} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Trading Costs Page")).toBeTruthy();
+    expect(screen.getByTestId("synthetics-provider").getAttribute("data-page-type")).toBe("tradingCosts");
+    expect(screen.getByTestId("synthetics-provider").getAttribute("data-override-chain-id")).toBe(String(ARBITRUM));
+  });
+});

--- a/src/App/MainRoutes.tsx
+++ b/src/App/MainRoutes.tsx
@@ -29,6 +29,7 @@ import { ReferralsRouter } from "pages/Referrals/ReferralsRouter";
 import ReferralsTier from "pages/ReferralsTier/ReferralsTier";
 import { SyntheticsPage } from "pages/SyntheticsPage/SyntheticsPage";
 import { SyntheticsStats } from "pages/SyntheticsStats/SyntheticsStats";
+import { TradingCostsPage } from "pages/TradingCosts/TradingCosts";
 
 import { EarnRedirect } from "components/Earn/EarnRedirect";
 import { RedirectWithQuery } from "components/RedirectWithQuery/RedirectWithQuery";
@@ -118,6 +119,11 @@ export function MainRoutes({ openSettings }: { openSettings: () => void }) {
       </Route>
       <Route exact path="/monitor">
         <SyntheticsStats />
+      </Route>
+      <Route exact path="/costs">
+        <SyntheticsStateContextProvider skipLocalReferralCode pageType="tradingCosts">
+          <TradingCostsPage />
+        </SyntheticsStateContextProvider>
       </Route>
       <Route exact path="/earn/discover">
         <SyntheticsStateContextProvider skipLocalReferralCode={false} pageType="earn">

--- a/src/App/MainRoutes.tsx
+++ b/src/App/MainRoutes.tsx
@@ -3,6 +3,7 @@ import { Suspense, lazy, useEffect } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router-dom";
 import type { Address } from "viem";
 
+import { ARBITRUM } from "config/chains";
 import { isDevelopment } from "config/env";
 import { SyntheticsStateContextProvider } from "context/SyntheticsStateContext/SyntheticsStateContextProvider";
 import { useChainId } from "lib/chains";
@@ -121,7 +122,7 @@ export function MainRoutes({ openSettings }: { openSettings: () => void }) {
         <SyntheticsStats />
       </Route>
       <Route exact path="/costs">
-        <SyntheticsStateContextProvider skipLocalReferralCode pageType="tradingCosts">
+        <SyntheticsStateContextProvider skipLocalReferralCode pageType="tradingCosts" overrideChainId={ARBITRUM}>
           <TradingCostsPage />
         </SyntheticsStateContextProvider>
       </Route>

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -193,6 +193,7 @@ export function MenuSection({
       to: "/pools",
     },
     { icon: <DashboardIcon className="size-20" />, label: t`Stats`, key: "stats", to: "/stats" },
+    { icon: <DashboardIcon className="size-20" />, label: t`Costs`, key: "costs", to: "/costs" },
     {
       icon: <ReferralsIcon className="size-20" />,
       label: withMegaethSparkle(t`Referrals`),

--- a/src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx
+++ b/src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx
@@ -87,6 +87,7 @@ export type SyntheticsPageType =
   | "leaderboard"
   | "competitions"
   | "stats"
+  | "tradingCosts"
   | "earn"
   | "buy"
   | "home"

--- a/src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx
+++ b/src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx
@@ -190,6 +190,7 @@ export function SyntheticsStateContextProvider({
 
   const isLeaderboardPage = pageType === "competitions" || pageType === "leaderboard";
   const isTradePage = pageType === "trade";
+  const shouldFetchJitLiquidity = isTradePage || pageType === "tradingCosts";
   const isAccountPage = pageType === "accounts";
 
   const account = isAccountPage ? checkSummedAccount : walletAccount;
@@ -262,7 +263,7 @@ export function SyntheticsStateContextProvider({
   });
 
   const oracleSettings = useOracleSettingsData();
-  const jitLiquidityData = useJitLiquidityRequest(chainId, { enabled: isTradePage });
+  const jitLiquidityData = useJitLiquidityRequest(chainId, { enabled: shouldFetchJitLiquidity });
 
   const [missedCoinsModalPlace, setMissedCoinsModalPlace] = useState<MissedCoinsPlace>();
 

--- a/src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts
+++ b/src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+import { expandDecimals } from "lib/numbers";
+
+import { buildTradingCostRows } from "../buildTradingCostRows";
+import { numberToUsd, usdToNumber } from "../costs";
+import type { TradingCostBreakdown, TradingCostScenario } from "../types";
+
+const scenario: TradingCostScenario = {
+  sizeUsd: expandDecimals(10_000, 30),
+  side: "long",
+  holdingPeriodHours: 8,
+  comparisonVenue: "hyperliquid",
+  venueAssumptions: { hyperliquid: { takerFeeRate: 0.00045 } },
+};
+
+function breakdown(providerId: "gmx" | "hyperliquid", totalUsd: bigint | undefined): TradingCostBreakdown {
+  return {
+    providerId,
+    totalUsd,
+    components: [],
+    timestamp: 1,
+    status: totalUsd === undefined ? "providerError" : "ready",
+    warnings: [],
+  };
+}
+
+describe("buildTradingCostRows", () => {
+  it("builds matched rows, calculates delta, and sorts by venue volume", () => {
+    const eth = createMockMarketInfo();
+    const btc = {
+      ...createMockMarketInfo(),
+      marketTokenAddress: "0xbtc",
+      name: "BTC/USD [BTC-USDC]",
+      indexToken: { ...createMockMarketInfo().indexToken, symbol: "BTC" },
+    };
+
+    const rows = buildTradingCostRows({
+      scenario,
+      gmxMarkets: [eth, btc],
+      venueMarkets: [
+        { providerId: "hyperliquid", symbol: "ETH", displayName: "ETH", volume24hUsd: numberToUsd(100) },
+        { providerId: "hyperliquid", symbol: "BTC", displayName: "BTC", volume24hUsd: numberToUsd(200) },
+      ],
+      buildGmxBreakdown: (market) =>
+        breakdown("gmx", market.marketTokenAddress === "0xbtc" ? numberToUsd(12) : numberToUsd(20)),
+      buildVenueBreakdown: (match) =>
+        breakdown("hyperliquid", match.venueMarket.symbol === "BTC" ? numberToUsd(10) : numberToUsd(15)),
+    });
+
+    expect(rows.map((row) => row.indexSymbol)).toEqual(["BTC", "ETH"]);
+    expect(usdToNumber(rows[0].deltaUsd)).toBeCloseTo(2, 6);
+    expect(usdToNumber(rows[1].deltaUsd)).toBeCloseTo(5, 6);
+  });
+});

--- a/src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts
+++ b/src/domain/tradingCosts/__tests__/buildTradingCostRows.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
 import { expandDecimals } from "lib/numbers";
 
-import { buildTradingCostRows } from "../buildTradingCostRows";
+import { buildTradingCostRows, getMatchedVenueSymbols } from "../buildTradingCostRows";
 import { numberToUsd, usdToNumber } from "../costs";
 import type { TradingCostBreakdown, TradingCostScenario } from "../types";
 
@@ -52,5 +52,31 @@ describe("buildTradingCostRows", () => {
     expect(rows.map((row) => row.indexSymbol)).toEqual(["BTC", "ETH"]);
     expect(usdToNumber(rows[0].deltaUsd)).toBeCloseTo(2, 6);
     expect(usdToNumber(rows[1].deltaUsd)).toBeCloseTo(5, 6);
+  });
+
+  it("returns only matched venue symbols for book requests", () => {
+    const eth = createMockMarketInfo();
+    const btc = {
+      ...createMockMarketInfo(),
+      marketTokenAddress: "0xbtc",
+      name: "BTC/USD [BTC-USDC]",
+      indexToken: { ...createMockMarketInfo().indexToken, symbol: "BTC" },
+    };
+    const secondEth = {
+      ...createMockMarketInfo(),
+      marketTokenAddress: "0xeth2",
+      name: "ETH/USD [ETH-USDT]",
+    };
+
+    const symbols = getMatchedVenueSymbols({
+      gmxMarkets: [eth, btc, secondEth],
+      venueMarkets: [
+        { providerId: "hyperliquid", symbol: "ETH", displayName: "ETH", volume24hUsd: numberToUsd(100) },
+        { providerId: "hyperliquid", symbol: "BTC", displayName: "BTC", volume24hUsd: numberToUsd(200) },
+        { providerId: "hyperliquid", symbol: "DOGE", displayName: "DOGE", volume24hUsd: numberToUsd(300) },
+      ],
+    });
+
+    expect(symbols).toEqual(["ETH", "BTC"]);
   });
 });

--- a/src/domain/tradingCosts/__tests__/costs.spec.ts
+++ b/src/domain/tradingCosts/__tests__/costs.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateDeltaUsd,
+  filterTradingCostRows,
+  getCombinedStatus,
+  numberToUsd,
+  sortTradingCostRowsByVenueVolume,
+  sumTradingCostComponents,
+  usdToNumber,
+} from "../costs";
+import type { TradingCostRow } from "../types";
+
+const readyBreakdown = {
+  providerId: "gmx" as const,
+  totalUsd: 0n,
+  components: [],
+  timestamp: 1,
+  status: "ready" as const,
+  warnings: [],
+};
+
+function row(overrides: Partial<TradingCostRow>): TradingCostRow {
+  return {
+    marketKey: "ETH:0x1",
+    displayName: "ETH/USD [WETH-USDC]",
+    indexSymbol: "ETH",
+    venueVolume24hUsd: 0n,
+    gmx: readyBreakdown,
+    venue: { ...readyBreakdown, providerId: "hyperliquid" },
+    deltaUsd: 0n,
+    status: "ready",
+    ...overrides,
+  };
+}
+
+describe("trading cost helpers", () => {
+  it("uses positive values as costs and negative values as rebates", () => {
+    expect(
+      sumTradingCostComponents([
+        { key: "protocolFee", label: "Protocol fee", usd: 100n },
+        { key: "openPriceImpact", label: "Open price impact", usd: -25n },
+        { key: "networkFee", label: "Network fee", usd: 5n },
+      ])
+    ).toBe(80n);
+  });
+
+  it("calculates positive delta when GMX costs more than the venue", () => {
+    expect(calculateDeltaUsd(150n, 90n)).toBe(60n);
+    expect(calculateDeltaUsd(undefined, 90n)).toBeUndefined();
+    expect(calculateDeltaUsd(150n, undefined)).toBeUndefined();
+  });
+
+  it("preserves USD values through number conversion within six decimal places", () => {
+    const usd = numberToUsd(12.345678);
+    expect(usdToNumber(usd)).toBeCloseTo(12.345678, 6);
+  });
+
+  it("combines statuses by severity", () => {
+    expect(getCombinedStatus("ready", "ready")).toBe("ready");
+    expect(getCombinedStatus("ready", "insufficientDepth")).toBe("insufficientDepth");
+    expect(getCombinedStatus("providerError", "insufficientDepth")).toBe("providerError");
+  });
+
+  it("filters rows by market display name and symbol", () => {
+    const rows = [
+      row({ displayName: "ETH/USD [WETH-USDC]", indexSymbol: "ETH" }),
+      row({ displayName: "BTC/USD [BTC-USDC]", indexSymbol: "BTC", marketKey: "BTC:0x2" }),
+    ];
+
+    expect(filterTradingCostRows(rows, "eth").map((r) => r.indexSymbol)).toEqual(["ETH"]);
+    expect(filterTradingCostRows(rows, "btc-usd").map((r) => r.indexSymbol)).toEqual(["BTC"]);
+    expect(filterTradingCostRows(rows, "").length).toBe(2);
+  });
+
+  it("sorts rows by selected venue 24h volume descending and puts unknown volume last", () => {
+    const rows = [
+      row({ indexSymbol: "ETH", venueVolume24hUsd: numberToUsd(100) }),
+      row({ indexSymbol: "BTC", venueVolume24hUsd: numberToUsd(300), marketKey: "BTC:0x2" }),
+      row({ indexSymbol: "SOL", venueVolume24hUsd: undefined, marketKey: "SOL:0x3" }),
+    ];
+
+    expect(sortTradingCostRowsByVenueVolume(rows).map((r) => r.indexSymbol)).toEqual(["BTC", "ETH", "SOL"]);
+  });
+});

--- a/src/domain/tradingCosts/__tests__/marketMatching.spec.ts
+++ b/src/domain/tradingCosts/__tests__/marketMatching.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+
+import { matchGmxMarketsToVenueMarkets, normalizeMarketSymbol } from "../marketMatching";
+import type { ComparisonVenueMarket } from "../types";
+
+const hyperliquidEth: ComparisonVenueMarket = {
+  providerId: "hyperliquid",
+  symbol: "ETH",
+  displayName: "ETH",
+  volume24hUsd: 100n,
+};
+
+describe("market matching", () => {
+  it("normalizes wrapped symbols to venue symbols", () => {
+    expect(normalizeMarketSymbol("WETH")).toBe("ETH");
+    expect(normalizeMarketSymbol("WBTC")).toBe("BTC");
+    expect(normalizeMarketSymbol("kPEPE")).toBe("KPEPE");
+  });
+
+  it("matches every enabled non-spot GMX market with a venue symbol", () => {
+    const ethMarket = createMockMarketInfo();
+    const secondEthMarket = { ...ethMarket, marketTokenAddress: "0x222", name: "ETH/USD [ETH-USDT]" };
+
+    const result = matchGmxMarketsToVenueMarkets([ethMarket, secondEthMarket], [hyperliquidEth]);
+
+    expect(result.matched.map((item) => item.gmxMarket.marketTokenAddress)).toEqual([
+      ethMarket.marketTokenAddress,
+      "0x222",
+    ]);
+    expect(result.unmatched).toEqual([]);
+  });
+
+  it("excludes disabled, spot-only, and disabled venue markets from matched rows", () => {
+    const enabledMarket = createMockMarketInfo();
+    const disabledMarket = { ...createMockMarketInfo(), marketTokenAddress: "0xdisabled", isDisabled: true };
+    const spotMarket = { ...createMockMarketInfo(), marketTokenAddress: "0xspot", isSpotOnly: true };
+
+    const disabledVenue: ComparisonVenueMarket = { ...hyperliquidEth, isDisabled: true };
+
+    expect(matchGmxMarketsToVenueMarkets([enabledMarket, disabledMarket, spotMarket], [disabledVenue]).matched).toEqual(
+      []
+    );
+    expect(
+      matchGmxMarketsToVenueMarkets([enabledMarket, disabledMarket, spotMarket], [hyperliquidEth]).matched
+    ).toHaveLength(1);
+  });
+});

--- a/src/domain/tradingCosts/buildTradingCostRows.ts
+++ b/src/domain/tradingCosts/buildTradingCostRows.ts
@@ -1,0 +1,45 @@
+import type { MarketInfo } from "domain/synthetics/markets";
+
+import { calculateDeltaUsd, getCombinedStatus, sortTradingCostRowsByVenueVolume } from "./costs";
+import { matchGmxMarketsToVenueMarkets } from "./marketMatching";
+import type {
+  ComparisonVenueMarket,
+  MatchedTradingMarket,
+  TradingCostBreakdown,
+  TradingCostRow,
+  TradingCostScenario,
+} from "./types";
+
+export function buildTradingCostRows({
+  scenario,
+  gmxMarkets,
+  venueMarkets,
+  buildGmxBreakdown,
+  buildVenueBreakdown,
+}: {
+  scenario: TradingCostScenario;
+  gmxMarkets: MarketInfo[];
+  venueMarkets: ComparisonVenueMarket[];
+  buildGmxBreakdown: (market: MarketInfo, scenario: TradingCostScenario) => TradingCostBreakdown;
+  buildVenueBreakdown: (match: MatchedTradingMarket, scenario: TradingCostScenario) => TradingCostBreakdown;
+}): TradingCostRow[] {
+  const { matched } = matchGmxMarketsToVenueMarkets(gmxMarkets, venueMarkets);
+  const rows = matched.map((match) => {
+    const gmx = buildGmxBreakdown(match.gmxMarket, scenario);
+    const venue = buildVenueBreakdown(match, scenario);
+    const deltaUsd = calculateDeltaUsd(gmx.totalUsd, venue.totalUsd);
+
+    return {
+      marketKey: `${match.venueMarket.providerId}:${match.venueMarket.symbol}:${match.gmxMarket.marketTokenAddress}`,
+      displayName: match.gmxMarket.name,
+      indexSymbol: match.gmxMarket.indexToken.symbol,
+      venueVolume24hUsd: match.venueMarket.volume24hUsd,
+      gmx,
+      venue,
+      deltaUsd,
+      status: getCombinedStatus(gmx.status, venue.status),
+    };
+  });
+
+  return sortTradingCostRowsByVenueVolume(rows);
+}

--- a/src/domain/tradingCosts/buildTradingCostRows.ts
+++ b/src/domain/tradingCosts/buildTradingCostRows.ts
@@ -43,3 +43,14 @@ export function buildTradingCostRows({
 
   return sortTradingCostRowsByVenueVolume(rows);
 }
+
+export function getMatchedVenueSymbols({
+  gmxMarkets,
+  venueMarkets,
+}: {
+  gmxMarkets: MarketInfo[];
+  venueMarkets: ComparisonVenueMarket[];
+}): string[] {
+  const { matched } = matchGmxMarketsToVenueMarkets(gmxMarkets, venueMarkets);
+  return [...new Set(matched.map((match) => match.venueMarket.symbol))];
+}

--- a/src/domain/tradingCosts/costs.ts
+++ b/src/domain/tradingCosts/costs.ts
@@ -1,0 +1,74 @@
+import type { TradingCostComponent, TradingCostRow, TradingCostStatus } from "./types";
+
+export const USD_DECIMALS = 30n;
+export const USD_PRECISION = 10n ** USD_DECIMALS;
+const NUMBER_CONVERSION_DECIMALS = 6n;
+const NUMBER_CONVERSION_PRECISION = 10n ** NUMBER_CONVERSION_DECIMALS;
+
+const STATUS_SEVERITY: Record<TradingCostStatus, number> = {
+  ready: 0,
+  loading: 1,
+  stale: 2,
+  unmatched: 3,
+  insufficientDepth: 4,
+  providerError: 5,
+};
+
+export function numberToUsd(value: number): bigint {
+  if (!Number.isFinite(value)) {
+    return 0n;
+  }
+
+  return (
+    BigInt(Math.round(value * Number(NUMBER_CONVERSION_PRECISION))) * 10n ** (USD_DECIMALS - NUMBER_CONVERSION_DECIMALS)
+  );
+}
+
+export function usdToNumber(value: bigint | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Number(value) / Number(USD_PRECISION);
+}
+
+export function sumTradingCostComponents(components: TradingCostComponent[]): bigint {
+  return components.reduce((sum, component) => sum + component.usd, 0n);
+}
+
+export function calculateDeltaUsd(gmxTotalUsd: bigint | undefined, venueTotalUsd: bigint | undefined) {
+  if (gmxTotalUsd === undefined || venueTotalUsd === undefined) {
+    return undefined;
+  }
+
+  return gmxTotalUsd - venueTotalUsd;
+}
+
+export function getCombinedStatus(...statuses: TradingCostStatus[]): TradingCostStatus {
+  return statuses.reduce<TradingCostStatus>((highest, status) => {
+    return STATUS_SEVERITY[status] > STATUS_SEVERITY[highest] ? status : highest;
+  }, "ready");
+}
+
+export function filterTradingCostRows(rows: TradingCostRow[], query: string): TradingCostRow[] {
+  const normalizedQuery = query.trim().toLowerCase().replace(/\//g, "-");
+
+  if (!normalizedQuery) {
+    return rows;
+  }
+
+  return rows.filter((row) => {
+    const haystack = `${row.displayName} ${row.indexSymbol}`.toLowerCase().replace(/\//g, "-");
+    return haystack.includes(normalizedQuery);
+  });
+}
+
+export function sortTradingCostRowsByVenueVolume(rows: TradingCostRow[]): TradingCostRow[] {
+  return [...rows].sort((a, b) => {
+    if (a.venueVolume24hUsd === undefined && b.venueVolume24hUsd === undefined) return 0;
+    if (a.venueVolume24hUsd === undefined) return 1;
+    if (b.venueVolume24hUsd === undefined) return -1;
+    if (a.venueVolume24hUsd === b.venueVolume24hUsd) return a.indexSymbol.localeCompare(b.indexSymbol);
+    return a.venueVolume24hUsd > b.venueVolume24hUsd ? -1 : 1;
+  });
+}

--- a/src/domain/tradingCosts/costs.ts
+++ b/src/domain/tradingCosts/costs.ts
@@ -11,6 +11,7 @@ const STATUS_SEVERITY: Record<TradingCostStatus, number> = {
   stale: 2,
   unmatched: 3,
   insufficientDepth: 4,
+  insufficientLiquidity: 4,
   providerError: 5,
 };
 

--- a/src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts
+++ b/src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts
@@ -120,6 +120,35 @@ describe("GMX trading cost adapter", () => {
     expect(breakdown.components.find((item) => item.key === "openPriceImpact")!.usd).toBeLessThanOrEqual(0n);
   });
 
+  it("calculates close price impact after the simulated open leg", () => {
+    const marketInfo = {
+      ...createMockMarketInfo(),
+      longInterestUsd: 0n,
+      shortInterestUsd: 0n,
+      longInterestInTokens: 0n,
+      shortInterestInTokens: 0n,
+      useOpenInterestInTokensForBalance: false,
+      positionFeeFactorForBalanceWasImproved: 0n,
+      positionFeeFactorForBalanceWasNotImproved: 0n,
+      borrowingFactorPerSecondForLongs: 0n,
+      borrowingFactorPerSecondForShorts: 0n,
+      fundingFactorPerSecond: 0n,
+    };
+
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd: expandDecimals(10_000, 30),
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+
+    expect(breakdown.components.find((item) => item.key === "closePriceImpact")!.usd).toBeLessThan(0n);
+  });
+
   it("uses the order oracle price count for both network fee legs", () => {
     const gasLimits = {
       ...zeroGasLimits,

--- a/src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts
+++ b/src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts
@@ -186,4 +186,67 @@ describe("GMX trading cost adapter", () => {
 
     expect(breakdown.components.find((item) => item.key === "networkFee")?.usd).toBe(expandDecimals(60, 30));
   });
+
+  it("marks GMX as insufficient liquidity when the requested size exceeds available position liquidity", () => {
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo: {
+        ...createMockMarketInfo(),
+        maxOpenInterestLong: expandDecimals(5_000, 30),
+        positionImpactFactorPositive: 0n,
+        positionImpactFactorNegative: 0n,
+        borrowingFactorPerSecondForLongs: 0n,
+        borrowingFactorPerSecondForShorts: 0n,
+        fundingFactorPerSecond: 0n,
+      },
+      sizeUsd: expandDecimals(10_000, 30),
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+
+    expect(breakdown.status).toBe("insufficientLiquidity");
+    expect(breakdown.totalUsd).toBeUndefined();
+    expect(breakdown.components).toEqual([]);
+    expect(breakdown.warnings).toContain("GMX available liquidity is lower than the requested trade size.");
+  });
+
+  it("includes JIT max reserve liquidity when checking whether GMX can fill the requested size", () => {
+    const sizeUsd = expandDecimals(2_000_000, 30);
+    const marketInfo = {
+      ...createMockMarketInfo(),
+      positionImpactFactorPositive: 0n,
+      positionImpactFactorNegative: 0n,
+      borrowingFactorPerSecondForLongs: 0n,
+      borrowingFactorPerSecondForShorts: 0n,
+      fundingFactorPerSecond: 0n,
+    };
+
+    const withoutJit = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd,
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+    const withJit = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd,
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      maxReservedUsdWithJit: expandDecimals(3_000_000, 30),
+      timestamp: 1000,
+    });
+
+    expect(withoutJit.status).toBe("insufficientLiquidity");
+    expect(withJit.status).toBe("ready");
+  });
 });

--- a/src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts
+++ b/src/domain/tradingCosts/gmx/__tests__/gmxCost.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import type { GasLimitsConfig } from "domain/synthetics/fees";
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+import { ETH_TOKEN } from "domain/testUtils/mockTokens";
+import { expandDecimals } from "lib/numbers";
+import { NATIVE_TOKEN_ADDRESS } from "sdk/configs/tokens";
+
+import { getGmxTradingCostBreakdown } from "../gmxCost";
+
+const feeFactor = expandDecimals(5, 26);
+const zeroGasLimits: GasLimitsConfig = {
+  depositToken: 0n,
+  withdrawalMultiToken: 0n,
+  shift: 0n,
+  singleSwap: 0n,
+  swapOrder: 0n,
+  increaseOrder: 0n,
+  decreaseOrder: 0n,
+  estimatedGasFeeBaseAmount: 0n,
+  estimatedGasFeePerOraclePrice: 0n,
+  estimatedFeeMultiplierFactor: 0n,
+  gelatoRelayFeeMultiplierFactor: 0n,
+  glvDepositGasLimit: 0n,
+  glvWithdrawalGasLimit: 0n,
+  glvPerMarketGasLimit: 0n,
+  createOrderGasLimit: 0n,
+  updateOrderGasLimit: 0n,
+  cancelOrderGasLimit: 0n,
+  tokenPermitGasLimit: 0n,
+  gmxAccountCollateralGasLimit: 0n,
+};
+
+describe("GMX trading cost adapter", () => {
+  it("includes protocol fees on both open and close legs", () => {
+    const marketInfo = {
+      ...createMockMarketInfo(),
+      positionFeeFactorForBalanceWasImproved: feeFactor,
+      positionFeeFactorForBalanceWasNotImproved: feeFactor,
+      positionImpactFactorPositive: 0n,
+      positionImpactFactorNegative: 0n,
+      fundingFactorPerSecond: 0n,
+      borrowingFactorPerSecondForLongs: 0n,
+      borrowingFactorPerSecondForShorts: 0n,
+    };
+
+    const sizeUsd = expandDecimals(10_000, 30);
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd,
+      side: "long",
+      holdingPeriodHours: 8,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+
+    expect(breakdown.status).toBe("ready");
+    expect(breakdown.components.find((item) => item.key === "protocolFee")?.usd).toBe(expandDecimals(10, 30));
+    expect(breakdown.components.find((item) => item.key === "openPriceImpact")?.usd).toBe(0n);
+    expect(breakdown.components.find((item) => item.key === "closePriceImpact")?.usd).toBe(0n);
+    expect(breakdown.warnings).toContain("Collateral swap routing is not included.");
+  });
+
+  it("uses the not-improved position fee factor for the close leg", () => {
+    const sizeUsd = expandDecimals(10_000, 30);
+    const marketInfo = {
+      ...createMockMarketInfo(),
+      longInterestUsd: expandDecimals(1_000_000, 30),
+      shortInterestUsd: expandDecimals(100_000, 30),
+      useOpenInterestInTokensForBalance: false,
+      positionFeeFactorForBalanceWasImproved: 0n,
+      positionFeeFactorForBalanceWasNotImproved: expandDecimals(1, 27),
+      positionImpactFactorPositive: 0n,
+      positionImpactFactorNegative: 0n,
+      fundingFactorPerSecond: 0n,
+      borrowingFactorPerSecondForLongs: 0n,
+      borrowingFactorPerSecondForShorts: 0n,
+    };
+
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd,
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+
+    expect(breakdown.components.find((item) => item.key === "protocolFee")?.usd).toBe(expandDecimals(20, 30));
+  });
+
+  it("converts positive price impact into a negative cost", () => {
+    const marketInfo = {
+      ...createMockMarketInfo(),
+      longInterestUsd: expandDecimals(100_000, 30),
+      shortInterestUsd: expandDecimals(1_000_000, 30),
+      useOpenInterestInTokensForBalance: false,
+      positionFeeFactorForBalanceWasImproved: 0n,
+      positionFeeFactorForBalanceWasNotImproved: 0n,
+      borrowingFactorPerSecondForLongs: 0n,
+      borrowingFactorPerSecondForShorts: 0n,
+      fundingFactorPerSecond: 0n,
+    };
+
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo,
+      sizeUsd: expandDecimals(10_000, 30),
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits: undefined,
+      gasPrice: undefined,
+      tokensData: undefined,
+      timestamp: 1000,
+    });
+
+    expect(breakdown.components.find((item) => item.key === "openPriceImpact")!.usd).toBeLessThanOrEqual(0n);
+  });
+
+  it("uses the order oracle price count for both network fee legs", () => {
+    const gasLimits = {
+      ...zeroGasLimits,
+      estimatedGasFeePerOraclePrice: 10n,
+    };
+    const nativeToken = {
+      ...ETH_TOKEN,
+      address: NATIVE_TOKEN_ADDRESS,
+      isNative: true,
+      isWrapped: false,
+      prices: { minPrice: expandDecimals(1, 30), maxPrice: expandDecimals(1, 30) },
+    };
+
+    const breakdown = getGmxTradingCostBreakdown({
+      marketInfo: {
+        ...createMockMarketInfo(),
+        positionFeeFactorForBalanceWasImproved: 0n,
+        positionFeeFactorForBalanceWasNotImproved: 0n,
+        positionImpactFactorPositive: 0n,
+        positionImpactFactorNegative: 0n,
+        borrowingFactorPerSecondForLongs: 0n,
+        borrowingFactorPerSecondForShorts: 0n,
+        fundingFactorPerSecond: 0n,
+      },
+      sizeUsd: expandDecimals(10_000, 30),
+      side: "long",
+      holdingPeriodHours: 1,
+      gasLimits,
+      gasPrice: expandDecimals(1, 18),
+      tokensData: {
+        [NATIVE_TOKEN_ADDRESS]: nativeToken,
+      },
+      timestamp: 1000,
+    });
+
+    expect(breakdown.components.find((item) => item.key === "networkFee")?.usd).toBe(expandDecimals(60, 30));
+  });
+});

--- a/src/domain/tradingCosts/gmx/gmxCost.ts
+++ b/src/domain/tradingCosts/gmx/gmxCost.ts
@@ -7,6 +7,7 @@ import {
   type GasLimitsConfig,
 } from "domain/synthetics/fees";
 import { DecreasePositionSwapType } from "domain/synthetics/orders";
+import { convertToTokenAmount, getMidPrice } from "domain/synthetics/tokens";
 import {
   estimateExecuteDecreaseOrderGasLimit,
   estimateExecuteIncreaseOrderGasLimit,
@@ -49,6 +50,34 @@ function estimateGmxNetworkFeeUsd({
   return increaseFee + decreaseFee;
 }
 
+function getMarketInfoAfterOpen({
+  marketInfo,
+  sizeUsd,
+  isLong,
+}: {
+  marketInfo: MarketInfo;
+  sizeUsd: bigint;
+  isLong: boolean;
+}): MarketInfo {
+  const indexTokenAmount =
+    convertToTokenAmount(sizeUsd, marketInfo.indexToken.decimals, getMidPrice(marketInfo.indexToken.prices)) ?? 0n;
+
+  return {
+    ...marketInfo,
+    longInterestUsd: isLong ? marketInfo.longInterestUsd + sizeUsd : marketInfo.longInterestUsd,
+    shortInterestUsd: isLong ? marketInfo.shortInterestUsd : marketInfo.shortInterestUsd + sizeUsd,
+    longInterestInTokens: isLong
+      ? marketInfo.longInterestInTokens + indexTokenAmount
+      : marketInfo.longInterestInTokens,
+    shortInterestInTokens: isLong
+      ? marketInfo.shortInterestInTokens
+      : marketInfo.shortInterestInTokens + indexTokenAmount,
+    virtualInventoryForPositions: isLong
+      ? marketInfo.virtualInventoryForPositions - sizeUsd
+      : marketInfo.virtualInventoryForPositions + sizeUsd,
+  };
+}
+
 export function getGmxTradingCostBreakdown({
   marketInfo,
   sizeUsd,
@@ -75,7 +104,8 @@ export function getGmxTradingCostBreakdown({
     fallbackToZero: true,
     shouldCapNegativeImpact: true,
   });
-  const closeImpact = getCappedPositionImpactUsd(marketInfo, sizeUsd, isLong, false, {
+  const marketInfoAfterOpen = getMarketInfoAfterOpen({ marketInfo, sizeUsd, isLong });
+  const closeImpact = getCappedPositionImpactUsd(marketInfoAfterOpen, sizeUsd, isLong, false, {
     fallbackToZero: true,
     shouldCapNegativeImpact: true,
   });

--- a/src/domain/tradingCosts/gmx/gmxCost.ts
+++ b/src/domain/tradingCosts/gmx/gmxCost.ts
@@ -1,0 +1,110 @@
+import {
+  getBorrowingFeeRateUsd,
+  getCappedPositionImpactUsd,
+  estimateOrderOraclePriceCount,
+  getFundingFeeRateUsd,
+  getPositionFee,
+  type GasLimitsConfig,
+} from "domain/synthetics/fees";
+import { DecreasePositionSwapType } from "domain/synthetics/orders";
+import {
+  estimateExecuteDecreaseOrderGasLimit,
+  estimateExecuteIncreaseOrderGasLimit,
+  getExecutionFee,
+} from "sdk/utils/fees/executionFee";
+import type { MarketInfo } from "sdk/utils/markets/types";
+import type { TokensData } from "sdk/utils/tokens/types";
+
+import { sumTradingCostComponents } from "../costs";
+import type { TradingCostBreakdown, TradingCostComponent, TradingCostSide } from "../types";
+
+function estimateGmxNetworkFeeUsd({
+  chainId,
+  gasLimits,
+  gasPrice,
+  tokensData,
+}: {
+  chainId: number;
+  gasLimits: GasLimitsConfig | undefined;
+  gasPrice: bigint | undefined;
+  tokensData: TokensData | undefined;
+}) {
+  if (!gasLimits || gasPrice === undefined || !tokensData) {
+    return 0n;
+  }
+
+  const increaseGasLimit = estimateExecuteIncreaseOrderGasLimit(gasLimits, { swapsCount: 0, callbackGasLimit: 0n });
+  const decreaseGasLimit = estimateExecuteDecreaseOrderGasLimit(gasLimits, {
+    swapsCount: 0,
+    callbackGasLimit: 0n,
+    decreaseSwapType: DecreasePositionSwapType.NoSwap,
+  });
+  const oraclePriceCount = estimateOrderOraclePriceCount(0);
+
+  const increaseFee =
+    getExecutionFee(chainId, gasLimits, tokensData, increaseGasLimit, gasPrice, oraclePriceCount)?.feeUsd ?? 0n;
+  const decreaseFee =
+    getExecutionFee(chainId, gasLimits, tokensData, decreaseGasLimit, gasPrice, oraclePriceCount)?.feeUsd ?? 0n;
+
+  return increaseFee + decreaseFee;
+}
+
+export function getGmxTradingCostBreakdown({
+  marketInfo,
+  sizeUsd,
+  side,
+  holdingPeriodHours,
+  chainId = 42161,
+  gasLimits,
+  gasPrice,
+  tokensData,
+  timestamp,
+}: {
+  marketInfo: MarketInfo;
+  sizeUsd: bigint;
+  side: TradingCostSide;
+  holdingPeriodHours: number;
+  chainId?: number;
+  gasLimits: GasLimitsConfig | undefined;
+  gasPrice: bigint | undefined;
+  tokensData: TokensData | undefined;
+  timestamp: number;
+}): TradingCostBreakdown {
+  const isLong = side === "long";
+  const openImpact = getCappedPositionImpactUsd(marketInfo, sizeUsd, isLong, true, {
+    fallbackToZero: true,
+    shouldCapNegativeImpact: true,
+  });
+  const closeImpact = getCappedPositionImpactUsd(marketInfo, sizeUsd, isLong, false, {
+    fallbackToZero: true,
+    shouldCapNegativeImpact: true,
+  });
+
+  const openPositionFee = getPositionFee(marketInfo, sizeUsd, openImpact.balanceWasImproved, undefined).positionFeeUsd;
+  const closePositionFee = getPositionFee(marketInfo, sizeUsd, false, undefined).positionFeeUsd;
+  const periodSeconds = BigInt(Math.round(holdingPeriodHours * 3600));
+  const borrowingFeeUsd = getBorrowingFeeRateUsd(marketInfo, isLong, sizeUsd, periodSeconds);
+  const fundingRateUsd = getFundingFeeRateUsd(marketInfo, isLong, sizeUsd, periodSeconds);
+  const networkFeeUsd = estimateGmxNetworkFeeUsd({ chainId, gasLimits, gasPrice, tokensData });
+
+  const components: TradingCostComponent[] = [
+    { key: "protocolFee", label: "Protocol fee", usd: openPositionFee + closePositionFee },
+    { key: "openPriceImpact", label: "Open price impact", usd: -openImpact.priceImpactDeltaUsd },
+    { key: "closePriceImpact", label: "Close price impact", usd: -closeImpact.priceImpactDeltaUsd },
+    { key: "netRate", label: "Net-rate cost", usd: borrowingFeeUsd - fundingRateUsd },
+    { key: "networkFee", label: "Network fee", usd: networkFeeUsd },
+  ];
+
+  return {
+    providerId: "gmx",
+    totalUsd: sumTradingCostComponents(components),
+    components,
+    timestamp,
+    status: "ready",
+    warnings: [
+      "Collateral swap routing is not included.",
+      "Account-specific referral discounts are not included.",
+      "Results are current estimates, not guaranteed execution quotes.",
+    ],
+  };
+}

--- a/src/domain/tradingCosts/gmx/gmxCost.ts
+++ b/src/domain/tradingCosts/gmx/gmxCost.ts
@@ -6,6 +6,7 @@ import {
   getPositionFee,
   type GasLimitsConfig,
 } from "domain/synthetics/fees";
+import { getAvailableUsdLiquidityForPosition } from "domain/synthetics/markets";
 import { DecreasePositionSwapType } from "domain/synthetics/orders";
 import { convertToTokenAmount, getMidPrice } from "domain/synthetics/tokens";
 import {
@@ -87,6 +88,7 @@ export function getGmxTradingCostBreakdown({
   gasLimits,
   gasPrice,
   tokensData,
+  maxReservedUsdWithJit,
   timestamp,
 }: {
   marketInfo: MarketInfo;
@@ -97,9 +99,23 @@ export function getGmxTradingCostBreakdown({
   gasLimits: GasLimitsConfig | undefined;
   gasPrice: bigint | undefined;
   tokensData: TokensData | undefined;
+  maxReservedUsdWithJit?: bigint;
   timestamp: number;
 }): TradingCostBreakdown {
   const isLong = side === "long";
+  const availableLiquidityUsd = getAvailableUsdLiquidityForPosition(marketInfo, isLong, maxReservedUsdWithJit);
+
+  if (sizeUsd > availableLiquidityUsd) {
+    return {
+      providerId: "gmx",
+      totalUsd: undefined,
+      components: [],
+      timestamp,
+      status: "insufficientLiquidity",
+      warnings: ["GMX available liquidity is lower than the requested trade size."],
+    };
+  }
+
   const openImpact = getCappedPositionImpactUsd(marketInfo, sizeUsd, isLong, true, {
     fallbackToZero: true,
     shouldCapNegativeImpact: true,

--- a/src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts
+++ b/src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { usdToNumber } from "../../costs";
-import { normalizeHyperliquidMarkets } from "../api";
+import { fetchHyperliquidL2Books, normalizeHyperliquidMarkets } from "../api";
 import type { HyperliquidMetaAndAssetCtxsResponse } from "../types";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("Hyperliquid API normalization", () => {
   it("combines meta and asset contexts and excludes delisted markets", () => {
@@ -32,5 +36,29 @@ describe("Hyperliquid API normalization", () => {
       timestamp: 123,
     });
     expect(usdToNumber(markets[0].volume24hUsd)).toBeCloseTo(12345.67, 6);
+  });
+
+  it("fetches default and aggregated L2 books for each coin", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+
+      return {
+        ok: true,
+        json: async () => ({ coin: body.coin, time: 1, levels: [[], []] }),
+      };
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchHyperliquidL2Books(["BTC"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({ type: "l2Book", coin: "BTC" });
+    expect(JSON.parse(String(fetchMock.mock.calls[1][1]?.body))).toEqual({
+      type: "l2Book",
+      coin: "BTC",
+      nSigFigs: 5,
+      mantissa: 5,
+    });
   });
 });

--- a/src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts
+++ b/src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts
@@ -38,7 +38,7 @@ describe("Hyperliquid API normalization", () => {
     expect(usdToNumber(markets[0].volume24hUsd)).toBeCloseTo(12345.67, 6);
   });
 
-  it("fetches default and aggregated L2 books for each coin", async () => {
+  it("fetches default and aggregated L2 book precision ladder for each coin", async () => {
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body));
 
@@ -52,13 +52,23 @@ describe("Hyperliquid API normalization", () => {
 
     await fetchHyperliquidL2Books(["BTC"]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({ type: "l2Book", coin: "BTC" });
     expect(JSON.parse(String(fetchMock.mock.calls[1][1]?.body))).toEqual({
       type: "l2Book",
       coin: "BTC",
       nSigFigs: 5,
       mantissa: 5,
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[2][1]?.body))).toEqual({
+      type: "l2Book",
+      coin: "BTC",
+      nSigFigs: 4,
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[3][1]?.body))).toEqual({
+      type: "l2Book",
+      coin: "BTC",
+      nSigFigs: 3,
     });
   });
 });

--- a/src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts
+++ b/src/domain/tradingCosts/hyperliquid/__tests__/api.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { usdToNumber } from "../../costs";
+import { normalizeHyperliquidMarkets } from "../api";
+import type { HyperliquidMetaAndAssetCtxsResponse } from "../types";
+
+describe("Hyperliquid API normalization", () => {
+  it("combines meta and asset contexts and excludes delisted markets", () => {
+    const response: HyperliquidMetaAndAssetCtxsResponse = [
+      {
+        universe: [
+          { name: "ETH", szDecimals: 4, maxLeverage: 25, marginTableId: 1 },
+          { name: "MATIC", szDecimals: 1, maxLeverage: 20, marginTableId: 2, isDelisted: true },
+        ],
+      },
+      [
+        { dayNtlVlm: "12345.67", markPx: "2100", midPx: "2100.5", funding: "0.0000125" },
+        { dayNtlVlm: "999", markPx: "1", funding: "0" },
+      ],
+    ];
+
+    const markets = normalizeHyperliquidMarkets(response, 123);
+
+    expect(markets).toHaveLength(1);
+    expect(markets[0]).toMatchObject({
+      symbol: "ETH",
+      displayName: "ETH",
+      isDisabled: false,
+      markPrice: 2100,
+      midPrice: 2100.5,
+      hourlyFundingRate: 0.0000125,
+      timestamp: 123,
+    });
+    expect(usdToNumber(markets[0].volume24hUsd)).toBeCloseTo(12345.67, 6);
+  });
+});

--- a/src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts
+++ b/src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts
@@ -15,20 +15,20 @@ const bids: HyperliquidBookLevel[] = [
 ];
 
 describe("Hyperliquid L2 book math", () => {
-  it("fills a USD notional across multiple levels", () => {
-    const fill = simulateL2BookFill({ levels: asks, sizeUsd: numberToUsd(210) });
-    const bidFill = simulateL2BookFill({ levels: bids, sizeUsd: numberToUsd(197) });
+  it("fills the base quantity implied by reference-price USD notional across multiple levels", () => {
+    const fill = simulateL2BookFill({ levels: asks, sizeUsd: numberToUsd(210), referencePrice: 100 });
+    const bidFill = simulateL2BookFill({ levels: bids, sizeUsd: numberToUsd(197), referencePrice: 100 });
 
     expect(fill.status).toBe("filled");
-    expect(fill.averagePrice).toBeCloseTo(105, 6);
-    expect(usdToNumber(fill.filledUsd)).toBeCloseTo(210, 6);
+    expect(fill.averagePrice).toBeCloseTo(105.238095, 6);
+    expect(usdToNumber(fill.filledUsd)).toBeCloseTo(221, 6);
     expect(bidFill.status).toBe("filled");
-    expect(bidFill.averagePrice).toBeCloseTo(98.5, 6);
-    expect(usdToNumber(bidFill.filledUsd)).toBeCloseTo(197, 6);
+    expect(bidFill.averagePrice).toBeCloseTo(98.507614, 6);
+    expect(usdToNumber(bidFill.filledUsd)).toBeCloseTo(194.06, 6);
   });
 
   it("marks insufficient depth when returned levels cannot fill requested notional", () => {
-    const fill = simulateL2BookFill({ levels: asks.slice(0, 1), sizeUsd: numberToUsd(250) });
+    const fill = simulateL2BookFill({ levels: asks.slice(0, 1), sizeUsd: numberToUsd(250), referencePrice: 100 });
 
     expect(fill.status).toBe("insufficientDepth");
     expect(usdToNumber(fill.filledUsd)).toBeCloseTo(100, 6);

--- a/src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts
+++ b/src/domain/tradingCosts/hyperliquid/__tests__/book.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { numberToUsd, usdToNumber } from "../../costs";
+import { getHyperliquidExecutionImpactUsd, getHyperliquidFundingCostUsd, simulateL2BookFill } from "../book";
+import type { HyperliquidBookLevel } from "../types";
+
+const asks: HyperliquidBookLevel[] = [
+  { px: "100", sz: "1", n: 1 },
+  { px: "110", sz: "2", n: 1 },
+];
+
+const bids: HyperliquidBookLevel[] = [
+  { px: "99", sz: "1", n: 1 },
+  { px: "98", sz: "2", n: 1 },
+];
+
+describe("Hyperliquid L2 book math", () => {
+  it("fills a USD notional across multiple levels", () => {
+    const fill = simulateL2BookFill({ levels: asks, sizeUsd: numberToUsd(210) });
+    const bidFill = simulateL2BookFill({ levels: bids, sizeUsd: numberToUsd(197) });
+
+    expect(fill.status).toBe("filled");
+    expect(fill.averagePrice).toBeCloseTo(105, 6);
+    expect(usdToNumber(fill.filledUsd)).toBeCloseTo(210, 6);
+    expect(bidFill.status).toBe("filled");
+    expect(bidFill.averagePrice).toBeCloseTo(98.5, 6);
+    expect(usdToNumber(bidFill.filledUsd)).toBeCloseTo(197, 6);
+  });
+
+  it("marks insufficient depth when returned levels cannot fill requested notional", () => {
+    const fill = simulateL2BookFill({ levels: asks.slice(0, 1), sizeUsd: numberToUsd(250) });
+
+    expect(fill.status).toBe("insufficientDepth");
+    expect(usdToNumber(fill.filledUsd)).toBeCloseTo(100, 6);
+  });
+
+  it("calculates ask-side and bid-side execution impact as trader cost", () => {
+    expect(
+      usdToNumber(
+        getHyperliquidExecutionImpactUsd({
+          sizeUsd: numberToUsd(1000),
+          referencePrice: 100,
+          averagePrice: 101,
+          side: "ask",
+        })
+      )
+    ).toBeCloseTo(10, 6);
+    expect(
+      usdToNumber(
+        getHyperliquidExecutionImpactUsd({
+          sizeUsd: numberToUsd(1000),
+          referencePrice: 100,
+          averagePrice: 99,
+          side: "bid",
+        })
+      )
+    ).toBeCloseTo(10, 6);
+    expect(
+      usdToNumber(
+        getHyperliquidExecutionImpactUsd({
+          sizeUsd: numberToUsd(1000),
+          referencePrice: 100,
+          averagePrice: 99.5,
+          side: "ask",
+        })
+      )
+    ).toBeCloseTo(-5, 6);
+  });
+
+  it("projects funding cost with positive rates paid by longs and received by shorts", () => {
+    expect(
+      usdToNumber(
+        getHyperliquidFundingCostUsd({
+          sizeUsd: numberToUsd(10_000),
+          side: "long",
+          hourlyFundingRate: 0.0001,
+          holdingPeriodHours: 8,
+        })
+      )
+    ).toBeCloseTo(8, 6);
+    expect(
+      usdToNumber(
+        getHyperliquidFundingCostUsd({
+          sizeUsd: numberToUsd(10_000),
+          side: "short",
+          hourlyFundingRate: 0.0001,
+          holdingPeriodHours: 8,
+        })
+      )
+    ).toBeCloseTo(-8, 6);
+  });
+});

--- a/src/domain/tradingCosts/hyperliquid/__tests__/buildHyperliquidBreakdown.spec.ts
+++ b/src/domain/tradingCosts/hyperliquid/__tests__/buildHyperliquidBreakdown.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { numberToUsd, usdToNumber } from "../../costs";
+import type { TradingCostScenario } from "../../types";
+import { buildHyperliquidBreakdown } from "../buildHyperliquidBreakdown";
+import type { HyperliquidBookBundle, HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "../types";
+
+const market: HyperliquidNormalizedMarket = {
+  symbol: "BTC",
+  displayName: "BTC",
+  isDisabled: false,
+  volume24hUsd: numberToUsd(1_000_000_000),
+  markPrice: 100,
+  midPrice: 100,
+  hourlyFundingRate: 0,
+  timestamp: 1,
+};
+
+const scenario: TradingCostScenario = {
+  sizeUsd: numberToUsd(1_000),
+  side: "long",
+  holdingPeriodHours: 8,
+  comparisonVenue: "hyperliquid",
+  venueAssumptions: {
+    hyperliquid: { takerFeeRate: 0.00045 },
+  },
+};
+
+function book({
+  bidSize,
+  askSize,
+  time,
+}: {
+  bidSize: string;
+  askSize: string;
+  time: number;
+}): HyperliquidL2BookResponse {
+  return {
+    coin: "BTC",
+    time,
+    levels: [[{ px: "99", sz: bidSize, n: 1 }], [{ px: "101", sz: askSize, n: 1 }]],
+  };
+}
+
+describe("buildHyperliquidBreakdown", () => {
+  it("uses aggregated book fallback when default levels cannot fill the requested round trip", () => {
+    const books: HyperliquidBookBundle = {
+      default: book({ bidSize: "1", askSize: "1", time: 10 }),
+      aggregated: book({ bidSize: "20", askSize: "20", time: 20 }),
+    };
+
+    const breakdown = buildHyperliquidBreakdown({
+      scenario,
+      match: undefined as never,
+      market,
+      book: books,
+    });
+
+    expect(breakdown.status).toBe("ready");
+    expect(breakdown.timestamp).toBe(20);
+    expect(breakdown.warnings).toEqual([
+      "Using aggregated Hyperliquid book depth because the default 20-level book cannot fill the requested round-trip size.",
+    ]);
+    expect(usdToNumber(breakdown.totalUsd)).toBeCloseTo(20.9, 6);
+  });
+});

--- a/src/domain/tradingCosts/hyperliquid/__tests__/buildHyperliquidBreakdown.spec.ts
+++ b/src/domain/tradingCosts/hyperliquid/__tests__/buildHyperliquidBreakdown.spec.ts
@@ -43,11 +43,29 @@ function book({
 }
 
 describe("buildHyperliquidBreakdown", () => {
-  it("uses aggregated book fallback when default levels cannot fill the requested round trip", () => {
-    const books: HyperliquidBookBundle = {
-      default: book({ bidSize: "1", askSize: "1", time: 10 }),
-      aggregated: book({ bidSize: "20", askSize: "20", time: 20 }),
-    };
+  it("uses the most precise aggregated book that can fill the requested round trip", () => {
+    const books: HyperliquidBookBundle = [
+      {
+        key: "default",
+        label: "default 20-level book",
+        book: book({ bidSize: "1", askSize: "1", time: 10 }),
+      },
+      {
+        key: "5SigFigsMantissa5",
+        label: "5 significant figures, mantissa 5",
+        book: book({ bidSize: "5", askSize: "5", time: 20 }),
+      },
+      {
+        key: "4SigFigs",
+        label: "4 significant figures",
+        book: book({ bidSize: "20", askSize: "20", time: 30 }),
+      },
+      {
+        key: "3SigFigs",
+        label: "3 significant figures",
+        book: book({ bidSize: "20", askSize: "20", time: 40 }),
+      },
+    ];
 
     const breakdown = buildHyperliquidBreakdown({
       scenario,
@@ -57,9 +75,9 @@ describe("buildHyperliquidBreakdown", () => {
     });
 
     expect(breakdown.status).toBe("ready");
-    expect(breakdown.timestamp).toBe(20);
+    expect(breakdown.timestamp).toBe(30);
     expect(breakdown.warnings).toEqual([
-      "Using aggregated Hyperliquid book depth because the default 20-level book cannot fill the requested round-trip size.",
+      "Using aggregated Hyperliquid book depth (4 significant figures) because more precise books cannot fill the requested round-trip size.",
     ]);
     expect(usdToNumber(breakdown.totalUsd)).toBeCloseTo(20.9, 6);
   });

--- a/src/domain/tradingCosts/hyperliquid/api.ts
+++ b/src/domain/tradingCosts/hyperliquid/api.ts
@@ -1,0 +1,85 @@
+import { numberToUsd } from "../costs";
+import type {
+  HyperliquidL2BookResponse,
+  HyperliquidMetaAndAssetCtxsResponse,
+  HyperliquidNormalizedMarket,
+} from "./types";
+
+const HYPERLIQUID_INFO_URL = "https://api.hyperliquid.xyz/info";
+
+async function postHyperliquidInfo<T>(body: Record<string, string>): Promise<T> {
+  const response = await fetch(HYPERLIQUID_INFO_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Hyperliquid info request failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function parseOptionalNumber(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function normalizeHyperliquidMarkets(
+  response: HyperliquidMetaAndAssetCtxsResponse,
+  timestamp: number
+): HyperliquidNormalizedMarket[] {
+  const [meta, contexts] = response;
+
+  return meta.universe.flatMap((asset, index) => {
+    const ctx = contexts[index];
+
+    if (!ctx || asset.isDelisted) {
+      return [];
+    }
+
+    const volume = parseOptionalNumber(ctx.dayNtlVlm);
+
+    return {
+      symbol: asset.name,
+      displayName: asset.name,
+      isDisabled: false,
+      volume24hUsd: volume === undefined ? undefined : numberToUsd(volume),
+      markPrice: parseOptionalNumber(ctx.markPx),
+      midPrice: parseOptionalNumber(ctx.midPx),
+      hourlyFundingRate: parseOptionalNumber(ctx.funding),
+      timestamp,
+    };
+  });
+}
+
+export async function fetchHyperliquidMetaAndAssetCtxs(): Promise<HyperliquidNormalizedMarket[]> {
+  const timestamp = Date.now();
+  const response = await postHyperliquidInfo<HyperliquidMetaAndAssetCtxsResponse>({ type: "metaAndAssetCtxs" });
+  return normalizeHyperliquidMarkets(response, timestamp);
+}
+
+export async function fetchHyperliquidL2Book(coin: string): Promise<HyperliquidL2BookResponse> {
+  return postHyperliquidInfo<HyperliquidL2BookResponse>({ type: "l2Book", coin });
+}
+
+export async function fetchHyperliquidL2Books(
+  coins: string[]
+): Promise<Record<string, HyperliquidL2BookResponse | Error>> {
+  const entries = await Promise.all(
+    coins.map(async (coin) => {
+      try {
+        return [coin, await fetchHyperliquidL2Book(coin)] as const;
+      } catch (error) {
+        return [coin, error instanceof Error ? error : new Error(String(error))] as const;
+      }
+    })
+  );
+
+  return Object.fromEntries(entries);
+}

--- a/src/domain/tradingCosts/hyperliquid/api.ts
+++ b/src/domain/tradingCosts/hyperliquid/api.ts
@@ -1,13 +1,15 @@
 import { numberToUsd } from "../costs";
 import type {
+  HyperliquidBookBundle,
   HyperliquidL2BookResponse,
   HyperliquidMetaAndAssetCtxsResponse,
   HyperliquidNormalizedMarket,
 } from "./types";
 
 const HYPERLIQUID_INFO_URL = "https://api.hyperliquid.xyz/info";
+const HYPERLIQUID_AGGREGATED_BOOK_PARAMS = { nSigFigs: 5, mantissa: 5 } as const;
 
-async function postHyperliquidInfo<T>(body: Record<string, string>): Promise<T> {
+async function postHyperliquidInfo<T>(body: Record<string, string | number>): Promise<T> {
   const response = await fetch(HYPERLIQUID_INFO_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
@@ -64,20 +66,33 @@ export async function fetchHyperliquidMetaAndAssetCtxs(): Promise<HyperliquidNor
   return normalizeHyperliquidMarkets(response, timestamp);
 }
 
-export async function fetchHyperliquidL2Book(coin: string): Promise<HyperliquidL2BookResponse> {
-  return postHyperliquidInfo<HyperliquidL2BookResponse>({ type: "l2Book", coin });
+export async function fetchHyperliquidL2Book(
+  coin: string,
+  aggregation?: typeof HYPERLIQUID_AGGREGATED_BOOK_PARAMS
+): Promise<HyperliquidL2BookResponse> {
+  return postHyperliquidInfo<HyperliquidL2BookResponse>({ type: "l2Book", coin, ...aggregation });
 }
 
-export async function fetchHyperliquidL2Books(
-  coins: string[]
-): Promise<Record<string, HyperliquidL2BookResponse | Error>> {
+async function fetchHyperliquidL2BookSafely(
+  coin: string,
+  aggregation?: typeof HYPERLIQUID_AGGREGATED_BOOK_PARAMS
+): Promise<HyperliquidL2BookResponse | Error> {
+  try {
+    return await fetchHyperliquidL2Book(coin, aggregation);
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+export async function fetchHyperliquidL2Books(coins: string[]): Promise<Record<string, HyperliquidBookBundle>> {
   const entries = await Promise.all(
     coins.map(async (coin) => {
-      try {
-        return [coin, await fetchHyperliquidL2Book(coin)] as const;
-      } catch (error) {
-        return [coin, error instanceof Error ? error : new Error(String(error))] as const;
-      }
+      const [defaultBook, aggregatedBook] = await Promise.all([
+        fetchHyperliquidL2BookSafely(coin),
+        fetchHyperliquidL2BookSafely(coin, HYPERLIQUID_AGGREGATED_BOOK_PARAMS),
+      ]);
+
+      return [coin, { default: defaultBook, aggregated: aggregatedBook }] as const;
     })
   );
 

--- a/src/domain/tradingCosts/hyperliquid/api.ts
+++ b/src/domain/tradingCosts/hyperliquid/api.ts
@@ -1,13 +1,29 @@
 import { numberToUsd } from "../costs";
 import type {
   HyperliquidBookBundle,
+  HyperliquidBookPrecisionKey,
   HyperliquidL2BookResponse,
   HyperliquidMetaAndAssetCtxsResponse,
   HyperliquidNormalizedMarket,
 } from "./types";
 
 const HYPERLIQUID_INFO_URL = "https://api.hyperliquid.xyz/info";
-const HYPERLIQUID_AGGREGATED_BOOK_PARAMS = { nSigFigs: 5, mantissa: 5 } as const;
+
+type HyperliquidBookAggregation = {
+  nSigFigs?: 3 | 4 | 5;
+  mantissa?: 5;
+};
+
+const HYPERLIQUID_BOOK_PRECISION_LEVELS: {
+  key: HyperliquidBookPrecisionKey;
+  label: string;
+  aggregation?: HyperliquidBookAggregation;
+}[] = [
+  { key: "default", label: "default 20-level book" },
+  { key: "5SigFigsMantissa5", label: "5 significant figures, mantissa 5", aggregation: { nSigFigs: 5, mantissa: 5 } },
+  { key: "4SigFigs", label: "4 significant figures", aggregation: { nSigFigs: 4 } },
+  { key: "3SigFigs", label: "3 significant figures", aggregation: { nSigFigs: 3 } },
+];
 
 async function postHyperliquidInfo<T>(body: Record<string, string | number>): Promise<T> {
   const response = await fetch(HYPERLIQUID_INFO_URL, {
@@ -68,14 +84,14 @@ export async function fetchHyperliquidMetaAndAssetCtxs(): Promise<HyperliquidNor
 
 export async function fetchHyperliquidL2Book(
   coin: string,
-  aggregation?: typeof HYPERLIQUID_AGGREGATED_BOOK_PARAMS
+  aggregation?: HyperliquidBookAggregation
 ): Promise<HyperliquidL2BookResponse> {
   return postHyperliquidInfo<HyperliquidL2BookResponse>({ type: "l2Book", coin, ...aggregation });
 }
 
 async function fetchHyperliquidL2BookSafely(
   coin: string,
-  aggregation?: typeof HYPERLIQUID_AGGREGATED_BOOK_PARAMS
+  aggregation?: HyperliquidBookAggregation
 ): Promise<HyperliquidL2BookResponse | Error> {
   try {
     return await fetchHyperliquidL2Book(coin, aggregation);
@@ -87,12 +103,15 @@ async function fetchHyperliquidL2BookSafely(
 export async function fetchHyperliquidL2Books(coins: string[]): Promise<Record<string, HyperliquidBookBundle>> {
   const entries = await Promise.all(
     coins.map(async (coin) => {
-      const [defaultBook, aggregatedBook] = await Promise.all([
-        fetchHyperliquidL2BookSafely(coin),
-        fetchHyperliquidL2BookSafely(coin, HYPERLIQUID_AGGREGATED_BOOK_PARAMS),
-      ]);
+      const books = await Promise.all(
+        HYPERLIQUID_BOOK_PRECISION_LEVELS.map(async (precision) => ({
+          key: precision.key,
+          label: precision.label,
+          book: await fetchHyperliquidL2BookSafely(coin, precision.aggregation),
+        }))
+      );
 
-      return [coin, { default: defaultBook, aggregated: aggregatedBook }] as const;
+      return [coin, books] as const;
     })
   );
 

--- a/src/domain/tradingCosts/hyperliquid/book.ts
+++ b/src/domain/tradingCosts/hyperliquid/book.ts
@@ -11,31 +11,33 @@ export type BookFillResult = {
 export function simulateL2BookFill({
   levels,
   sizeUsd,
+  referencePrice,
 }: {
   levels: HyperliquidBookLevel[];
   sizeUsd: bigint;
+  referencePrice: number;
 }): BookFillResult {
   const targetUsd = usdToNumber(sizeUsd) ?? 0;
-  let remainingUsd = targetUsd;
+  const targetBase = referencePrice > 0 ? targetUsd / referencePrice : 0;
+  let remainingBase = targetBase;
   let filledUsd = 0;
   let filledBase = 0;
 
   for (const level of levels) {
-    if (remainingUsd <= 0) break;
+    if (remainingBase <= 0) break;
 
     const price = Number(level.px);
     const size = Number(level.sz);
-    const levelUsd = price * size;
-    const takeUsd = Math.min(levelUsd, remainingUsd);
-    const takeBase = takeUsd / price;
+    const takeBase = Math.min(size, remainingBase);
+    const takeUsd = takeBase * price;
 
     filledUsd += takeUsd;
     filledBase += takeBase;
-    remainingUsd -= takeUsd;
+    remainingBase -= takeBase;
   }
 
   return {
-    status: remainingUsd > 0.000001 ? "insufficientDepth" : "filled",
+    status: remainingBase > 0.000001 ? "insufficientDepth" : "filled",
     averagePrice: filledBase > 0 ? filledUsd / filledBase : undefined,
     filledUsd: numberToUsd(filledUsd),
   };

--- a/src/domain/tradingCosts/hyperliquid/book.ts
+++ b/src/domain/tradingCosts/hyperliquid/book.ts
@@ -1,0 +1,91 @@
+import { numberToUsd, usdToNumber } from "../costs";
+import type { TradingCostSide } from "../types";
+import type { BookSide, HyperliquidBookLevel } from "./types";
+
+export type BookFillResult = {
+  status: "filled" | "insufficientDepth";
+  averagePrice: number | undefined;
+  filledUsd: bigint;
+};
+
+export function simulateL2BookFill({
+  levels,
+  sizeUsd,
+}: {
+  levels: HyperliquidBookLevel[];
+  sizeUsd: bigint;
+}): BookFillResult {
+  const targetUsd = usdToNumber(sizeUsd) ?? 0;
+  let remainingUsd = targetUsd;
+  let filledUsd = 0;
+  let filledBase = 0;
+
+  for (const level of levels) {
+    if (remainingUsd <= 0) break;
+
+    const price = Number(level.px);
+    const size = Number(level.sz);
+    const levelUsd = price * size;
+    const takeUsd = Math.min(levelUsd, remainingUsd);
+    const takeBase = takeUsd / price;
+
+    filledUsd += takeUsd;
+    filledBase += takeBase;
+    remainingUsd -= takeUsd;
+  }
+
+  return {
+    status: remainingUsd > 0.000001 ? "insufficientDepth" : "filled",
+    averagePrice: filledBase > 0 ? filledUsd / filledBase : undefined,
+    filledUsd: numberToUsd(filledUsd),
+  };
+}
+
+export function getHyperliquidExecutionImpactUsd({
+  sizeUsd,
+  referencePrice,
+  averagePrice,
+  side,
+}: {
+  sizeUsd: bigint;
+  referencePrice: number;
+  averagePrice: number;
+  side: BookSide;
+}) {
+  if (referencePrice <= 0) {
+    return 0n;
+  }
+
+  const size = usdToNumber(sizeUsd) ?? 0;
+  const direction = side === "ask" ? 1 : -1;
+  return numberToUsd(size * ((averagePrice - referencePrice) / referencePrice) * direction);
+}
+
+export function getBookSideForLeg({
+  tradingSide,
+  isOpen,
+}: {
+  tradingSide: TradingCostSide;
+  isOpen: boolean;
+}): BookSide {
+  if (tradingSide === "long") {
+    return isOpen ? "ask" : "bid";
+  }
+
+  return isOpen ? "bid" : "ask";
+}
+
+export function getHyperliquidFundingCostUsd({
+  sizeUsd,
+  side,
+  hourlyFundingRate,
+  holdingPeriodHours,
+}: {
+  sizeUsd: bigint;
+  side: TradingCostSide;
+  hourlyFundingRate: number;
+  holdingPeriodHours: number;
+}) {
+  const signedRate = side === "long" ? hourlyFundingRate : -hourlyFundingRate;
+  return numberToUsd((usdToNumber(sizeUsd) ?? 0) * signedRate * holdingPeriodHours);
+}

--- a/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
+++ b/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
@@ -12,7 +12,10 @@ import {
   getHyperliquidFundingCostUsd,
   simulateL2BookFill,
 } from "./book";
-import type { HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
+import type { BookSide, HyperliquidBookBundle, HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
+
+const AGGREGATED_BOOK_WARNING =
+  "Using aggregated Hyperliquid book depth because the default 20-level book cannot fill the requested round-trip size.";
 
 export function getHyperliquidVenueMarkets(markets: HyperliquidNormalizedMarket[]): ComparisonVenueMarket[] {
   return markets.map((market) => ({
@@ -33,25 +36,39 @@ export function buildHyperliquidBreakdown({
   scenario: TradingCostScenario;
   match: MatchedTradingMarket;
   market: HyperliquidNormalizedMarket | undefined;
-  book: HyperliquidL2BookResponse | Error | undefined;
+  book: HyperliquidBookBundle | undefined;
 }): TradingCostBreakdown {
   if (!market) {
-    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: undefined, status: "loading", warnings: [] };
+    return {
+      providerId: "hyperliquid",
+      totalUsd: undefined,
+      components: [],
+      timestamp: undefined,
+      status: "loading",
+      warnings: [],
+    };
   }
 
-  if (book instanceof Error) {
+  if (!book) {
+    return {
+      providerId: "hyperliquid",
+      totalUsd: undefined,
+      components: [],
+      timestamp: market.timestamp,
+      status: "loading",
+      warnings: [],
+    };
+  }
+
+  if (book.default instanceof Error && book.aggregated instanceof Error) {
     return {
       providerId: "hyperliquid",
       totalUsd: undefined,
       components: [],
       timestamp: market.timestamp,
       status: "providerError",
-      warnings: [book.message],
+      warnings: [book.default.message, book.aggregated.message],
     };
-  }
-
-  if (!book) {
-    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: market.timestamp, status: "loading", warnings: [] };
   }
 
   const referencePrice = market.midPrice ?? market.markPrice;
@@ -70,22 +87,28 @@ export function buildHyperliquidBreakdown({
 
   const openBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: true });
   const closeBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: false });
-  const openLevels = openBookSide === "bid" ? book.levels[0] : book.levels[1];
-  const closeLevels = closeBookSide === "bid" ? book.levels[0] : book.levels[1];
-  const openFill = simulateL2BookFill({ levels: openLevels, sizeUsd: scenario.sizeUsd, referencePrice });
-  const closeFill = simulateL2BookFill({ levels: closeLevels, sizeUsd: scenario.sizeUsd, referencePrice });
+  const defaultBook = book.default instanceof Error ? undefined : book.default;
+  const aggregatedBook = book.aggregated instanceof Error ? undefined : book.aggregated;
+  const defaultEvaluation = defaultBook
+    ? evaluateBook({ book: defaultBook, scenario, referencePrice, openBookSide, closeBookSide })
+    : undefined;
+  const aggregatedEvaluation = aggregatedBook
+    ? evaluateBook({ book: aggregatedBook, scenario, referencePrice, openBookSide, closeBookSide })
+    : undefined;
+  const evaluation =
+    defaultEvaluation?.isFilled || !aggregatedEvaluation?.isFilled ? defaultEvaluation : aggregatedEvaluation;
+  const warnings = evaluation === aggregatedEvaluation ? [AGGREGATED_BOOK_WARNING] : [];
 
   if (
-    openFill.status === "insufficientDepth" ||
-    closeFill.status === "insufficientDepth" ||
-    openFill.averagePrice === undefined ||
-    closeFill.averagePrice === undefined
+    !evaluation?.isFilled ||
+    evaluation.openFill.averagePrice === undefined ||
+    evaluation.closeFill.averagePrice === undefined
   ) {
     return {
       providerId: "hyperliquid",
       totalUsd: undefined,
       components: [],
-      timestamp: book.time,
+      timestamp: defaultBook?.time ?? aggregatedBook?.time ?? market.timestamp,
       status: "insufficientDepth",
       warnings: ["Hyperliquid L2 levels cannot fill the requested round-trip size."],
     };
@@ -96,13 +119,13 @@ export function buildHyperliquidBreakdown({
   const openImpactUsd = getHyperliquidExecutionImpactUsd({
     sizeUsd: scenario.sizeUsd,
     referencePrice,
-    averagePrice: openFill.averagePrice,
+    averagePrice: evaluation.openFill.averagePrice,
     side: openBookSide,
   });
   const closeImpactUsd = getHyperliquidExecutionImpactUsd({
     sizeUsd: scenario.sizeUsd,
     referencePrice,
-    averagePrice: closeFill.averagePrice,
+    averagePrice: evaluation.closeFill.averagePrice,
     side: closeBookSide,
   });
   const fundingUsd = getHyperliquidFundingCostUsd({
@@ -124,8 +147,38 @@ export function buildHyperliquidBreakdown({
     providerId: "hyperliquid",
     totalUsd: sumTradingCostComponents(components),
     components,
-    timestamp: book.time,
+    timestamp: evaluation.book.time,
     status: "ready",
-    warnings: [],
+    warnings,
+  };
+}
+
+function evaluateBook({
+  book,
+  scenario,
+  referencePrice,
+  openBookSide,
+  closeBookSide,
+}: {
+  book: HyperliquidL2BookResponse;
+  scenario: TradingCostScenario;
+  referencePrice: number;
+  openBookSide: BookSide;
+  closeBookSide: BookSide;
+}) {
+  const openLevels = openBookSide === "bid" ? book.levels[0] : book.levels[1];
+  const closeLevels = closeBookSide === "bid" ? book.levels[0] : book.levels[1];
+  const openFill = simulateL2BookFill({ levels: openLevels, sizeUsd: scenario.sizeUsd, referencePrice });
+  const closeFill = simulateL2BookFill({ levels: closeLevels, sizeUsd: scenario.sizeUsd, referencePrice });
+
+  return {
+    book,
+    openFill,
+    closeFill,
+    isFilled:
+      openFill.status !== "insufficientDepth" &&
+      closeFill.status !== "insufficientDepth" &&
+      openFill.averagePrice !== undefined &&
+      closeFill.averagePrice !== undefined,
   };
 }

--- a/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
+++ b/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
@@ -1,0 +1,131 @@
+import { sumTradingCostComponents } from "../costs";
+import type {
+  ComparisonVenueMarket,
+  MatchedTradingMarket,
+  TradingCostBreakdown,
+  TradingCostComponent,
+  TradingCostScenario,
+} from "../types";
+import {
+  getBookSideForLeg,
+  getHyperliquidExecutionImpactUsd,
+  getHyperliquidFundingCostUsd,
+  simulateL2BookFill,
+} from "./book";
+import type { HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
+
+export function getHyperliquidVenueMarkets(markets: HyperliquidNormalizedMarket[]): ComparisonVenueMarket[] {
+  return markets.map((market) => ({
+    providerId: "hyperliquid",
+    symbol: market.symbol,
+    displayName: market.displayName,
+    volume24hUsd: market.volume24hUsd,
+    isDisabled: market.isDisabled,
+  }));
+}
+
+export function buildHyperliquidBreakdown({
+  scenario,
+  match: _match,
+  market,
+  book,
+}: {
+  scenario: TradingCostScenario;
+  match: MatchedTradingMarket;
+  market: HyperliquidNormalizedMarket | undefined;
+  book: HyperliquidL2BookResponse | Error | undefined;
+}): TradingCostBreakdown {
+  if (!market) {
+    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: undefined, status: "loading", warnings: [] };
+  }
+
+  if (book instanceof Error) {
+    return {
+      providerId: "hyperliquid",
+      totalUsd: undefined,
+      components: [],
+      timestamp: market.timestamp,
+      status: "providerError",
+      warnings: [book.message],
+    };
+  }
+
+  if (!book) {
+    return { providerId: "hyperliquid", totalUsd: undefined, components: [], timestamp: market.timestamp, status: "loading", warnings: [] };
+  }
+
+  const referencePrice = market.midPrice ?? market.markPrice;
+  const hourlyFundingRate = market.hourlyFundingRate;
+
+  if (!referencePrice || hourlyFundingRate === undefined) {
+    return {
+      providerId: "hyperliquid",
+      totalUsd: undefined,
+      components: [],
+      timestamp: market.timestamp,
+      status: "providerError",
+      warnings: ["Hyperliquid market context is missing price or funding data."],
+    };
+  }
+
+  const openBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: true });
+  const closeBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: false });
+  const openLevels = openBookSide === "bid" ? book.levels[0] : book.levels[1];
+  const closeLevels = closeBookSide === "bid" ? book.levels[0] : book.levels[1];
+  const openFill = simulateL2BookFill({ levels: openLevels, sizeUsd: scenario.sizeUsd });
+  const closeFill = simulateL2BookFill({ levels: closeLevels, sizeUsd: scenario.sizeUsd });
+
+  if (
+    openFill.status === "insufficientDepth" ||
+    closeFill.status === "insufficientDepth" ||
+    openFill.averagePrice === undefined ||
+    closeFill.averagePrice === undefined
+  ) {
+    return {
+      providerId: "hyperliquid",
+      totalUsd: undefined,
+      components: [],
+      timestamp: book.time,
+      status: "insufficientDepth",
+      warnings: ["Hyperliquid L2 levels cannot fill the requested round-trip size."],
+    };
+  }
+
+  const feeRate = scenario.venueAssumptions.hyperliquid.takerFeeRate;
+  const protocolFeeUsd = (scenario.sizeUsd * BigInt(Math.round(feeRate * 1_000_000)) * 2n) / 1_000_000n;
+  const openImpactUsd = getHyperliquidExecutionImpactUsd({
+    sizeUsd: scenario.sizeUsd,
+    referencePrice,
+    averagePrice: openFill.averagePrice,
+    side: openBookSide,
+  });
+  const closeImpactUsd = getHyperliquidExecutionImpactUsd({
+    sizeUsd: scenario.sizeUsd,
+    referencePrice,
+    averagePrice: closeFill.averagePrice,
+    side: closeBookSide,
+  });
+  const fundingUsd = getHyperliquidFundingCostUsd({
+    sizeUsd: scenario.sizeUsd,
+    side: scenario.side,
+    hourlyFundingRate,
+    holdingPeriodHours: scenario.holdingPeriodHours,
+  });
+
+  const components: TradingCostComponent[] = [
+    { key: "protocolFee", label: "Venue fee", usd: protocolFeeUsd },
+    { key: "venueExecutionImpact", label: "Open execution impact", usd: openImpactUsd },
+    { key: "venueExecutionImpact", label: "Close execution impact", usd: closeImpactUsd },
+    { key: "funding", label: "Funding", usd: fundingUsd },
+    { key: "networkFee", label: "Network fee", usd: 0n },
+  ];
+
+  return {
+    providerId: "hyperliquid",
+    totalUsd: sumTradingCostComponents(components),
+    components,
+    timestamp: book.time,
+    status: "ready",
+    warnings: [],
+  };
+}

--- a/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
+++ b/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
@@ -14,8 +14,9 @@ import {
 } from "./book";
 import type { BookSide, HyperliquidBookBundle, HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
 
-const AGGREGATED_BOOK_WARNING =
-  "Using aggregated Hyperliquid book depth because the default 20-level book cannot fill the requested round-trip size.";
+function getAggregatedBookWarning(label: string) {
+  return `Using aggregated Hyperliquid book depth (${label}) because more precise books cannot fill the requested round-trip size.`;
+}
 
 export function getHyperliquidVenueMarkets(markets: HyperliquidNormalizedMarket[]): ComparisonVenueMarket[] {
   return markets.map((market) => ({
@@ -60,14 +61,14 @@ export function buildHyperliquidBreakdown({
     };
   }
 
-  if (book.default instanceof Error && book.aggregated instanceof Error) {
+  if (book.every((entry) => entry.book instanceof Error)) {
     return {
       providerId: "hyperliquid",
       totalUsd: undefined,
       components: [],
       timestamp: market.timestamp,
       status: "providerError",
-      warnings: [book.default.message, book.aggregated.message],
+      warnings: book.map((entry) => (entry.book as Error).message),
     };
   }
 
@@ -87,17 +88,16 @@ export function buildHyperliquidBreakdown({
 
   const openBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: true });
   const closeBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: false });
-  const defaultBook = book.default instanceof Error ? undefined : book.default;
-  const aggregatedBook = book.aggregated instanceof Error ? undefined : book.aggregated;
-  const defaultEvaluation = defaultBook
-    ? evaluateBook({ book: defaultBook, scenario, referencePrice, openBookSide, closeBookSide })
-    : undefined;
-  const aggregatedEvaluation = aggregatedBook
-    ? evaluateBook({ book: aggregatedBook, scenario, referencePrice, openBookSide, closeBookSide })
-    : undefined;
-  const evaluation =
-    defaultEvaluation?.isFilled || !aggregatedEvaluation?.isFilled ? defaultEvaluation : aggregatedEvaluation;
-  const warnings = evaluation === aggregatedEvaluation ? [AGGREGATED_BOOK_WARNING] : [];
+  const bookEvaluations = book.flatMap((entry) => {
+    if (entry.book instanceof Error) {
+      return [];
+    }
+
+    return [evaluateBook({ entry, book: entry.book, scenario, referencePrice, openBookSide, closeBookSide })];
+  });
+  const evaluation = bookEvaluations.find((bookEvaluation) => bookEvaluation.isFilled);
+  const warnings =
+    evaluation && evaluation.entry.key !== "default" ? [getAggregatedBookWarning(evaluation.entry.label)] : [];
 
   if (
     !evaluation?.isFilled ||
@@ -108,7 +108,7 @@ export function buildHyperliquidBreakdown({
       providerId: "hyperliquid",
       totalUsd: undefined,
       components: [],
-      timestamp: defaultBook?.time ?? aggregatedBook?.time ?? market.timestamp,
+      timestamp: bookEvaluations[0]?.book.time ?? market.timestamp,
       status: "insufficientDepth",
       warnings: ["Hyperliquid L2 levels cannot fill the requested round-trip size."],
     };
@@ -155,12 +155,14 @@ export function buildHyperliquidBreakdown({
 
 function evaluateBook({
   book,
+  entry,
   scenario,
   referencePrice,
   openBookSide,
   closeBookSide,
 }: {
   book: HyperliquidL2BookResponse;
+  entry: HyperliquidBookBundle[number];
   scenario: TradingCostScenario;
   referencePrice: number;
   openBookSide: BookSide;
@@ -172,6 +174,7 @@ function evaluateBook({
   const closeFill = simulateL2BookFill({ levels: closeLevels, sizeUsd: scenario.sizeUsd, referencePrice });
 
   return {
+    entry,
     book,
     openFill,
     closeFill,

--- a/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
+++ b/src/domain/tradingCosts/hyperliquid/buildHyperliquidBreakdown.ts
@@ -72,8 +72,8 @@ export function buildHyperliquidBreakdown({
   const closeBookSide = getBookSideForLeg({ tradingSide: scenario.side, isOpen: false });
   const openLevels = openBookSide === "bid" ? book.levels[0] : book.levels[1];
   const closeLevels = closeBookSide === "bid" ? book.levels[0] : book.levels[1];
-  const openFill = simulateL2BookFill({ levels: openLevels, sizeUsd: scenario.sizeUsd });
-  const closeFill = simulateL2BookFill({ levels: closeLevels, sizeUsd: scenario.sizeUsd });
+  const openFill = simulateL2BookFill({ levels: openLevels, sizeUsd: scenario.sizeUsd, referencePrice });
+  const closeFill = simulateL2BookFill({ levels: closeLevels, sizeUsd: scenario.sizeUsd, referencePrice });
 
   if (
     openFill.status === "insufficientDepth" ||

--- a/src/domain/tradingCosts/hyperliquid/types.ts
+++ b/src/domain/tradingCosts/hyperliquid/types.ts
@@ -31,6 +31,11 @@ export type HyperliquidL2BookResponse = {
   levels: [HyperliquidBookLevel[], HyperliquidBookLevel[]];
 };
 
+export type HyperliquidBookBundle = {
+  default: HyperliquidL2BookResponse | Error;
+  aggregated: HyperliquidL2BookResponse | Error;
+};
+
 export type HyperliquidNormalizedMarket = {
   symbol: string;
   displayName: string;

--- a/src/domain/tradingCosts/hyperliquid/types.ts
+++ b/src/domain/tradingCosts/hyperliquid/types.ts
@@ -1,0 +1,50 @@
+import type { TradingCostSide } from "../types";
+
+export type HyperliquidAssetMeta = {
+  name: string;
+  szDecimals: number;
+  maxLeverage: number;
+  marginTableId: number;
+  isDelisted?: boolean;
+};
+
+export type HyperliquidAssetCtx = {
+  dayNtlVlm?: string;
+  funding?: string;
+  markPx?: string;
+  midPx?: string;
+  oraclePx?: string;
+  premium?: string;
+};
+
+export type HyperliquidMetaAndAssetCtxsResponse = [{ universe: HyperliquidAssetMeta[] }, HyperliquidAssetCtx[]];
+
+export type HyperliquidBookLevel = {
+  px: string;
+  sz: string;
+  n: number;
+};
+
+export type HyperliquidL2BookResponse = {
+  coin: string;
+  time: number;
+  levels: [HyperliquidBookLevel[], HyperliquidBookLevel[]];
+};
+
+export type HyperliquidNormalizedMarket = {
+  symbol: string;
+  displayName: string;
+  isDisabled: boolean;
+  volume24hUsd: bigint | undefined;
+  markPrice: number | undefined;
+  midPrice: number | undefined;
+  hourlyFundingRate: number | undefined;
+  timestamp: number;
+};
+
+export type BookSide = "ask" | "bid";
+
+export type HyperliquidLeg = {
+  bookSide: BookSide;
+  tradingSide: TradingCostSide;
+};

--- a/src/domain/tradingCosts/hyperliquid/types.ts
+++ b/src/domain/tradingCosts/hyperliquid/types.ts
@@ -31,10 +31,15 @@ export type HyperliquidL2BookResponse = {
   levels: [HyperliquidBookLevel[], HyperliquidBookLevel[]];
 };
 
-export type HyperliquidBookBundle = {
-  default: HyperliquidL2BookResponse | Error;
-  aggregated: HyperliquidL2BookResponse | Error;
+export type HyperliquidBookPrecisionKey = "default" | "5SigFigsMantissa5" | "4SigFigs" | "3SigFigs";
+
+export type HyperliquidBookEntry = {
+  key: HyperliquidBookPrecisionKey;
+  label: string;
+  book: HyperliquidL2BookResponse | Error;
 };
+
+export type HyperliquidBookBundle = HyperliquidBookEntry[];
 
 export type HyperliquidNormalizedMarket = {
   symbol: string;

--- a/src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts
+++ b/src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts
@@ -4,7 +4,7 @@ import useSWR from "swr";
 import { FREQUENT_UPDATE_INTERVAL } from "lib/timeConstants";
 
 import { fetchHyperliquidL2Books, fetchHyperliquidMetaAndAssetCtxs } from "./api";
-import type { HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
+import type { HyperliquidBookBundle, HyperliquidNormalizedMarket } from "./types";
 
 export type HyperliquidMarketsResult = {
   markets: HyperliquidNormalizedMarket[] | undefined;
@@ -13,7 +13,7 @@ export type HyperliquidMarketsResult = {
 };
 
 export type HyperliquidBooksResult = {
-  booksByCoin: Record<string, HyperliquidL2BookResponse | Error> | undefined;
+  booksByCoin: Record<string, HyperliquidBookBundle> | undefined;
   isLoading: boolean;
   error: Error | undefined;
 };

--- a/src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts
+++ b/src/domain/tradingCosts/hyperliquid/useHyperliquidData.ts
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import useSWR from "swr";
+
+import { FREQUENT_UPDATE_INTERVAL } from "lib/timeConstants";
+
+import { fetchHyperliquidL2Books, fetchHyperliquidMetaAndAssetCtxs } from "./api";
+import type { HyperliquidL2BookResponse, HyperliquidNormalizedMarket } from "./types";
+
+export type HyperliquidMarketsResult = {
+  markets: HyperliquidNormalizedMarket[] | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+};
+
+export type HyperliquidBooksResult = {
+  booksByCoin: Record<string, HyperliquidL2BookResponse | Error> | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+};
+
+export function useHyperliquidMarkets(): HyperliquidMarketsResult {
+  const marketsRequest = useSWR(["tradingCosts", "hyperliquid", "metaAndAssetCtxs"], fetchHyperliquidMetaAndAssetCtxs, {
+    refreshInterval: FREQUENT_UPDATE_INTERVAL,
+  });
+
+  return {
+    markets: marketsRequest.data,
+    isLoading: marketsRequest.isLoading,
+    error: marketsRequest.error as Error | undefined,
+  };
+}
+
+export function useHyperliquidL2Books(coins: string[] | undefined): HyperliquidBooksResult {
+  const sortedCoins = useMemo(() => {
+    return coins?.filter(Boolean).sort() ?? [];
+  }, [coins]);
+
+  const booksRequest = useSWR(
+    sortedCoins.length ? ["tradingCosts", "hyperliquid", "l2Books", sortedCoins.join(",")] : null,
+    () => fetchHyperliquidL2Books(sortedCoins),
+    { refreshInterval: FREQUENT_UPDATE_INTERVAL }
+  );
+
+  return {
+    booksByCoin: booksRequest.data,
+    isLoading: booksRequest.isLoading,
+    error: booksRequest.error as Error | undefined,
+  };
+}

--- a/src/domain/tradingCosts/marketMatching.ts
+++ b/src/domain/tradingCosts/marketMatching.ts
@@ -1,0 +1,46 @@
+import type { MarketInfo } from "domain/synthetics/markets";
+
+import type { ComparisonVenueMarket, MatchedTradingMarket } from "./types";
+
+const SYMBOL_ALIASES: Record<string, string> = {
+  WETH: "ETH",
+  WBTC: "BTC",
+};
+
+export function normalizeMarketSymbol(symbol: string | undefined): string {
+  const normalized = (symbol ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+  return SYMBOL_ALIASES[normalized] ?? normalized;
+}
+
+export function matchGmxMarketsToVenueMarkets(
+  gmxMarkets: MarketInfo[],
+  venueMarkets: ComparisonVenueMarket[]
+): { matched: MatchedTradingMarket[]; unmatched: MarketInfo[] } {
+  const venueBySymbol = new Map(
+    venueMarkets.filter((market) => !market.isDisabled).map((market) => [normalizeMarketSymbol(market.symbol), market])
+  );
+
+  const matched: MatchedTradingMarket[] = [];
+  const unmatched: MarketInfo[] = [];
+
+  for (const gmxMarket of gmxMarkets) {
+    if (gmxMarket.isDisabled || gmxMarket.isSpotOnly) {
+      continue;
+    }
+
+    const symbol = normalizeMarketSymbol(gmxMarket.indexToken?.symbol);
+    const venueMarket = venueBySymbol.get(symbol);
+
+    if (!venueMarket) {
+      unmatched.push(gmxMarket);
+      continue;
+    }
+
+    matched.push({ gmxMarket, venueMarket });
+  }
+
+  return { matched, unmatched };
+}

--- a/src/domain/tradingCosts/types.ts
+++ b/src/domain/tradingCosts/types.ts
@@ -33,7 +33,14 @@ export type TradingCostComponent = {
   usd: bigint;
 };
 
-export type TradingCostStatus = "ready" | "loading" | "unmatched" | "insufficientDepth" | "providerError" | "stale";
+export type TradingCostStatus =
+  | "ready"
+  | "loading"
+  | "unmatched"
+  | "insufficientDepth"
+  | "insufficientLiquidity"
+  | "providerError"
+  | "stale";
 
 export type TradingCostBreakdown = {
   providerId: TradingCostProviderId;

--- a/src/domain/tradingCosts/types.ts
+++ b/src/domain/tradingCosts/types.ts
@@ -1,0 +1,69 @@
+import type { MarketInfo } from "domain/synthetics/markets";
+
+export type TradingCostProviderId = "gmx" | "hyperliquid";
+export type TradingCostSide = "long" | "short";
+export type ComparisonVenueId = "hyperliquid";
+
+export type HyperliquidVenueAssumptions = {
+  takerFeeRate: number;
+};
+
+export type TradingCostScenario = {
+  sizeUsd: bigint;
+  side: TradingCostSide;
+  holdingPeriodHours: number;
+  comparisonVenue: ComparisonVenueId;
+  venueAssumptions: {
+    hyperliquid: HyperliquidVenueAssumptions;
+  };
+};
+
+export type TradingCostComponentKey =
+  | "protocolFee"
+  | "openPriceImpact"
+  | "closePriceImpact"
+  | "netRate"
+  | "networkFee"
+  | "venueExecutionImpact"
+  | "funding";
+
+export type TradingCostComponent = {
+  key: TradingCostComponentKey;
+  label: string;
+  usd: bigint;
+};
+
+export type TradingCostStatus = "ready" | "loading" | "unmatched" | "insufficientDepth" | "providerError" | "stale";
+
+export type TradingCostBreakdown = {
+  providerId: TradingCostProviderId;
+  totalUsd: bigint | undefined;
+  components: TradingCostComponent[];
+  timestamp: number | undefined;
+  status: TradingCostStatus;
+  warnings: string[];
+};
+
+export type TradingCostRow = {
+  marketKey: string;
+  displayName: string;
+  indexSymbol: string;
+  venueVolume24hUsd: bigint | undefined;
+  gmx: TradingCostBreakdown;
+  venue: TradingCostBreakdown;
+  deltaUsd: bigint | undefined;
+  status: TradingCostStatus;
+};
+
+export type ComparisonVenueMarket = {
+  providerId: Exclude<TradingCostProviderId, "gmx">;
+  symbol: string;
+  displayName: string;
+  volume24hUsd: bigint | undefined;
+  isDisabled?: boolean;
+};
+
+export type MatchedTradingMarket = {
+  gmxMarket: MarketInfo;
+  venueMarket: ComparisonVenueMarket;
+};

--- a/src/domain/tradingCosts/useTradingCosts.ts
+++ b/src/domain/tradingCosts/useTradingCosts.ts
@@ -1,0 +1,80 @@
+import { useMemo } from "react";
+
+import {
+  selectChainId,
+  selectGasLimits,
+  selectGasPrice,
+  selectMarketsInfoData,
+  selectTokensData,
+} from "context/SyntheticsStateContext/selectors/globalSelectors";
+import { useSelector } from "context/SyntheticsStateContext/utils";
+import { getGmxTradingCostBreakdown } from "domain/tradingCosts/gmx/gmxCost";
+
+import { buildTradingCostRows } from "./buildTradingCostRows";
+import { filterTradingCostRows } from "./costs";
+import { buildHyperliquidBreakdown, getHyperliquidVenueMarkets } from "./hyperliquid/buildHyperliquidBreakdown";
+import { useHyperliquidL2Books, useHyperliquidMarkets } from "./hyperliquid/useHyperliquidData";
+import type { TradingCostScenario } from "./types";
+
+export function useTradingCosts({ scenario, search }: { scenario: TradingCostScenario; search: string }) {
+  const chainId = useSelector(selectChainId);
+  const marketsInfoData = useSelector(selectMarketsInfoData);
+  const gasLimits = useSelector(selectGasLimits);
+  const gasPrice = useSelector(selectGasPrice);
+  const tokensData = useSelector(selectTokensData);
+
+  const gmxMarkets = useMemo(() => Object.values(marketsInfoData ?? {}), [marketsInfoData]);
+  const hyperliquidMarkets = useHyperliquidMarkets();
+  const venueMarkets = useMemo(
+    () => getHyperliquidVenueMarkets(hyperliquidMarkets.markets ?? []),
+    [hyperliquidMarkets.markets]
+  );
+  const coins = useMemo(() => venueMarkets.map((market) => market.symbol), [venueMarkets]);
+  const hyperliquidBooks = useHyperliquidL2Books(coins);
+
+  const rows = useMemo(() => {
+    const builtRows = buildTradingCostRows({
+      scenario,
+      gmxMarkets,
+      venueMarkets,
+      buildGmxBreakdown: (marketInfo) =>
+        getGmxTradingCostBreakdown({
+          marketInfo,
+          sizeUsd: scenario.sizeUsd,
+          side: scenario.side,
+          holdingPeriodHours: scenario.holdingPeriodHours,
+          chainId,
+          gasLimits,
+          gasPrice,
+          tokensData,
+          timestamp: Date.now(),
+        }),
+      buildVenueBreakdown: (match) =>
+        buildHyperliquidBreakdown({
+          match,
+          scenario,
+          market: hyperliquidMarkets.markets?.find((item) => item.symbol === match.venueMarket.symbol),
+          book: hyperliquidBooks.booksByCoin?.[match.venueMarket.symbol],
+        }),
+    });
+
+    return filterTradingCostRows(builtRows, search);
+  }, [
+    chainId,
+    gasLimits,
+    gasPrice,
+    gmxMarkets,
+    hyperliquidBooks.booksByCoin,
+    hyperliquidMarkets.markets,
+    scenario,
+    search,
+    tokensData,
+    venueMarkets,
+  ]);
+
+  return {
+    rows,
+    isLoading: hyperliquidMarkets.isLoading || hyperliquidBooks.isLoading || !marketsInfoData,
+    error: hyperliquidMarkets.error ?? hyperliquidBooks.error,
+  };
+}

--- a/src/domain/tradingCosts/useTradingCosts.ts
+++ b/src/domain/tradingCosts/useTradingCosts.ts
@@ -4,10 +4,12 @@ import {
   selectChainId,
   selectGasLimits,
   selectGasPrice,
+  selectJitLiquidityMap,
   selectMarketsInfoData,
   selectTokensData,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
+import { getJitMaxReservedUsd } from "domain/synthetics/jit/utils";
 import { getGmxTradingCostBreakdown } from "domain/tradingCosts/gmx/gmxCost";
 
 import { buildTradingCostRows, getMatchedVenueSymbols } from "./buildTradingCostRows";
@@ -22,6 +24,7 @@ export function useTradingCosts({ scenario, search }: { scenario: TradingCostSce
   const gasLimits = useSelector(selectGasLimits);
   const gasPrice = useSelector(selectGasPrice);
   const tokensData = useSelector(selectTokensData);
+  const jitLiquidityMap = useSelector(selectJitLiquidityMap);
 
   const gmxMarkets = useMemo(() => Object.values(marketsInfoData ?? {}), [marketsInfoData]);
   const hyperliquidMarkets = useHyperliquidMarkets();
@@ -47,6 +50,11 @@ export function useTradingCosts({ scenario, search }: { scenario: TradingCostSce
           gasLimits,
           gasPrice,
           tokensData,
+          maxReservedUsdWithJit: getJitMaxReservedUsd(
+            jitLiquidityMap,
+            marketInfo.marketTokenAddress,
+            scenario.side === "long"
+          ),
           timestamp: Date.now(),
         }),
       buildVenueBreakdown: (match) =>
@@ -66,6 +74,7 @@ export function useTradingCosts({ scenario, search }: { scenario: TradingCostSce
     gmxMarkets,
     hyperliquidBooks.booksByCoin,
     hyperliquidMarkets.markets,
+    jitLiquidityMap,
     scenario,
     search,
     tokensData,

--- a/src/domain/tradingCosts/useTradingCosts.ts
+++ b/src/domain/tradingCosts/useTradingCosts.ts
@@ -10,7 +10,7 @@ import {
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { getGmxTradingCostBreakdown } from "domain/tradingCosts/gmx/gmxCost";
 
-import { buildTradingCostRows } from "./buildTradingCostRows";
+import { buildTradingCostRows, getMatchedVenueSymbols } from "./buildTradingCostRows";
 import { filterTradingCostRows } from "./costs";
 import { buildHyperliquidBreakdown, getHyperliquidVenueMarkets } from "./hyperliquid/buildHyperliquidBreakdown";
 import { useHyperliquidL2Books, useHyperliquidMarkets } from "./hyperliquid/useHyperliquidData";
@@ -29,7 +29,7 @@ export function useTradingCosts({ scenario, search }: { scenario: TradingCostSce
     () => getHyperliquidVenueMarkets(hyperliquidMarkets.markets ?? []),
     [hyperliquidMarkets.markets]
   );
-  const coins = useMemo(() => venueMarkets.map((market) => market.symbol), [venueMarkets]);
+  const coins = useMemo(() => getMatchedVenueSymbols({ gmxMarkets, venueMarkets }), [gmxMarkets, venueMarkets]);
   const hyperliquidBooks = useHyperliquidL2Books(coins);
 
   const rows = useMemo(() => {

--- a/src/pages/TradingCosts/TradingCosts.scss
+++ b/src/pages/TradingCosts/TradingCosts.scss
@@ -52,9 +52,9 @@
     font-size: 1.2rem;
   }
 
-  .Select {
+  .TradingCosts-holdingPeriodDropdown {
     flex: 0 0 10rem;
-    height: 3.2rem;
+    min-width: 0;
   }
 }
 
@@ -211,7 +211,7 @@
   .TradingCosts-provider,
   .TradingCosts-search,
   .TradingCosts-controls label,
-  .TradingCosts-controls .Select,
+  .TradingCosts-holdingPeriodDropdown,
   .TradingCosts-sideTabs {
     flex-basis: 100%;
     max-width: none;

--- a/src/pages/TradingCosts/TradingCosts.scss
+++ b/src/pages/TradingCosts/TradingCosts.scss
@@ -91,7 +91,7 @@
   overflow-x: auto;
 
   table {
-    min-width: 82rem;
+    min-width: 94rem;
   }
 
   th,
@@ -128,6 +128,32 @@
   color: var(--color-white);
   font-size: 1.4rem;
   font-weight: 500;
+}
+
+.TradingCosts-detailSection {
+  margin-top: 1.6rem;
+
+  h3 {
+    margin: 0 0 0.8rem;
+    color: var(--color-slate-100);
+    font-size: 1.3rem;
+    font-weight: 500;
+  }
+}
+
+.TradingCosts-detailRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.2rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid var(--color-slate-700);
+  color: var(--color-slate-100);
+  font-size: 1.2rem;
+
+  span:last-child {
+    color: var(--color-white);
+    text-align: right;
+  }
 }
 
 .TradingCosts-breakdown {

--- a/src/pages/TradingCosts/TradingCosts.scss
+++ b/src/pages/TradingCosts/TradingCosts.scss
@@ -1,0 +1,193 @@
+.TradingCosts {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  text-align: left;
+}
+
+.TradingCosts-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.6rem;
+
+  h1 {
+    margin: 0;
+    font-size: 2.4rem;
+    line-height: 1.2;
+  }
+
+  p {
+    margin: 0.4rem 0 0;
+    color: var(--color-slate-100);
+    font-size: 1.3rem;
+  }
+}
+
+.TradingCosts-provider {
+  flex: 0 0 auto;
+  border: 1px solid var(--color-slate-600);
+  border-radius: 0.4rem;
+  padding: 0.8rem 1.2rem;
+  color: var(--color-slate-100);
+  font-size: 1.3rem;
+  white-space: nowrap;
+}
+
+.TradingCosts-controls {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  padding: 1.2rem;
+  background: var(--color-slate-900);
+
+  label {
+    display: flex;
+    flex: 0 0 14rem;
+    flex-direction: column;
+    gap: 0.6rem;
+    min-width: 0;
+    color: var(--color-slate-100);
+    font-size: 1.2rem;
+  }
+
+  .Select {
+    flex: 0 0 10rem;
+    height: 3.2rem;
+  }
+}
+
+.TradingCosts-search {
+  flex: 1 1 24rem;
+  max-width: 36rem;
+}
+
+.TradingCosts-input {
+  height: 3.2rem;
+  width: 100%;
+  border: 1px solid var(--color-slate-600);
+  border-radius: 0.4rem;
+  background: var(--color-slate-800);
+  padding: 0.6rem 0.8rem;
+  font-size: 1.3rem;
+}
+
+.TradingCosts-sideTabs {
+  flex: 0 0 14rem;
+  height: 3.2rem;
+  align-items: center;
+}
+
+.TradingCosts-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 36rem;
+  gap: 1.6rem;
+  align-items: start;
+}
+
+.TradingCosts-tableWrap {
+  min-width: 0;
+  overflow-x: auto;
+
+  table {
+    min-width: 82rem;
+  }
+
+  th,
+  td {
+    white-space: nowrap;
+  }
+}
+
+.TradingCosts-empty {
+  padding: 2rem;
+  background: var(--color-slate-900);
+  color: var(--color-slate-100);
+  font-size: 1.3rem;
+  text-align: center;
+}
+
+.TradingCosts-details {
+  border-left: 1px solid var(--color-slate-600);
+  padding-left: 1.6rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1.8rem;
+    line-height: 1.3;
+  }
+
+  p {
+    color: var(--color-slate-100);
+  }
+}
+
+.TradingCosts-detailTitle {
+  margin-top: 0.8rem;
+  color: var(--color-white);
+  font-size: 1.4rem;
+  font-weight: 500;
+}
+
+.TradingCosts-breakdown {
+  margin-top: 1.6rem;
+
+  h3 {
+    margin: 0 0 0.8rem;
+    color: var(--color-slate-100);
+    font-size: 1.3rem;
+    font-weight: 500;
+  }
+
+  ul {
+    margin: 0.8rem 0 0;
+    padding-left: 1.8rem;
+    color: var(--color-yellow-300);
+    font-size: 1.2rem;
+  }
+}
+
+.TradingCosts-breakdownRow,
+.TradingCosts-breakdownTotal {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.2rem;
+  padding: 0.6rem 0;
+  border-top: 1px solid var(--color-slate-700);
+  color: var(--color-slate-100);
+  font-size: 1.3rem;
+}
+
+.TradingCosts-breakdownTotal {
+  color: var(--color-white);
+  font-weight: 500;
+}
+
+@media screen and (max-width: 1100px) {
+  .TradingCosts-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .TradingCosts-details {
+    border-left: 0;
+    border-top: 1px solid var(--color-slate-600);
+    padding-top: 1.6rem;
+    padding-left: 0;
+  }
+}
+
+@media screen and (max-width: 700px) {
+  .TradingCosts-header {
+    flex-direction: column;
+  }
+
+  .TradingCosts-provider,
+  .TradingCosts-search,
+  .TradingCosts-controls label,
+  .TradingCosts-controls .Select,
+  .TradingCosts-sideTabs {
+    flex-basis: 100%;
+    max-width: none;
+  }
+}

--- a/src/pages/TradingCosts/TradingCosts.tsx
+++ b/src/pages/TradingCosts/TradingCosts.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from "react";
+
+import { numberToUsd } from "domain/tradingCosts/costs";
+import type { TradingCostScenario, TradingCostSide } from "domain/tradingCosts/types";
+import { useTradingCosts } from "domain/tradingCosts/useTradingCosts";
+
+import AppPageLayout from "components/AppPageLayout/AppPageLayout";
+
+import type { HoldingPeriodPreset } from "./TradingCostsView";
+import { TradingCostsView } from "./TradingCostsView";
+
+import "./TradingCosts.scss";
+
+const DEFAULT_SIZE_USD = "10000";
+const DEFAULT_HYPERLIQUID_TAKER_FEE_PERCENT = "0.045";
+
+export function TradingCostsPage() {
+  const [search, setSearch] = useState("");
+  const [sizeUsdInput, setSizeUsdInput] = useState(DEFAULT_SIZE_USD);
+  const [side, setSide] = useState<TradingCostSide>("long");
+  const [holdingPeriodPreset, setHoldingPeriodPreset] = useState<HoldingPeriodPreset>("8");
+  const [customHoldingHoursInput, setCustomHoldingHoursInput] = useState("");
+  const [takerFeeInput, setTakerFeeInput] = useState(DEFAULT_HYPERLIQUID_TAKER_FEE_PERCENT);
+
+  const holdingPeriodHours =
+    holdingPeriodPreset === "custom" ? Number(customHoldingHoursInput || "0") : Number(holdingPeriodPreset);
+  const scenario = useMemo<TradingCostScenario>(
+    () => ({
+      sizeUsd: numberToUsd(Number(sizeUsdInput || "0")),
+      side,
+      holdingPeriodHours,
+      comparisonVenue: "hyperliquid",
+      venueAssumptions: {
+        hyperliquid: { takerFeeRate: Number(takerFeeInput || "0") / 100 },
+      },
+    }),
+    [holdingPeriodHours, side, sizeUsdInput, takerFeeInput]
+  );
+
+  const { rows, isLoading } = useTradingCosts({ scenario, search });
+
+  return (
+    <AppPageLayout title="Trading Costs" contentClassName="!max-w-[1760px]">
+      <TradingCostsView
+        rows={rows}
+        isLoading={isLoading}
+        search={search}
+        setSearch={setSearch}
+        sizeUsdInput={sizeUsdInput}
+        setSizeUsdInput={setSizeUsdInput}
+        side={side}
+        setSide={setSide}
+        holdingPeriodPreset={holdingPeriodPreset}
+        setHoldingPeriodPreset={setHoldingPeriodPreset}
+        customHoldingHoursInput={customHoldingHoursInput}
+        setCustomHoldingHoursInput={setCustomHoldingHoursInput}
+        takerFeeInput={takerFeeInput}
+        setTakerFeeInput={setTakerFeeInput}
+      />
+    </AppPageLayout>
+  );
+}

--- a/src/pages/TradingCosts/TradingCostsView.tsx
+++ b/src/pages/TradingCosts/TradingCostsView.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 
 import type { TradingCostRow, TradingCostSide } from "domain/tradingCosts/types";
-import { formatUsd } from "lib/numbers";
+import { formatDeltaUsd, formatUsd } from "lib/numbers";
 
 import { DropdownSelector } from "components/DropdownSelector/DropdownSelector";
 import NumberInput from "components/NumberInput/NumberInput";
@@ -28,6 +28,19 @@ function getGmxPriceImpactTotal(row: TradingCostRow) {
   return row.gmx.components
     .filter((component) => component.key === "openPriceImpact" || component.key === "closePriceImpact")
     .reduce((total, component) => total + component.usd, 0n);
+}
+
+function getDeltaPercentage(row: TradingCostRow) {
+  const deltaUsd = row.deltaUsd;
+  const venueTotalUsd = row.venue.totalUsd;
+
+  if (deltaUsd === undefined || venueTotalUsd === undefined || venueTotalUsd === 0n) {
+    return undefined;
+  }
+
+  const denominator = venueTotalUsd < 0n ? -venueTotalUsd : venueTotalUsd;
+
+  return (deltaUsd * 10000n) / denominator;
 }
 
 function formatTimestamp(timestamp: number | undefined) {
@@ -155,7 +168,9 @@ export function TradingCostsView({
                   <TableTd>{formatUsd(row.venueVolume24hUsd) ?? "-"}</TableTd>
                   <TableTd>{formatUsd(row.gmx.totalUsd) ?? "-"}</TableTd>
                   <TableTd>{formatUsd(row.venue.totalUsd) ?? "-"}</TableTd>
-                  <TableTd>{formatUsd(row.deltaUsd, { displayPlus: true }) ?? "-"}</TableTd>
+                  <TableTd>
+                    {formatDeltaUsd(row.deltaUsd, getDeltaPercentage(row), { showPlusForZero: true }) ?? "-"}
+                  </TableTd>
                   <TableTd>{formatUsd(getGmxPriceImpactTotal(row), { displayPlus: true }) ?? "-"}</TableTd>
                   <TableTd>{row.status}</TableTd>
                 </TableTr>

--- a/src/pages/TradingCosts/TradingCostsView.tsx
+++ b/src/pages/TradingCosts/TradingCostsView.tsx
@@ -3,9 +3,9 @@ import { useMemo, useState } from "react";
 import type { TradingCostRow, TradingCostSide } from "domain/tradingCosts/types";
 import { formatUsd } from "lib/numbers";
 
+import { DropdownSelector } from "components/DropdownSelector/DropdownSelector";
 import NumberInput from "components/NumberInput/NumberInput";
 import SearchInput from "components/SearchInput/SearchInput";
-import Select from "components/Select/Select";
 import { Table, TableTd, TableTh, TableTheadTr, TableTr } from "components/Table/Table";
 import Tabs from "components/Tabs/Tabs";
 
@@ -16,12 +16,13 @@ const SIDE_OPTIONS: { value: TradingCostSide; label: string }[] = [
   { value: "short", label: "Short" },
 ];
 
-const HOLDING_PERIOD_OPTIONS: { value: HoldingPeriodPreset; label: string }[] = [
-  { value: "1", label: "1h" },
-  { value: "8", label: "8h" },
-  { value: "24", label: "24h" },
-  { value: "custom", label: "Custom" },
-];
+const HOLDING_PERIOD_OPTIONS: HoldingPeriodPreset[] = ["1", "8", "24", "custom"];
+const HOLDING_PERIOD_LABELS: Record<HoldingPeriodPreset, string> = {
+  "1": "1h",
+  "8": "8h",
+  "24": "24h",
+  custom: "Custom",
+};
 
 function getGmxPriceImpactTotal(row: TradingCostRow) {
   return row.gmx.components
@@ -103,11 +104,16 @@ export function TradingCostsView({
           options={SIDE_OPTIONS}
           className="TradingCosts-sideTabs"
         />
-        <Select
-          value={holdingPeriodPreset}
-          onChange={(event) => setHoldingPeriodPreset(event.target.value as HoldingPeriodPreset)}
-          options={HOLDING_PERIOD_OPTIONS}
-        />
+        <div className="TradingCosts-holdingPeriodDropdown">
+          <DropdownSelector
+            slim
+            value={holdingPeriodPreset}
+            onChange={setHoldingPeriodPreset}
+            options={HOLDING_PERIOD_OPTIONS}
+            item={({ option }) => <span className="text-typography-primary">{HOLDING_PERIOD_LABELS[option]}</span>}
+            button={<span className="text-typography-primary">{HOLDING_PERIOD_LABELS[holdingPeriodPreset]}</span>}
+          />
+        </div>
         {holdingPeriodPreset === "custom" && (
           <label>
             <span>Custom hours</span>

--- a/src/pages/TradingCosts/TradingCostsView.tsx
+++ b/src/pages/TradingCosts/TradingCostsView.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from "react";
+
+import type { TradingCostRow, TradingCostSide } from "domain/tradingCosts/types";
+import { formatUsd } from "lib/numbers";
+
+import NumberInput from "components/NumberInput/NumberInput";
+import SearchInput from "components/SearchInput/SearchInput";
+import Select from "components/Select/Select";
+import { Table, TableTd, TableTh, TableTheadTr, TableTr } from "components/Table/Table";
+import Tabs from "components/Tabs/Tabs";
+
+export type HoldingPeriodPreset = "1" | "8" | "24" | "custom";
+
+const SIDE_OPTIONS: { value: TradingCostSide; label: string }[] = [
+  { value: "long", label: "Long" },
+  { value: "short", label: "Short" },
+];
+
+const HOLDING_PERIOD_OPTIONS: { value: HoldingPeriodPreset; label: string }[] = [
+  { value: "1", label: "1h" },
+  { value: "8", label: "8h" },
+  { value: "24", label: "24h" },
+  { value: "custom", label: "Custom" },
+];
+
+export function TradingCostsView({
+  rows,
+  isLoading,
+  search,
+  setSearch,
+  sizeUsdInput,
+  setSizeUsdInput,
+  side,
+  setSide,
+  holdingPeriodPreset,
+  setHoldingPeriodPreset,
+  customHoldingHoursInput,
+  setCustomHoldingHoursInput,
+  takerFeeInput,
+  setTakerFeeInput,
+}: {
+  rows: TradingCostRow[];
+  isLoading: boolean;
+  search: string;
+  setSearch: (value: string) => void;
+  sizeUsdInput: string;
+  setSizeUsdInput: (value: string) => void;
+  side: TradingCostSide;
+  setSide: (value: TradingCostSide) => void;
+  holdingPeriodPreset: HoldingPeriodPreset;
+  setHoldingPeriodPreset: (value: HoldingPeriodPreset) => void;
+  customHoldingHoursInput: string;
+  setCustomHoldingHoursInput: (value: string) => void;
+  takerFeeInput: string;
+  setTakerFeeInput: (value: string) => void;
+}) {
+  const [selectedMarketKey, setSelectedMarketKey] = useState<string | undefined>();
+  const selectedRow = useMemo(
+    () => rows.find((row) => row.marketKey === selectedMarketKey) ?? rows[0],
+    [rows, selectedMarketKey]
+  );
+
+  return (
+    <div className="TradingCosts">
+      <div className="TradingCosts-header">
+        <div>
+          <h1>Trading Costs</h1>
+          <p>Round-trip current cost comparison across matched perps markets.</p>
+        </div>
+        <div className="TradingCosts-provider">Compare venue: Hyperliquid</div>
+      </div>
+
+      <div className="TradingCosts-controls">
+        <SearchInput value={search} setValue={setSearch} placeholder="Search market" className="TradingCosts-search" />
+        <label>
+          <span>Size, USD</span>
+          <NumberInput
+            value={sizeUsdInput}
+            onValueChange={(event) => setSizeUsdInput(event.target.value)}
+            className="TradingCosts-input"
+          />
+        </label>
+        <Tabs
+          type="inline"
+          selectedValue={side}
+          onChange={(value) => setSide(value as TradingCostSide)}
+          options={SIDE_OPTIONS}
+          className="TradingCosts-sideTabs"
+        />
+        <Select
+          value={holdingPeriodPreset}
+          onChange={(event) => setHoldingPeriodPreset(event.target.value as HoldingPeriodPreset)}
+          options={HOLDING_PERIOD_OPTIONS}
+        />
+        {holdingPeriodPreset === "custom" && (
+          <label>
+            <span>Custom hours</span>
+            <NumberInput
+              value={customHoldingHoursInput}
+              onValueChange={(event) => setCustomHoldingHoursInput(event.target.value)}
+              className="TradingCosts-input"
+            />
+          </label>
+        )}
+        <label>
+          <span>Venue assumptions</span>
+          <NumberInput
+            value={takerFeeInput}
+            onValueChange={(event) => setTakerFeeInput(event.target.value)}
+            className="TradingCosts-input"
+          />
+        </label>
+      </div>
+
+      <div className="TradingCosts-layout">
+        <div className="TradingCosts-tableWrap">
+          <Table>
+            <thead>
+              <TableTheadTr>
+                <TableTh>Market</TableTh>
+                <TableTh>Venue volume</TableTh>
+                <TableTh>GMX total</TableTh>
+                <TableTh>Venue total</TableTh>
+                <TableTh>Delta</TableTh>
+                <TableTh>Status</TableTh>
+              </TableTheadTr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <TableTr key={row.marketKey} hoverable onClick={() => setSelectedMarketKey(row.marketKey)}>
+                  <TableTd>{row.displayName}</TableTd>
+                  <TableTd>{formatUsd(row.venueVolume24hUsd) ?? "-"}</TableTd>
+                  <TableTd>{formatUsd(row.gmx.totalUsd) ?? "-"}</TableTd>
+                  <TableTd>{formatUsd(row.venue.totalUsd) ?? "-"}</TableTd>
+                  <TableTd>{formatUsd(row.deltaUsd, { displayPlus: true }) ?? "-"}</TableTd>
+                  <TableTd>{row.status}</TableTd>
+                </TableTr>
+              ))}
+            </tbody>
+          </Table>
+          {!rows.length && <div className="TradingCosts-empty">{isLoading ? "Loading..." : "No matched markets"}</div>}
+        </div>
+
+        <aside className="TradingCosts-details">
+          <h2>Selected market</h2>
+          {selectedRow ? (
+            <>
+              <div className="TradingCosts-detailTitle">{selectedRow.indexSymbol}</div>
+              <Breakdown title="GMX" row={selectedRow} provider="gmx" />
+              <Breakdown title="Venue" row={selectedRow} provider="venue" />
+            </>
+          ) : (
+            <p>No market selected</p>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function Breakdown({ title, row, provider }: { title: string; row: TradingCostRow; provider: "gmx" | "venue" }) {
+  const breakdown = row[provider];
+
+  return (
+    <div className="TradingCosts-breakdown">
+      <h3>{title}</h3>
+      {breakdown.components.map((component, index) => (
+        <div key={`${component.key}-${index}`} className="TradingCosts-breakdownRow">
+          <span>{component.label}</span>
+          <span>{formatUsd(component.usd) ?? "-"}</span>
+        </div>
+      ))}
+      <div className="TradingCosts-breakdownTotal">
+        <span>Total</span>
+        <span>{formatUsd(breakdown.totalUsd) ?? "-"}</span>
+      </div>
+      {!!breakdown.warnings.length && (
+        <ul>
+          {breakdown.warnings.map((warning) => (
+            <li key={warning}>{warning}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/pages/TradingCosts/TradingCostsView.tsx
+++ b/src/pages/TradingCosts/TradingCostsView.tsx
@@ -25,9 +25,15 @@ const HOLDING_PERIOD_LABELS: Record<HoldingPeriodPreset, string> = {
 };
 
 function getGmxPriceImpactTotal(row: TradingCostRow) {
-  return row.gmx.components
-    .filter((component) => component.key === "openPriceImpact" || component.key === "closePriceImpact")
-    .reduce((total, component) => total + component.usd, 0n);
+  const priceImpactComponents = row.gmx.components.filter(
+    (component) => component.key === "openPriceImpact" || component.key === "closePriceImpact"
+  );
+
+  if (!priceImpactComponents.length) {
+    return undefined;
+  }
+
+  return priceImpactComponents.reduce((total, component) => total + component.usd, 0n);
 }
 
 function getDeltaPercentage(row: TradingCostRow) {

--- a/src/pages/TradingCosts/TradingCostsView.tsx
+++ b/src/pages/TradingCosts/TradingCostsView.tsx
@@ -23,6 +23,20 @@ const HOLDING_PERIOD_OPTIONS: { value: HoldingPeriodPreset; label: string }[] = 
   { value: "custom", label: "Custom" },
 ];
 
+function getGmxPriceImpactTotal(row: TradingCostRow) {
+  return row.gmx.components
+    .filter((component) => component.key === "openPriceImpact" || component.key === "closePriceImpact")
+    .reduce((total, component) => total + component.usd, 0n);
+}
+
+function formatTimestamp(timestamp: number | undefined) {
+  if (timestamp === undefined) {
+    return "-";
+  }
+
+  return new Date(timestamp).toLocaleString();
+}
+
 export function TradingCostsView({
   rows,
   isLoading,
@@ -59,6 +73,8 @@ export function TradingCostsView({
     () => rows.find((row) => row.marketKey === selectedMarketKey) ?? rows[0],
     [rows, selectedMarketKey]
   );
+  const holdingPeriodLabel =
+    holdingPeriodPreset === "custom" ? `${customHoldingHoursInput || "0"}h` : `${holdingPeriodPreset}h`;
 
   return (
     <div className="TradingCosts">
@@ -122,6 +138,7 @@ export function TradingCostsView({
                 <TableTh>GMX total</TableTh>
                 <TableTh>Venue total</TableTh>
                 <TableTh>Delta</TableTh>
+                <TableTh>GMX price impact</TableTh>
                 <TableTh>Status</TableTh>
               </TableTheadTr>
             </thead>
@@ -133,6 +150,7 @@ export function TradingCostsView({
                   <TableTd>{formatUsd(row.gmx.totalUsd) ?? "-"}</TableTd>
                   <TableTd>{formatUsd(row.venue.totalUsd) ?? "-"}</TableTd>
                   <TableTd>{formatUsd(row.deltaUsd, { displayPlus: true }) ?? "-"}</TableTd>
+                  <TableTd>{formatUsd(getGmxPriceImpactTotal(row), { displayPlus: true }) ?? "-"}</TableTd>
                   <TableTd>{row.status}</TableTd>
                 </TableTr>
               ))}
@@ -146,6 +164,24 @@ export function TradingCostsView({
           {selectedRow ? (
             <>
               <div className="TradingCosts-detailTitle">{selectedRow.indexSymbol}</div>
+              <div className="TradingCosts-detailSection">
+                <h3>Scenario</h3>
+                <DetailRow label="Size" value={`$${sizeUsdInput || "0"}`} />
+                <DetailRow label="Side" value={side} />
+                <DetailRow label="Holding period" value={holdingPeriodLabel} />
+                <DetailRow label="Venue fee assumption" value={`${takerFeeInput || "0"}%`} />
+              </div>
+              <div className="TradingCosts-detailSection">
+                <h3>Data timestamps</h3>
+                <DetailRow label="GMX" value={formatTimestamp(selectedRow.gmx.timestamp)} />
+                <DetailRow label="Venue" value={formatTimestamp(selectedRow.venue.timestamp)} />
+              </div>
+              <div className="TradingCosts-detailSection">
+                <h3>Status details</h3>
+                <DetailRow label="Row" value={selectedRow.status} />
+                <DetailRow label="GMX" value={selectedRow.gmx.status} />
+                <DetailRow label="Venue" value={selectedRow.venue.status} />
+              </div>
               <Breakdown title="GMX" row={selectedRow} provider="gmx" />
               <Breakdown title="Venue" row={selectedRow} provider="venue" />
             </>
@@ -154,6 +190,15 @@ export function TradingCostsView({
           )}
         </aside>
       </div>
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="TradingCosts-detailRow">
+      <span>{label}</span>
+      <span>{value}</span>
     </div>
   );
 }

--- a/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
+++ b/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
@@ -30,6 +30,25 @@ const rows: TradingCostRow[] = [
   },
 ];
 
+const unavailableRows: TradingCostRow[] = [
+  {
+    marketKey: "hyperliquid:ZEC:0x1",
+    displayName: "ZEC/USD [BTC-USDC]",
+    indexSymbol: "ZEC",
+    venueVolume24hUsd: numberToUsd(1_000_000),
+    gmx: {
+      ...baseBreakdown,
+      totalUsd: undefined,
+      components: [],
+      status: "insufficientLiquidity",
+      warnings: ["GMX available liquidity is lower than the requested trade size."],
+    },
+    venue: { ...baseBreakdown, providerId: "hyperliquid", totalUsd: undefined, status: "insufficientDepth" },
+    deltaUsd: undefined,
+    status: "insufficientLiquidity",
+  },
+];
+
 test("renders generic venue labels and selected market details", async ({ mount }) => {
   const component = await mount(
     <TradingCostsView
@@ -82,6 +101,31 @@ test("renders delta percentage relative to venue total", async ({ mount }) => {
   );
 
   await expect(component.getByText("(+33.33%)")).toBeVisible();
+});
+
+test("renders a dash for GMX price impact when GMX costs are unavailable", async ({ mount }) => {
+  const component = await mount(
+    <TradingCostsView
+      rows={unavailableRows}
+      isLoading={false}
+      search=""
+      setSearch={() => undefined}
+      sizeUsdInput="10000000"
+      setSizeUsdInput={() => undefined}
+      side="long"
+      setSide={() => undefined}
+      holdingPeriodPreset="8"
+      setHoldingPeriodPreset={() => undefined}
+      customHoldingHoursInput=""
+      setCustomHoldingHoursInput={() => undefined}
+      takerFeeInput="0.045"
+      setTakerFeeInput={() => undefined}
+    />
+  );
+
+  const marketRow = component.getByRole("row").filter({ hasText: "ZEC/USD [BTC-USDC]" });
+
+  await expect(marketRow.locator("td").nth(5)).toHaveText("-");
 });
 
 test("uses the app dropdown for holding period presets", async ({ mount, page }) => {

--- a/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
+++ b/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
@@ -52,7 +52,11 @@ test("renders generic venue labels and selected market details", async ({ mount 
 
   await expect(component.getByText("Trading Costs")).toBeVisible();
   await expect(component.getByText("Venue total")).toBeVisible();
+  await expect(component.getByText("GMX price impact")).toBeVisible();
   await expect(component.getByText("Venue assumptions")).toBeVisible();
   await expect(component.getByText("ETH/USD [WETH-USDC]")).toBeVisible();
   await expect(component.getByText("Selected market")).toBeVisible();
+  await expect(component.getByText("Scenario")).toBeVisible();
+  await expect(component.getByText("Data timestamps")).toBeVisible();
+  await expect(component.getByText("Status details")).toBeVisible();
 });

--- a/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
+++ b/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { numberToUsd } from "domain/tradingCosts/costs";
+import type { TradingCostRow } from "domain/tradingCosts/types";
+
+import { TradingCostsView } from "../TradingCostsView";
+
+const baseBreakdown = {
+  providerId: "gmx" as const,
+  totalUsd: numberToUsd(20),
+  components: [
+    { key: "protocolFee" as const, label: "Protocol fee", usd: numberToUsd(10) },
+    { key: "openPriceImpact" as const, label: "Open price impact", usd: numberToUsd(3) },
+  ],
+  timestamp: 1,
+  status: "ready" as const,
+  warnings: [],
+};
+
+const rows: TradingCostRow[] = [
+  {
+    marketKey: "hyperliquid:ETH:0x1",
+    displayName: "ETH/USD [WETH-USDC]",
+    indexSymbol: "ETH",
+    venueVolume24hUsd: numberToUsd(1_000_000),
+    gmx: baseBreakdown,
+    venue: { ...baseBreakdown, providerId: "hyperliquid", totalUsd: numberToUsd(15) },
+    deltaUsd: numberToUsd(5),
+    status: "ready",
+  },
+];
+
+test("renders generic venue labels and selected market details", async ({ mount }) => {
+  const component = await mount(
+    <TradingCostsView
+      rows={rows}
+      isLoading={false}
+      search=""
+      setSearch={() => undefined}
+      sizeUsdInput="10000"
+      setSizeUsdInput={() => undefined}
+      side="long"
+      setSide={() => undefined}
+      holdingPeriodPreset="8"
+      setHoldingPeriodPreset={() => undefined}
+      customHoldingHoursInput=""
+      setCustomHoldingHoursInput={() => undefined}
+      takerFeeInput="0.045"
+      setTakerFeeInput={() => undefined}
+    />
+  );
+
+  await expect(component.getByText("Trading Costs")).toBeVisible();
+  await expect(component.getByText("Venue total")).toBeVisible();
+  await expect(component.getByText("Venue assumptions")).toBeVisible();
+  await expect(component.getByText("ETH/USD [WETH-USDC]")).toBeVisible();
+  await expect(component.getByText("Selected market")).toBeVisible();
+});

--- a/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
+++ b/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
@@ -61,6 +61,29 @@ test("renders generic venue labels and selected market details", async ({ mount 
   await expect(component.getByText("Status details")).toBeVisible();
 });
 
+test("renders delta percentage relative to venue total", async ({ mount }) => {
+  const component = await mount(
+    <TradingCostsView
+      rows={rows}
+      isLoading={false}
+      search=""
+      setSearch={() => undefined}
+      sizeUsdInput="10000"
+      setSizeUsdInput={() => undefined}
+      side="long"
+      setSide={() => undefined}
+      holdingPeriodPreset="8"
+      setHoldingPeriodPreset={() => undefined}
+      customHoldingHoursInput=""
+      setCustomHoldingHoursInput={() => undefined}
+      takerFeeInput="0.045"
+      setTakerFeeInput={() => undefined}
+    />
+  );
+
+  await expect(component.getByText("(+33.33%)")).toBeVisible();
+});
+
 test("uses the app dropdown for holding period presets", async ({ mount, page }) => {
   const component = await mount(
     <TradingCostsView

--- a/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
+++ b/src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx
@@ -60,3 +60,28 @@ test("renders generic venue labels and selected market details", async ({ mount 
   await expect(component.getByText("Data timestamps")).toBeVisible();
   await expect(component.getByText("Status details")).toBeVisible();
 });
+
+test("uses the app dropdown for holding period presets", async ({ mount, page }) => {
+  const component = await mount(
+    <TradingCostsView
+      rows={rows}
+      isLoading={false}
+      search=""
+      setSearch={() => undefined}
+      sizeUsdInput="10000"
+      setSizeUsdInput={() => undefined}
+      side="long"
+      setSide={() => undefined}
+      holdingPeriodPreset="8"
+      setHoldingPeriodPreset={() => undefined}
+      customHoldingHoursInput=""
+      setCustomHoldingHoursInput={() => undefined}
+      takerFeeInput="0.045"
+      setTakerFeeInput={() => undefined}
+    />
+  );
+
+  await component.locator(".TradingCosts-holdingPeriodDropdown button").click();
+
+  await expect(page.getByRole("option", { name: "24h" })).toBeVisible();
+});

--- a/src/pages/TradingCosts/__tests__/TradingCostsView.ct.stories.tsx
+++ b/src/pages/TradingCosts/__tests__/TradingCostsView.ct.stories.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+
+import { numberToUsd } from "domain/tradingCosts/costs";
+import type { TradingCostRow, TradingCostSide } from "domain/tradingCosts/types";
+
+import type { HoldingPeriodPreset } from "../TradingCostsView";
+import { TradingCostsView } from "../TradingCostsView";
+
+import "../TradingCosts.scss";
+
+const baseBreakdown = {
+  providerId: "gmx" as const,
+  totalUsd: numberToUsd(20),
+  components: [
+    { key: "protocolFee" as const, label: "Protocol fee", usd: numberToUsd(10) },
+    { key: "openPriceImpact" as const, label: "Open price impact", usd: numberToUsd(3) },
+    { key: "closePriceImpact" as const, label: "Close price impact", usd: numberToUsd(2) },
+  ],
+  timestamp: 1,
+  status: "ready" as const,
+  warnings: [],
+};
+
+const rows: TradingCostRow[] = [
+  {
+    marketKey: "hyperliquid:ETH:0x1",
+    displayName: "ETH/USD [WETH-USDC]",
+    indexSymbol: "ETH",
+    venueVolume24hUsd: numberToUsd(1_000_000),
+    gmx: baseBreakdown,
+    venue: { ...baseBreakdown, providerId: "hyperliquid", totalUsd: numberToUsd(15) },
+    deltaUsd: numberToUsd(5),
+    status: "ready",
+  },
+  {
+    marketKey: "hyperliquid:BTC:0x2",
+    displayName: "BTC/USD [WBTC-USDC]",
+    indexSymbol: "BTC",
+    venueVolume24hUsd: numberToUsd(2_500_000),
+    gmx: { ...baseBreakdown, totalUsd: numberToUsd(32) },
+    venue: { ...baseBreakdown, providerId: "hyperliquid", totalUsd: numberToUsd(28) },
+    deltaUsd: numberToUsd(4),
+    status: "ready",
+  },
+];
+
+export function TradingCostsViewStory() {
+  const [search, setSearch] = useState("");
+  const [sizeUsdInput, setSizeUsdInput] = useState("10000");
+  const [side, setSide] = useState<TradingCostSide>("long");
+  const [holdingPeriodPreset, setHoldingPeriodPreset] = useState<HoldingPeriodPreset>("8");
+  const [customHoldingHoursInput, setCustomHoldingHoursInput] = useState("");
+  const [takerFeeInput, setTakerFeeInput] = useState("0.045");
+
+  return (
+    <TradingCostsView
+      rows={rows}
+      isLoading={false}
+      search={search}
+      setSearch={setSearch}
+      sizeUsdInput={sizeUsdInput}
+      setSizeUsdInput={setSizeUsdInput}
+      side={side}
+      setSide={setSide}
+      holdingPeriodPreset={holdingPeriodPreset}
+      setHoldingPeriodPreset={setHoldingPeriodPreset}
+      customHoldingHoursInput={customHoldingHoursInput}
+      setCustomHoldingHoursInput={setCustomHoldingHoursInput}
+      takerFeeInput={takerFeeInput}
+      setTakerFeeInput={setTakerFeeInput}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Draft test-only PR for the trading costs dashboard work.

This includes:
- core trading-cost helpers and market matching
- Hyperliquid market/book data and cost estimates
- GMX protocol fee, price impact, rate, and network fee estimates
- the `/costs` dashboard route and UI
- fixes for Arbitrum production market sourcing and the holding-period app dropdown

## Validation

- `yarn test:ci src/domain/tradingCosts src/App/MainRoutes.spec.tsx`
- `yarn test:ct src/pages/TradingCosts/__tests__/TradingCostsView.ct.spec.tsx`
- `yarn tscheck:ci`
- Focused ESLint on changed TS/TSX files
- Pre-push hook also ran full unit/component checks successfully during branch push.

## Notes

Test-only draft. Not ready for review/merge.
