### PR TITLE
[codex] Fix Rabby login wallet selection

### DIFF
--- a/src/lib/wallets/WalletProvider.spec.ts
+++ b/src/lib/wallets/WalletProvider.spec.ts
@@ -1,0 +1,21 @@
+import type { ConnectedWallet, User } from "@privy-io/react-auth";
+import { describe, expect, it } from "vitest";
+
+import { getActiveWalletForWagmi } from "./WalletProvider";
+
+function mockWallet(address: string, connectedAt: number, linked: boolean) {
+  return { address, connectedAt, linked } as ConnectedWallet;
+}
+
+describe("getActiveWalletForWagmi", () => {
+  it("keeps Privy's most-recently connected wallet active", () => {
+    const latestWallet = mockWallet("0x2", 200, false);
+    const linkedWallet = mockWallet("0x1", 100, true);
+
+    expect(getActiveWalletForWagmi({ wallets: [latestWallet, linkedWallet], user: {} as User })).toBe(latestWallet);
+  });
+
+  it("does not select a wallet when Privy has no connected wallets", () => {
+    expect(getActiveWalletForWagmi({ wallets: [], user: {} as User })).toBeUndefined();
+  });
+});

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -23,8 +23,8 @@ const supportedChains = getSupportedChains();
 const defaultChain = supportedChains[0];
 const gmxLogoElement = <img src={gmxLogo} alt="GMX" width={100} />;
 
-function getActiveWalletForWagmi({ wallets, user }: { wallets: ConnectedWallet[]; user: User | null }) {
-  return user ? wallets.find((wallet) => wallet.linked) ?? wallets[0] : wallets[0];
+export function getActiveWalletForWagmi({ wallets }: { wallets: ConnectedWallet[]; user: User | null }) {
+  return wallets[0];
 }
 
 export default function WalletProvider({ children }: { children: React.ReactNode }) {

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useConnectOrCreateWallet } from "@privy-io/react-auth";
+import { useConnectOrCreateWallet, useLogin } from "@privy-io/react-auth";
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -46,9 +46,21 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
     });
   }, [settlementChainId]);
 
+  const handleError = useCallback(() => setConnectModalOpen(false), []);
+  const handleLoginComplete = useCallback(() => {
+    if (connectModalOpen) {
+      handleSuccess();
+    }
+  }, [connectModalOpen, handleSuccess]);
+
+  useLogin({
+    onComplete: handleLoginComplete,
+    onError: handleError,
+  });
+
   const { connectOrCreateWallet } = useConnectOrCreateWallet({
     onSuccess: handleSuccess,
-    onError: () => setConnectModalOpen(false),
+    onError: handleError,
   });
 
   const openConnectModal = useCallback(() => {

--- a/src/lib/wallets/walletConfig.spec.ts
+++ b/src/lib/wallets/walletConfig.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { ARBITRUM, DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
 
-import { getSupportedChains } from "./walletConfig";
+import { getSupportedChains, PRIVY_WALLET_LIST } from "./walletConfig";
 
 describe("getSupportedChains", () => {
   it("uses Arbitrum as the default settlement chain", () => {
@@ -19,5 +19,10 @@ describe("getSupportedChains", () => {
     const chainIds = getSupportedChains().map((chain) => chain.id);
 
     expect(new Set(chainIds).size).toBe(chainIds.length);
+  });
+
+  it("uses detected wallets for Rabby instead of the deprecated explicit entry", () => {
+    expect(PRIVY_WALLET_LIST).toContain("detected_ethereum_wallets");
+    expect(PRIVY_WALLET_LIST).not.toContain("rabby_wallet");
   });
 });

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -27,7 +27,6 @@ export { PRIVY_APP_ID };
 export const PRIVY_WALLET_LIST = [
   "detected_ethereum_wallets",
   "metamask",
-  "rabby_wallet",
   "wallet_connect_qr",
   "coinbase_wallet",
   "safe",


### PR DESCRIPTION
## Summary

Fixes two Rabby-related wallet issues in the Privy/Wagmi integration:

- Handles email/social login completion from the connect modal by listening to Privy's login callbacks, so those flows close the modal state and run the same network handling as wallet connect.
- Keeps Wagmi's active wallet aligned with Privy's most-recently connected wallet ordering instead of preferring any linked wallet.
- Removes the deprecated explicit `rabby_wallet` wallet-list entry so Rabby is surfaced through detected Ethereum wallets.

## Root Cause

The active wallet selector preferred `wallet.linked` when a Privy user existed, which could select a linked wallet that was not the last active/connected wallet. Separately, the connect modal only registered `connectOrCreateWallet` success/error callbacks, while email and social authentication complete through Privy's login events.

## Validation

- `yarn vitest run src/lib/wallets`
- `yarn tsc -p tsconfig.json --noEmit --incremental false`
- `yarn eslint src/lib/wallets/WalletProvider.tsx src/lib/wallets/WalletProvider.spec.ts src/lib/wallets/useConnectModal.tsx src/lib/wallets/walletConfig.ts src/lib/wallets/walletConfig.spec.ts --max-warnings=0`
- Pre-push hook passed, including SDK tests/build, app tests, and component tests.
