### PR TITLE
FEDEV-3920: Add wallet loading states and remove landing wallet provider

### DIFF
--- a/landing/src/App.tsx
+++ b/landing/src/App.tsx
@@ -8,7 +8,6 @@ import { LANGUAGE_LOCALSTORAGE_KEY } from "config/localStorage";
 import { ThemeProvider } from "context/ThemeContext/ThemeContext";
 import { defaultLocale, dynamicActivate } from "lib/i18n";
 import { useOracleKeeperFetcher } from "lib/oracleKeeperFetcher";
-import WalletProvider from "lib/wallets/WalletProvider";
 import { ARBITRUM } from "sdk/configs/chainIds";
 
 import SEO from "components/Seo/SEO";
@@ -34,13 +33,11 @@ export default function App() {
       <SWRConfig>
         <I18nProvider i18n={i18n as any}>
           <ThemeProvider>
-            <WalletProvider>
-              <SEO>
-                <div className="overflow-hidden proportional-nums text-white">
-                  <LandingRoutes />
-                </div>
-              </SEO>
-            </WalletProvider>
+            <SEO>
+              <div className="overflow-hidden proportional-nums text-white">
+                <LandingRoutes />
+              </div>
+            </SEO>
           </ThemeProvider>
         </I18nProvider>
       </SWRConfig>

--- a/landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
+++ b/landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
@@ -1,10 +1,6 @@
 import { t } from "@lingui/macro";
 import { useHomePageContext } from "landing/pages/Home/contexts/HomePageContext";
 
-import { useStakingProcessedData } from "domain/stake/useStakingProcessedData";
-import { bigintToNumber } from "lib/numbers";
-import { ARBITRUM } from "sdk/configs/chainIds";
-
 import glvCoin from "img/bg_coin_glv.png";
 import gmCoin from "img/bg_coin_gm.png";
 import gmxCoin from "img/bg_coin_gmx.png";
@@ -15,24 +11,18 @@ import IcGmxPool from "img/ic_gmx_pool.svg?react";
 import { PoolCard } from "./PoolCard";
 import { useGoToPools } from "../hooks/useGoToPools";
 
-const DECIMALS = 4;
-
 export function PoolCards() {
   const onClickGmx = useGoToPools("GMX");
   const onClickGlv = useGoToPools("GLV");
   const onClickGm = useGoToPools("GM");
   const { poolsData } = useHomePageContext();
-  const processedData = useStakingProcessedData(ARBITRUM);
-  const isRewardsSuspended = processedData?.data?.isRewardsSuspended ?? false;
-  const gmxAprForGmxPercentage = processedData?.data?.gmxAprForGmx
-    ? bigintToNumber(processedData.data.gmxAprForGmx, DECIMALS)
-    : undefined;
+
   return (
     <>
       <PoolCard
         name="GMX"
-        apr={gmxAprForGmxPercentage}
-        isRewardsSuspended={isRewardsSuspended}
+        apr={undefined}
+        isRewardsSuspended
         description={t`Stake for rewards and governance rights`}
         iconComponent={IcGmxPool}
         coinImage={gmxCoin}

--- a/src/components/AppHeader/AppHeaderUser.tsx
+++ b/src/components/AppHeader/AppHeaderUser.tsx
@@ -6,7 +6,10 @@ import { sendUserAnalyticsConnectWalletClickEvent } from "lib/userAnalytics";
 import { useConnectModal } from "lib/wallets/useConnectModal";
 import useWallet from "lib/wallets/useWallet";
 
+import Button from "components/Button/Button";
 import { OneClickButton } from "components/OneClickButton/OneClickButton";
+
+import SpinnerIcon from "img/ic_spinner.svg?react";
 
 import { AddressDropdown } from "../AddressDropdown/AddressDropdown";
 import ConnectWalletButton from "../ConnectWalletButton/ConnectWalletButton";
@@ -20,40 +23,65 @@ type Props = {
 export function AppHeaderUser({ openSettings, menuToggle }: Props) {
   const { chainId: settlementChainId, srcChainId } = useChainId();
   const { active, account } = useWallet();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
 
   const visualChainId = srcChainId ?? settlementChainId;
 
-  if (!active || !account) {
+  if (active && account) {
     return (
       <div className="flex items-center gap-8">
-        {openConnectModal ? (
-          <>
-            <ConnectWalletButton
-              onClick={() => {
-                sendUserAnalyticsConnectWalletClickEvent("Header");
-                openConnectModal();
-              }}
-            >
-              <Trans>Connect wallet</Trans>
-            </ConnectWalletButton>
-            <OneClickButton openSettings={openSettings} />
-            <NetworkDropdown chainId={visualChainId} networkOptions={NETWORK_OPTIONS} />
-            {menuToggle ? menuToggle : null}
-          </>
-        ) : null}
+        <div data-qa="user-address">
+          <AddressDropdown account={account} />
+        </div>
+        <OneClickButton openSettings={openSettings} />
+        <NetworkDropdown chainId={visualChainId} networkOptions={NETWORK_OPTIONS} />
+        {menuToggle ? menuToggle : null}
+      </div>
+    );
+  }
+
+  if (isConnectModalLoading) {
+    return (
+      <div className="flex items-center gap-8">
+        <div data-qa="user-address">
+          <Button
+            variant="secondary"
+            size="controlled"
+            className="flex h-40 items-center gap-8 px-15 pr-12 max-md:h-32"
+            disabled
+            aria-live="polite"
+          >
+            <SpinnerIcon className="size-16 animate-spin" />
+            <span className="text-body-medium font-medium text-typography-primary">
+              <Trans>Loading...</Trans>
+            </span>
+          </Button>
+        </div>
+        <OneClickButton openSettings={openSettings} />
+        <NetworkDropdown chainId={visualChainId} networkOptions={NETWORK_OPTIONS} />
+        {menuToggle ? menuToggle : null}
       </div>
     );
   }
 
   return (
     <div className="flex items-center gap-8">
-      <div data-qa="user-address">
-        <AddressDropdown account={account} />
-      </div>
-      <OneClickButton openSettings={openSettings} />
-      <NetworkDropdown chainId={visualChainId} networkOptions={NETWORK_OPTIONS} />
-      {menuToggle ? menuToggle : null}
+      {openConnectModal ? (
+        <>
+          <ConnectWalletButton
+            disabled={isConnectModalLoading}
+            onClick={() => {
+              sendUserAnalyticsConnectWalletClickEvent("Header");
+              openConnectModal();
+            }}
+          >
+            {isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Connect wallet</Trans>}
+          </ConnectWalletButton>
+          <OneClickButton openSettings={openSettings} />
+          <NetworkDropdown chainId={visualChainId} networkOptions={NETWORK_OPTIONS} />
+          {menuToggle ? menuToggle : null}
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/components/ConnectWalletButton/ConnectWalletButton.tsx
+++ b/src/components/ConnectWalletButton/ConnectWalletButton.tsx
@@ -7,15 +7,17 @@ import WalletIcon from "img/ic_wallet.svg?react";
 type Props = {
   children: ReactNode;
   onClick?: () => void;
+  disabled?: boolean;
 };
 
-export default function ConnectWalletButton({ children, onClick }: Props) {
+export default function ConnectWalletButton({ children, disabled, onClick }: Props) {
   return (
     <Button
       variant="primary"
       size="controlled"
       data-qa="connect-wallet-button"
       className="flex h-40 items-center gap-6 max-md:h-32"
+      disabled={disabled}
       onClick={onClick}
     >
       <WalletIcon className="box-content size-20" />

--- a/src/components/Earn/Portfolio/AssetsList/AssetsList.tsx
+++ b/src/components/Earn/Portfolio/AssetsList/AssetsList.tsx
@@ -96,7 +96,7 @@ function AssetsList({
   const shouldUseFlex = (cardsCount < 3 && isEnoughSpaceFor2Columns) || (cardsCount < 4 && isEnoughSpaceFor3Columns);
 
   const { account } = useWallet();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
 
   const sortedAssets = useMemo(() => {
     return getSortedAssets({
@@ -165,8 +165,8 @@ function AssetsList({
             )}
           </span>
           {!account && openConnectModal && (
-            <ConnectWalletButton onClick={openConnectModal}>
-              <Trans>Connect wallet</Trans>
+            <ConnectWalletButton disabled={isConnectModalLoading} onClick={openConnectModal}>
+              {isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Connect wallet</Trans>}
             </ConnectWalletButton>
           )}
         </div>

--- a/src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
+++ b/src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -52,7 +52,7 @@ export function VestModal({ isVisible, setIsVisible, processedData, reservedAmou
   const { chainId } = useChainId();
   const { signer, account, active } = useWallet();
   const { setPendingTxns } = usePendingTxns();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const vestingData = useVestingData(account);
 
   const [selectedVault, setSelectedVault] = useState<VestVault>("gmx");
@@ -420,9 +420,9 @@ export function VestModal({ isVisible, setIsVisible, processedData, reservedAmou
       variant="primary-action"
       className="w-full"
       onClick={() => openConnectModal?.()}
-      disabled={!openConnectModal}
+      disabled={!openConnectModal || isConnectModalLoading}
     >
-      <Trans>Connect wallet</Trans>
+      {isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Connect wallet</Trans>}
     </Button>
   );
 

--- a/src/components/Earn/Portfolio/ClaimRewardsButton.tsx
+++ b/src/components/Earn/Portfolio/ClaimRewardsButton.tsx
@@ -26,7 +26,7 @@ type ClaimRewardsButtonProps = {
 
 export function ClaimRewardsButton({ processedData, mutateProcessedData, className }: ClaimRewardsButtonProps) {
   const { active, account, signer } = useWallet();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { chainId } = useChainId();
   const { setPendingTxns } = usePendingTxns();
 
@@ -81,10 +81,10 @@ export function ClaimRewardsButton({ processedData, mutateProcessedData, classNa
         variant="secondary"
         onClick={handleClick}
         className="max-lg:w-full"
-        disabled={!hasGmxRewards && !hasEsGmxRewards && !hasNativeRewards}
+        disabled={isConnectModalLoading || (!hasGmxRewards && !hasEsGmxRewards && !hasNativeRewards)}
       >
         <EarnIcon className="size-16" />
-        <Trans>Claim rewards</Trans>
+        {!active && isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Claim rewards</Trans>}
       </Button>
 
       <ClaimModal

--- a/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
@@ -120,7 +120,7 @@ export const useGmSwapSubmitState = ({
   const gasPaymentToken = useSelector(selectGasPaymentToken);
   const hasOutdatedUi = useHasOutdatedUi();
   const multipleWalletExtensionsChainError = useMultipleWalletExtensionsChainError();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { account } = useWallet();
 
   const {
@@ -381,6 +381,18 @@ export const useGmSwapSubmitState = ({
   const isAvalancheGmxAccountWarning = paySource === "gmxAccount" && chainId === AVALANCHE && isDeposit;
 
   return useMemo((): SubmitButtonState => {
+    if (!account && isConnectModalLoading) {
+      return {
+        text: (
+          <>
+            <Trans>Loading...</Trans>
+            <SpinnerIcon className="ml-4 animate-spin" />
+          </>
+        ),
+        disabled: true,
+      };
+    }
+
     if (!account) {
       return {
         text: t`Connect wallet`,
@@ -505,6 +517,7 @@ export const useGmSwapSubmitState = ({
     };
   }, [
     account,
+    isConnectModalLoading,
     isAvalancheGmxAccountWarning,
     multipleWalletExtensionsChainError,
     isAllowanceLoading,

--- a/src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
@@ -53,7 +53,7 @@ export function useShiftSubmitState({
   const hasOutdatedUi = useHasOutdatedUi();
   const multipleWalletExtensionsChainError = useMultipleWalletExtensionsChainError();
 
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
 
   const { isSubmitting, onSubmit } = useShiftTransactions({
     fromMarketToken: selectedToken,
@@ -97,6 +97,13 @@ export function useShiftSubmitState({
     }
 
     if (isAllowanceLoading) {
+      return {
+        text: t`Loading...`,
+        disabled: true,
+      };
+    }
+
+    if (!account && isConnectModalLoading) {
       return {
         text: t`Loading...`,
         disabled: true,
@@ -201,6 +208,7 @@ export function useShiftSubmitState({
     toMarketInfo,
     toToken,
     fees,
+    isConnectModalLoading,
     multipleWalletExtensionsChainError,
     isApproving,
     tokensToApprove,

--- a/src/components/PositionEditor/usePositionEditorButtonState.tsx
+++ b/src/components/PositionEditor/usePositionEditorButtonState.tsx
@@ -102,7 +102,7 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
   const tokensData = useTokensData();
   const { account, signer } = useWallet();
   const { provider } = useJsonRpcProvider(chainId);
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const routerAddress = getContract(chainId, "SyntheticsRouter");
   const { minCollateralUsd } = usePositionsConstants();
   const userReferralInfo = useUserReferralInfo();
@@ -493,6 +493,19 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
     tooltipContent: errorTooltipContent,
     bannerErrorName: validationResult.bannerErrorName,
   };
+
+  if (!account && isConnectModalLoading) {
+    return {
+      text: (
+        <>
+          <Trans>Loading...</Trans>
+          <SpinnerIcon className="ml-4 animate-spin" />
+        </>
+      ),
+      disabled: true,
+      ...commonParams,
+    };
+  }
 
   if (multipleWalletExtensionsChainError.buttonErrorMessage) {
     return {

--- a/src/components/PositionSeller/PositionSeller.tsx
+++ b/src/components/PositionSeller/PositionSeller.tsx
@@ -155,7 +155,7 @@ export function PositionSeller() {
   const { chainId, srcChainId } = useChainId();
   const { signer, account } = useWallet();
   const { provider } = useJsonRpcProvider(chainId);
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { minCollateralUsd, minPositionSizeUsd } = usePositionsConstants();
   const userReferralInfo = useUserReferralInfo();
   const hasOutdatedUi = useHasOutdatedUi();
@@ -913,6 +913,18 @@ export function PositionSeller() {
   );
 
   const buttonState = useMemo(() => {
+    if (!account && isConnectModalLoading) {
+      return {
+        text: (
+          <>
+            <Trans>Loading...</Trans>
+            <SpinnerIcon className="ml-4 animate-spin" />
+          </>
+        ),
+        disabled: true,
+      };
+    }
+
     if (!isAllowanceLoaded) {
       return {
         text: t`Loading...`,
@@ -986,12 +998,14 @@ export function PositionSeller() {
       disabled: Boolean(error) && !shouldDisableValidationForTesting,
     };
   }, [
+    account,
     chainId,
     decreaseAmounts?.isFullClose,
     error,
     errorDescription,
     isAllowanceLoaded,
     isApproving,
+    isConnectModalLoading,
     isExpressLoading,
     localizedTradeModeLabels,
     localizedTradeTypeLabels,

--- a/src/components/PositionShare/CreateReferralCode.tsx
+++ b/src/components/PositionShare/CreateReferralCode.tsx
@@ -69,7 +69,7 @@ export function CreateReferralCode({ onSuccess }: Props) {
 
 function CreateReferralCodeSettlement({ onSuccess }: Props) {
   const { signer } = useWallet();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { address: account, isConnected } = useAccount();
   const { chainId } = useChainId();
 
@@ -169,6 +169,13 @@ function CreateReferralCodeSettlement({ onSuccess }: Props) {
     onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
   } => {
     if (!isConnected) {
+      if (isConnectModalLoading) {
+        return {
+          text: t`Loading...`,
+          disabled: true,
+        };
+      }
+
       return {
         text: t`Connect wallet`,
         disabled: false,
@@ -195,7 +202,16 @@ function CreateReferralCodeSettlement({ onSuccess }: Props) {
       disabled: Boolean(error),
       onSubmit: handleSubmit,
     };
-  }, [isConnected, openConnectModal, isProcessing, referralCode, referralCodeCheckStatus, error, handleSubmit]);
+  }, [
+    isConnected,
+    isConnectModalLoading,
+    openConnectModal,
+    isProcessing,
+    referralCode,
+    referralCodeCheckStatus,
+    error,
+    handleSubmit,
+  ]);
 
   return (
     <CreateReferralCodeLayout
@@ -216,7 +232,7 @@ function CreateReferralCodeSettlement({ onSuccess }: Props) {
 function CreateReferralCodeMultichain({ onSuccess }: Props) {
   const { chainId, srcChainId } = useChainId();
   const { account, signer } = useWallet();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { isConnected } = useAccount();
   const [referralCode, setReferralCode] = useState("");
   const [error, setError] = useState<string | undefined>();
@@ -372,6 +388,13 @@ function CreateReferralCodeMultichain({ onSuccess }: Props) {
     onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
   } => {
     if (!isConnected) {
+      if (isConnectModalLoading) {
+        return {
+          text: t`Loading...`,
+          disabled: true,
+        };
+      }
+
       return {
         text: t`Connect wallet`,
         disabled: false,
@@ -435,6 +458,7 @@ function CreateReferralCodeMultichain({ onSuccess }: Props) {
     };
   }, [
     isConnected,
+    isConnectModalLoading,
     openConnectModal,
     hasOutdatedUi,
     isApproving,

--- a/src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
+++ b/src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
@@ -56,7 +56,7 @@ export function CreateAffiliateWizard({
   initialReferralCode: string | undefined;
   traderDiscountPercentage?: string | number;
 }) {
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { isConnected } = useAccount();
 
   const [wizardStep, setWizardStep] = useState(CreateAffiliateWizardStep.ConnectWallet);
@@ -93,8 +93,14 @@ export function CreateAffiliateWizard({
                 <AffiliatePromos />
               </div>
               <div className="flex flex-col items-center gap-16">
-                <Button variant="primary-action" className="w-full" type="submit" onClick={openConnectModal}>
-                  <Trans>Connect wallet</Trans>
+                <Button
+                  variant="primary-action"
+                  className="w-full"
+                  type="submit"
+                  disabled={isConnectModalLoading}
+                  onClick={openConnectModal}
+                >
+                  {isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Connect wallet</Trans>}
                 </Button>
                 <ExternalLink href="https://docs.gmx.io/docs/referrals" variant="icon" className="text-blue-300">
                   <Trans>Read more</Trans>

--- a/src/components/Referrals/traders/joinCode/JoinReferralWizard.tsx
+++ b/src/components/Referrals/traders/joinCode/JoinReferralWizard.tsx
@@ -54,7 +54,7 @@ function DiscountPromos() {
 }
 
 export function JoinReferralWizard({ onGoToTraderDashboard }: { onGoToTraderDashboard: () => void }) {
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { isConnected, address } = useAccount();
   const { chainId } = useChainId();
   const history = useHistory();
@@ -97,8 +97,14 @@ export function JoinReferralWizard({ onGoToTraderDashboard }: { onGoToTraderDash
                 <DiscountPromos />
               </div>
               <div className="flex flex-col items-center gap-16">
-                <Button variant="primary-action" className="w-full" type="submit" onClick={openConnectModal}>
-                  <Trans>Connect wallet</Trans>
+                <Button
+                  variant="primary-action"
+                  className="w-full"
+                  type="submit"
+                  disabled={isConnectModalLoading}
+                  onClick={openConnectModal}
+                >
+                  {isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Connect wallet</Trans>}
                 </Button>
                 <ExternalLink href={REFERRALS_DOCS_URL} variant="icon" className="text-blue-300">
                   <Trans>Read more</Trans>

--- a/src/components/TokenSelector/ConnectWalletModalContent.tsx
+++ b/src/components/TokenSelector/ConnectWalletModalContent.tsx
@@ -1,6 +1,8 @@
 import { t, Trans } from "@lingui/macro";
 import { memo } from "react";
 
+import { useConnectModal } from "lib/wallets/useConnectModal";
+
 import ConnectWalletButton from "components/ConnectWalletButton/ConnectWalletButton";
 
 export const ConnectWalletModalContent = memo(function ConnectWalletModalContent({
@@ -10,6 +12,8 @@ export const ConnectWalletModalContent = memo(function ConnectWalletModalContent
   openConnectModal: (() => void) | undefined;
   walletIconUrls: string[] | undefined;
 }) {
+  const { isConnectModalLoading } = useConnectModal();
+
   return (
     <div className="flex grow flex-col items-center justify-center gap-20 p-adaptive">
       {walletIconUrls?.length && (
@@ -36,8 +40,8 @@ export const ConnectWalletModalContent = memo(function ConnectWalletModalContent
           payment options
         </Trans>
       </div>
-      <ConnectWalletButton onClick={openConnectModal}>
-        <Trans>Connect wallet</Trans>
+      <ConnectWalletButton disabled={isConnectModalLoading} onClick={openConnectModal}>
+        {isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Connect wallet</Trans>}
       </ConnectWalletButton>
     </div>
   );

--- a/src/components/TradeBox/hooks/useTradeButtonState.tsx
+++ b/src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -157,7 +157,7 @@ export function useTradeboxButtonState({
   const { tokenChainDataArray } = useMultichainTokens();
 
   const { setPendingTxns } = usePendingTxns();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
 
   const {
     onSubmitWrapOrUnwrap,
@@ -492,6 +492,19 @@ export function useTradeboxButtonState({
       isExpressLoading,
     };
 
+    if (!account && isConnectModalLoading) {
+      return {
+        ...commonState,
+        text: (
+          <>
+            <Trans>Loading...</Trans>
+            <SpinnerIcon className="ml-4 animate-spin" />
+          </>
+        ),
+        disabled: true,
+      };
+    }
+
     if (!account && buttonErrorText) {
       return {
         ...commonState,
@@ -649,6 +662,7 @@ export function useTradeboxButtonState({
     isExpressLoading,
     isWaitingForExternalSwapQuote,
     account,
+    isConnectModalLoading,
     buttonErrorText,
     shouldShowDepositButton,
     stopLoss.error?.percentage,

--- a/src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+++ b/src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -97,7 +97,7 @@ function getNormalizedIncentive(
 
 export default function UserIncentiveDistribution() {
   const { account, active } = useWallet();
-  const { openConnectModal } = useConnectModal();
+  const { isConnectModalLoading, openConnectModal } = useConnectModal();
   const { chainId, srcChainId } = useChainId();
   const tokens = getTokens(chainId);
   const gmMarkets = useSelector(selectGmMarkets);
@@ -151,9 +151,9 @@ export default function UserIncentiveDistribution() {
                   />
                   {!active ? (
                     <div className="mt-15">
-                      <Button variant="primary" onClick={openConnectModal}>
+                      <Button variant="primary" disabled={isConnectModalLoading} onClick={openConnectModal}>
                         <WalletIcon className="size-16" />
-                        <Trans>Connect wallet</Trans>
+                        {isConnectModalLoading ? <Trans>Loading...</Trans> : <Trans>Connect wallet</Trans>}
                       </Button>
                     </div>
                   ) : null}

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,5 +1,5 @@
-import { useConnectOrCreateWallet } from "@privy-io/react-auth";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { useConnectOrCreateWallet, usePrivy } from "@privy-io/react-auth";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
 import {
@@ -14,11 +14,13 @@ import { switchNetwork } from "lib/wallets";
 type ConnectModalContextValue = {
   openConnectModal: (() => void) | undefined;
   connectModalOpen: boolean;
+  isConnectModalLoading: boolean;
 };
 
 const ConnectModalContext = createContext<ConnectModalContextValue>({
   openConnectModal: undefined,
   connectModalOpen: false,
+  isConnectModalLoading: false,
 });
 
 function shouldKeepAppSelectedSourceChain(settlementChainId: SettlementChainId) {
@@ -33,9 +35,12 @@ function shouldKeepAppSelectedSourceChain(settlementChainId: SettlementChainId) 
 export function ConnectModalProvider({ children }: { children: React.ReactNode }) {
   const [settlementChainId] = useGmxAccountSettlementChainId();
   const [connectModalOpen, setConnectModalOpen] = useState(false);
+  const [isConnectRequestPending, setIsConnectRequestPending] = useState(false);
+  const { ready: isPrivyReady } = usePrivy();
 
   const handleSuccess = useCallback(() => {
     setConnectModalOpen(false);
+    setIsConnectRequestPending(false);
 
     if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
       return;
@@ -46,17 +51,48 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
     });
   }, [settlementChainId]);
 
+  const handleError = useCallback(() => {
+    setConnectModalOpen(false);
+    setIsConnectRequestPending(false);
+  }, []);
+
   const { connectOrCreateWallet } = useConnectOrCreateWallet({
     onSuccess: handleSuccess,
-    onError: () => setConnectModalOpen(false),
+    onError: handleError,
   });
 
-  const openConnectModal = useCallback(() => {
+  const openPrivyConnectModal = useCallback(() => {
     setConnectModalOpen(true);
-    connectOrCreateWallet();
+    setIsConnectRequestPending(false);
+
+    try {
+      connectOrCreateWallet();
+    } catch (error) {
+      setConnectModalOpen(false);
+      throw error;
+    }
   }, [connectOrCreateWallet]);
 
-  const value = useMemo(() => ({ openConnectModal, connectModalOpen }), [openConnectModal, connectModalOpen]);
+  const openConnectModal = useCallback(() => {
+    if (!isPrivyReady) {
+      setConnectModalOpen(false);
+      setIsConnectRequestPending(true);
+      return;
+    }
+
+    openPrivyConnectModal();
+  }, [isPrivyReady, openPrivyConnectModal]);
+
+  useEffect(() => {
+    if (isPrivyReady && isConnectRequestPending) {
+      openPrivyConnectModal();
+    }
+  }, [isPrivyReady, isConnectRequestPending, openPrivyConnectModal]);
+
+  const value = useMemo(
+    () => ({ openConnectModal, connectModalOpen, isConnectModalLoading: isConnectRequestPending }),
+    [openConnectModal, connectModalOpen, isConnectRequestPending]
+  );
 
   return <ConnectModalContext.Provider value={value}>{children}</ConnectModalContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- Add disabled/loading states to wallet connect entry points while the Privy connect modal is waiting on readiness.
- Remove `WalletProvider` from the landing app.
- Remove the landing GMX pool card staking hook dependency that pulled wallet state into the landing page.

Linear: [FEDEV-3920](https://linear.app/gmx-io/issue/FEDEV-3920/support-privy-lazy-loading)