### PR TITLE
(test-only) Disable external debugger sources

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,23 +34,6 @@
     <meta name="msapplication-TileImage" content="/favicon/ms-icon-144x144.png" />
     <meta name="theme-color" content="#ffffff" />
     <title>GMX | Decentralized Perpetual Exchange</title>
-    <!-- Addressable Pixel base code -->
-    <script>
-      !(function (w, d) {
-        w.__adrsbl = {
-          queue: [],
-          run: function () {
-            this.queue.push(arguments);
-          },
-        };
-        var s = d.createElement("script");
-        s.async = true;
-        s.src = "https://tag.adrsbl.io/p.js?tid=94d6c6f370f54f799afb611ec6ef2461";
-        var b = d.getElementsByTagName("script")[0];
-        b.parentNode.insertBefore(s, b);
-      })(window, document);
-    </script>
-    <!-- End Addressable Pixel base code -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/lib/addressablePixel.ts
+++ b/src/lib/addressablePixel.ts
@@ -12,7 +12,7 @@ import {
 
 declare global {
   interface Window {
-    __adrsbl: {
+    __adrsbl?: {
       queue: any[];
       run: (eventName: string, isConversion: boolean, properties?: any[]) => void;
     };
@@ -62,7 +62,7 @@ export function sendAddressablePixelEvent(event: AddressablePixelDepositSuccessE
   ];
 
   try {
-    window.__adrsbl.run(event.eventName, isConversion, properties);
+    window.__adrsbl?.run(event.eventName, isConversion, properties);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error("Error sending Addressable Pixel event", error);

--- a/src/lib/rpc/RpcTracker.ts
+++ b/src/lib/rpc/RpcTracker.ts
@@ -35,6 +35,7 @@ export type RpcTrackerParams = RpcTrackerConfig & {
 export type RpcCheckResult = {
   responseTime: number;
   blockNumber: number;
+  skipped?: boolean;
 };
 
 export type RpcStats = EndpointStats<RpcCheckResult>;
@@ -104,12 +105,10 @@ export class RpcTracker {
     return this.providersMap[endpoint];
   }
 
-  private checkForSkip(endpoint: string): void {
+  private getShouldSkip(endpoint: string): boolean {
     const rpcConfig = this.getRpcConfig(endpoint);
 
-    if (!rpcConfig?.isPublic && (!this.getIsLargeAccount() || rpcConfig?.purpose !== "largeAccount")) {
-      throw new Error("Skip private provider");
-    }
+    return !rpcConfig?.isPublic && (!this.getIsLargeAccount() || rpcConfig?.purpose !== "largeAccount");
   }
 
   public pickCurrentRpcUrls() {
@@ -137,6 +136,14 @@ export class RpcTracker {
   }
 
   checkRpc = async (endpoint: string, signal: AbortSignal): Promise<RpcCheckResult> => {
+    if (this.getShouldSkip(endpoint)) {
+      return {
+        responseTime: 0,
+        blockNumber: 0,
+        skipped: true,
+      };
+    }
+
     const chainId = this.params.chainId;
     const isContractChain = isContractsChain(chainId, isDevelopment());
 
@@ -148,8 +155,6 @@ export class RpcTracker {
   };
 
   private checkRpcForContractChain = async (endpoint: string, signal: AbortSignal): Promise<RpcCheckResult> => {
-    this.checkForSkip(endpoint);
-
     const chainId = this.params.chainId as ContractsChainId;
     const startTime = Date.now();
 
@@ -220,8 +225,6 @@ export class RpcTracker {
   };
 
   private checkRpcForSourceChain = async (endpoint: string, signal: AbortSignal): Promise<RpcCheckResult> => {
-    this.checkForSkip(endpoint);
-
     const startTime = Date.now();
 
     const { blockNumber } = await fetchBlockNumber({
@@ -312,6 +315,7 @@ export class RpcTracker {
 
       const isSuccess = lastCheckResult?.success;
       const rpcBlockNumber = lastCheckResult?.stats?.blockNumber;
+      const isSkipped = lastCheckResult?.stats?.skipped;
 
       const isFromFuture =
         bestValidBlock && rpcBlockNumber && rpcBlockNumber - bestValidBlock > this.params.blockFromFutureThreshold;
@@ -319,7 +323,7 @@ export class RpcTracker {
       const isLagging =
         bestValidBlock && rpcBlockNumber && bestValidBlock - rpcBlockNumber > this.params.blockLaggingThreshold;
 
-      return isSuccess && !isFromFuture && !isLagging;
+      return isSuccess && !isSkipped && !isFromFuture && !isLagging;
     });
 
     if (validStats.length === 0) {

--- a/src/lib/rpc/__tests__/RpcTracker.probeProvider.spec.ts
+++ b/src/lib/rpc/__tests__/RpcTracker.probeProvider.spec.ts
@@ -164,9 +164,14 @@ describe("RpcTracker - checkRpc", () => {
       const privateProviders = rpcConfigModule.getRpcProviders(SOURCE_SEPOLIA, "fallback").filter((p) => !p?.isPublic);
       const privateProvider = privateProviders[0];
 
-      await expect(tracker.checkRpc(privateProvider!.url, new AbortController().signal)).rejects.toThrow(
-        "Skip private provider"
-      );
+      const result = await tracker.checkRpc(privateProvider!.url, new AbortController().signal);
+
+      expect(result).toEqual({
+        responseTime: 0,
+        blockNumber: 0,
+        skipped: true,
+      });
+      expect(fetchRpcModule.fetchBlockNumber).not.toHaveBeenCalled();
     });
 
     it("should allow private provider for large account on source chain", async () => {
@@ -319,9 +324,14 @@ describe("RpcTracker - checkRpc", () => {
 
       const tracker = new RpcTracker(params);
 
-      await expect(tracker.checkRpc(mockPrivateProvider.url, new AbortController().signal)).rejects.toThrow(
-        "Skip private provider"
-      );
+      const result = await tracker.checkRpc(mockPrivateProvider.url, new AbortController().signal);
+
+      expect(result).toEqual({
+        responseTime: 0,
+        blockNumber: 0,
+        skipped: true,
+      });
+      expect(fetchRpcModule.fetchEthCall).not.toHaveBeenCalled();
     });
 
     it("should allow private provider for large account", async () => {

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -44,6 +44,8 @@ export default function WalletProvider({ children }: { children: React.ReactNode
       globalDisablePasskeys: true,
       defaultChain,
       supportedChains: [...supportedChains],
+      captchaEnabled: false,
+      headless: true,
       externalWallets: {
         signatureRequestTimeouts: PRIVY_SIGNATURE_REQUEST_TIMEOUTS,
       },


### PR DESCRIPTION
## Summary

This is a test-only PR to verify the DevTools pause behavior with the suspected external debugger sources disabled.

- Removes the Addressable Pixel bootstrap script from `index.html`.
- Makes `sendAddressablePixelEvent` a no-op when `window.__adrsbl` is not present.
- Avoids throwing `Error("Skip private provider")` while probing RPC endpoints; skipped private providers now return a `skipped` probe result and are excluded from valid RPC stats.
- Disables Privy's initial CAPTCHA / embedded-wallet preload path with `captchaEnabled: false` and `headless: true`, which should prevent the initial Cloudflare Turnstile worker from loading on page open.

## Root Cause

The first local DevTools pause was coming from the external `https://tag.adrsbl.io/p.js?...` script, which probes wallet globals and throws/catches ReferenceErrors during page load.

After removing Addressable, another pause remained when DevTools had pause-on-uncaught-exceptions enabled: the RPC tracker intentionally threw `Error("Skip private provider")` to avoid probing private RPCs for non-large accounts.

After the deployed instance still paused, the screenshot showed a real `debugger` statement in a dedicated worker, with the Sources tree including `challenges.cloudflare.com`, `normal?lang=auto`, and `embedded-wallets`. That points to Cloudflare Turnstile loaded through Privy, not to our bundled application code.

## Validation

- `yarn tscheck`
- `NODE_OPTIONS='--max-old-space-size=8192' yarn build-app`
- `yarn vitest run src/lib/rpc/__tests__/RpcTracker.probeProvider.spec.ts src/lib/rpc/__tests__/RpcTracker.selectionLogic.spec.ts`
- Local Playwright request smoke test on `http://localhost:3011/`: 5450 requests observed after load + reload, 0 matching `adrsbl` or the Addressable TID
- Production preview request smoke test on `http://127.0.0.1:4174/`: 468 requests observed after load + reload, 0 matching `challenges.cloudflare.com`, `turnstile`, or `adrsbl`
- Local CDP pause smoke test after the RPC skip fix:
  - no exception pause mode: 0 pauses
  - uncaught exception pause mode: 0 pauses
  - all exceptions pause mode: remaining pauses are caught dependency probes from `core-js`/React internals, with 0 `Skip private provider` pauses
- Pre-push hooks passed after the latest push, including SDK Vitest, app Vitest, build, and Playwright component tests

## Notes

Draft PR for deployed instance verification only. The Privy CAPTCHA / headless change is not intended as a production fix without checking wallet login and CAPTCHA-backed flows.
