### PR TITLE
FEDEV-3911 Fix chart token selector header alignment

### DIFF
--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -753,7 +753,7 @@ function MarketListItem({
   if (isSwap) {
     return (
       <tr key={token.symbol} className="group/row cursor-pointer hover:bg-fill-surfaceHover">
-        <td className={cx("pl-14 pr-0 text-center text-typography-secondary", rowVerticalPadding)}>
+        <td className={cx("pl-12 pr-0 text-center text-typography-secondary", rowVerticalPadding)}>
           <Button variant="ghost" className="!h-20 !min-h-32 !w-32 !p-0" onClick={handleFavoriteClick}>
             <RecentlyListedFavoriteSlot isRecentlyListed={isRecentlyListed} isFavorite={isFavorite} />
           </Button>

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -368,6 +368,8 @@ function MarketsList() {
     rowHorizontalPadding,
     "!py-10"
   );
+  const favoriteThClassName = cx(thClassName, "w-0 !pr-0 text-center");
+  const marketThClassName = cx(thClassName, "pl-12");
 
   const tdClassName = cx(
     "text-body-small",
@@ -455,8 +457,8 @@ function MarketsList() {
         <table className="text-body-small w-full border-separate border-spacing-0">
           <thead>
             <tr>
-              <th colSpan={1}></th>
-              <th className={cx(thClassName, "pl-4", isMobile ? "min-w-[18ch]" : "min-w-[28ch]")} colSpan={1}>
+              <th className={favoriteThClassName} colSpan={1}></th>
+              <th className={cx(marketThClassName, isMobile ? "min-w-[18ch]" : "min-w-[28ch]")} colSpan={1}>
                 <Trans>MARKET</Trans>
               </th>
               {isSwap ? (
@@ -792,7 +794,7 @@ function MarketListItem({
           <RecentlyListedFavoriteSlot isRecentlyListed={isRecentlyListed} isFavorite={isFavorite} />
         </Button>
       </td>
-      <td className={cx("pl-4 text-[13px]", rowVerticalPadding, isMobile ? "pr-2" : "pr-8")}>
+      <td className={cx("pl-12 text-[13px]", rowVerticalPadding, isMobile ? "pr-2" : rowHorizontalPadding)}>
         <div className={cx("flex", isMobile ? "items-start" : "items-center")}>
           <TokenIcon className="ChartToken-list-icon mr-6" symbol={token.symbol} displaySize={16} />
           <span className={cx("flex flex-wrap items-center gap-6")}>

--- a/src/components/FavoriteTabs/FavoriteTabs.tsx
+++ b/src/components/FavoriteTabs/FavoriteTabs.tsx
@@ -12,7 +12,7 @@ import { useLocalizedMap } from "lib/i18n";
 import Tabs from "components/Tabs/Tabs";
 import type { Option } from "components/Tabs/types";
 
-const REGULAR_TAB_CLASS_NAME = "!px-8 !pb-11 !pt-13 text-13";
+const REGULAR_TAB_CLASS_NAME = "!px-8 !pb-11 !pt-13 text-13 leading-[18px]";
 
 export function FavoriteTabs({
   favoritesKey,


### PR DESCRIPTION
## Summary
- Fix the transparent favorites-column header cell in the chart token selector modal by applying the same sticky header background classes as the other columns.
- Align the perpetuals market column padding with the swap variant.
- Stabilize favorite tab line-height to avoid jumpy tab UI.

Linear: https://linear.app/gmx-io/issue/FEDEV-3911/fix-chart-token-selector-header-and-tab-alignment
