### PR TITLE
use prod subsquid tag

### DIFF
--- a/sdk/scripts/subsquid-codegen.ts
+++ b/sdk/scripts/subsquid-codegen.ts
@@ -1,7 +1,7 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum@5eaa69/api/graphql",
+  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
   overwrite: true,
   debug: true,
   generates: {

--- a/sdk/src/clients/v1/testUtil.ts
+++ b/sdk/src/clients/v1/testUtil.ts
@@ -19,7 +19,7 @@ export const arbitrumSdkConfig: GmxSdkConfig = {
   oracleUrl: "https://arbitrum-api.gmxinfra.io",
   rpcUrl: "https://arb1.arbitrum.io/rpc",
   walletClient: client,
-  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@decb4e/api/graphql",
+  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
 };
 
 export const arbitrumSdk = new GmxSdk(arbitrumSdkConfig);

--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -22,7 +22,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-arbitrum-referrals/master-240506225935-51167d5/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-250410222518-4486206/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@decb4e/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
   },
 
   [AVALANCHE]: {
@@ -32,7 +32,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-avalanche-referrals/master-240415215829-f6877d6/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-avalanche-stats/master-250410222549-4486206/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche@decb4e/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche:prod/api/graphql",
   },
 
   [AVALANCHE_FUJI]: {
@@ -40,21 +40,21 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-fuji-referrals/synts-stats-230726124533-065cd0d/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-fuji-stats/master-250708141244-939c871/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-fuji@5eaa69/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-fuji:prod/api/graphql",
   },
 
   [ARBITRUM_SEPOLIA]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia@decb4e/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia:prod/api/graphql",
   },
 
   [BOTANIX]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-botanix@decb4e/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-botanix:prod/api/graphql",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-botanix-stats/botanix-250617091016-f7b3bb5/gn",
   },
 
   [MEGAETH]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth@decb4e/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth:prod/api/graphql",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-megaeth-stats/master-260120151613-540f334/gn",
     referrals:


### PR DESCRIPTION
## Summary

Replaces pinned Subsquid deployment URLs with the `:prod` slot/tag.

Updated runtime indexer config for Arbitrum, Avalanche, Fuji, Arbitrum Sepolia, Botanix, and MegaETH, plus the SDK test utility and Subsquid codegen schema URL.
