### PR TITLE
FEDEV-3928 Fix Privy multi-wallet active selection

### DIFF
--- a/playwright/mocks/privyReactAuth.tsx
+++ b/playwright/mocks/privyReactAuth.tsx
@@ -63,6 +63,12 @@ export function usePrivy() {
   };
 }
 
+export function useModalStatus() {
+  return {
+    isOpen: false,
+  };
+}
+
 export function useWallets() {
   return {
     wallets: [],

--- a/playwright/mocks/privyReactAuth.tsx
+++ b/playwright/mocks/privyReactAuth.tsx
@@ -58,6 +58,7 @@ export function useLogin({ onComplete }: { onComplete?: () => void; onError?: ()
 
 export function usePrivy() {
   return {
+    authenticated: false,
     user: null,
     logout: () => undefined,
   };

--- a/playwright/mocks/privyReactAuth.tsx
+++ b/playwright/mocks/privyReactAuth.tsx
@@ -1,21 +1,49 @@
 import type { ReactNode } from "react";
 
+const mockEthereumWallet = {
+  type: "ethereum",
+  address: "0x0000000000000000000000000000000000000001",
+  chainId: "eip155:42161",
+  walletClientType: "metamask",
+  connectorType: "injected",
+  imported: false,
+  meta: {
+    id: "io.metamask",
+    name: "MetaMask",
+  },
+  isConnected: () => Promise.resolve(true),
+  disconnect: () => undefined,
+  switchChain: () => Promise.resolve(),
+  getEthereumProvider: () => Promise.resolve({}),
+  sign: () => Promise.resolve("0x"),
+};
+
 export function PrivyProvider({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
-export function useConnectWallet({ onSuccess }: { onSuccess?: () => void; onError?: () => void } = {}) {
+export function useConnectWallet({
+  onSuccess,
+}: {
+  onSuccess?: (params: { wallet: typeof mockEthereumWallet }) => void;
+  onError?: () => void;
+} = {}) {
   return {
     connectWallet: () => {
-      onSuccess?.();
+      onSuccess?.({ wallet: mockEthereumWallet });
     },
   };
 }
 
-export function useConnectOrCreateWallet({ onSuccess }: { onSuccess?: () => void; onError?: () => void } = {}) {
+export function useConnectOrCreateWallet({
+  onSuccess,
+}: {
+  onSuccess?: (params: { wallet: typeof mockEthereumWallet }) => void;
+  onError?: () => void;
+} = {}) {
   return {
     connectOrCreateWallet: () => {
-      onSuccess?.();
+      onSuccess?.({ wallet: mockEthereumWallet });
     },
   };
 }

--- a/playwright/mocks/privyWagmi.tsx
+++ b/playwright/mocks/privyWagmi.tsx
@@ -21,3 +21,9 @@ export function WagmiProvider({
     </BaseWagmiProvider>
   );
 }
+
+export function useSetActiveWallet() {
+  return {
+    setActiveWallet: () => Promise.resolve(),
+  };
+}

--- a/playwright/mocks/privyWagmi.tsx
+++ b/playwright/mocks/privyWagmi.tsx
@@ -10,15 +10,11 @@ export function WagmiProvider({
   children,
   config,
   initialState,
-  setActiveWalletForWagmi,
 }: {
   children: ReactNode;
   config: ReturnType<typeof createWagmiConfig>;
   initialState?: State;
-  setActiveWalletForWagmi?: unknown;
 }) {
-  void setActiveWalletForWagmi;
-
   return (
     <BaseWagmiProvider config={config} initialState={initialState}>
       {children}

--- a/playwright/mocks/privyWagmi.tsx
+++ b/playwright/mocks/privyWagmi.tsx
@@ -10,11 +10,15 @@ export function WagmiProvider({
   children,
   config,
   initialState,
+  setActiveWalletForWagmi,
 }: {
   children: ReactNode;
   config: ReturnType<typeof createWagmiConfig>;
   initialState?: State;
+  setActiveWalletForWagmi?: unknown;
 }) {
+  void setActiveWalletForWagmi;
+
   return (
     <BaseWagmiProvider config={config} initialState={initialState}>
       {children}

--- a/src/domain/multichain/__tests__/useDisconnectAndClose.spec.tsx
+++ b/src/domain/multichain/__tests__/useDisconnectAndClose.spec.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   setIsSettingsVisible: vi.fn(),
   setIsVisible: vi.fn(),
   wallets: [] as { disconnect: ReturnType<typeof vi.fn> }[],
+  disconnectPrivyWalletsFromWagmi: vi.fn(),
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
@@ -45,6 +46,10 @@ vi.mock("lib/userAnalytics", () => ({
   },
 }));
 
+vi.mock("lib/wallets/privyWagmi", () => ({
+  disconnectPrivyWalletsFromWagmi: mocks.disconnectPrivyWalletsFromWagmi,
+}));
+
 function setup() {
   let handleDisconnect!: ReturnType<typeof useDisconnectAndClose>;
 
@@ -62,6 +67,7 @@ describe("useDisconnectAndClose", () => {
   beforeEach(() => {
     mocks.disconnectAsync.mockResolvedValue(undefined);
     mocks.logout.mockResolvedValue(undefined);
+    mocks.disconnectPrivyWalletsFromWagmi.mockResolvedValue(undefined);
     mocks.wallets = [{ disconnect: vi.fn() }, { disconnect: vi.fn() }];
 
     localStorage.setItem(SHOULD_EAGER_CONNECT_LOCALSTORAGE_KEY, "true");
@@ -82,6 +88,8 @@ describe("useDisconnectAndClose", () => {
     });
 
     expect(mocks.disconnectAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledTimes(2);
+    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledWith(mocks.wallets);
     expect(mocks.wallets[0].disconnect).toHaveBeenCalledTimes(1);
     expect(mocks.wallets[1].disconnect).toHaveBeenCalledTimes(1);
     expect(mocks.logout).toHaveBeenCalledTimes(1);

--- a/src/domain/multichain/useDisconnectAndClose.tsx
+++ b/src/domain/multichain/useDisconnectAndClose.tsx
@@ -28,6 +28,8 @@ export function useDisconnectAndClose() {
     localStorage.removeItem(CURRENT_PROVIDER_LOCALSTORAGE_KEY);
 
     try {
+      // Mark Privy-backed wagmi connectors disconnected before and after provider disconnects:
+      // injected wallets can mutate wagmi storage while their disconnect handlers run.
       await disconnectPrivyWalletsFromWagmi(wallets);
 
       await Promise.allSettled([

--- a/src/domain/multichain/useDisconnectAndClose.tsx
+++ b/src/domain/multichain/useDisconnectAndClose.tsx
@@ -7,6 +7,7 @@ import { useGmxAccountModalOpen } from "context/GmxAccountContext/hooks";
 import { useSettings } from "context/SettingsContext/SettingsContextProvider";
 import { userAnalytics } from "lib/userAnalytics";
 import { DisconnectWalletEvent } from "lib/userAnalytics/types";
+import { disconnectPrivyWalletsFromWagmi } from "lib/wallets/privyWagmi";
 
 export function useDisconnectAndClose() {
   const { setIsSettingsVisible } = useSettings();
@@ -27,10 +28,13 @@ export function useDisconnectAndClose() {
     localStorage.removeItem(CURRENT_PROVIDER_LOCALSTORAGE_KEY);
 
     try {
+      await disconnectPrivyWalletsFromWagmi(wallets);
+
       await Promise.allSettled([
         disconnectAsync(),
         ...wallets.map((wallet) => Promise.resolve().then(() => wallet.disconnect())),
       ]);
+      await disconnectPrivyWalletsFromWagmi(wallets);
       await Promise.allSettled([logout()]);
     } finally {
       setIsVisible(false);

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -13,7 +13,6 @@ import {
   getSupportedChains,
   PRIVY_APP_ID,
   PRIVY_LOGIN_METHODS,
-  PRIVY_SIGNATURE_REQUEST_TIMEOUTS,
   PRIVY_WALLET_LIST,
 } from "./walletConfig";
 
@@ -40,9 +39,6 @@ export default function WalletProvider({ children }: { children: React.ReactNode
       globalDisablePasskeys: true,
       defaultChain,
       supportedChains: [...supportedChains],
-      externalWallets: {
-        signatureRequestTimeouts: PRIVY_SIGNATURE_REQUEST_TIMEOUTS,
-      },
       embeddedWallets: {
         ethereum: {
           createOnLogin: "users-without-wallets" as const,

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -1,4 +1,4 @@
-import { PrivyProvider, type ConnectedWallet, type User } from "@privy-io/react-auth";
+import { PrivyProvider } from "@privy-io/react-auth";
 import { WagmiProvider } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useMemo } from "react";
@@ -22,10 +22,6 @@ const queryClient = new QueryClient();
 const supportedChains = getSupportedChains();
 const defaultChain = supportedChains[0];
 const gmxLogoElement = <img src={gmxLogo} alt="GMX" width={100} />;
-
-function getActiveWalletForWagmi({ wallets, user }: { wallets: ConnectedWallet[]; user: User | null }) {
-  return user ? wallets.find((wallet) => wallet.linked) ?? wallets[0] : wallets[0];
-}
 
 export default function WalletProvider({ children }: { children: React.ReactNode }) {
   const { theme } = useTheme();
@@ -59,9 +55,7 @@ export default function WalletProvider({ children }: { children: React.ReactNode
   return (
     <PrivyProvider appId={PRIVY_APP_ID} config={privyConfig}>
       <QueryClientProvider client={queryClient}>
-        <WagmiProvider config={getWagmiConfig()} setActiveWalletForWagmi={getActiveWalletForWagmi}>
-          {children}
-        </WagmiProvider>
+        <WagmiProvider config={getWagmiConfig()}>{children}</WagmiProvider>
       </QueryClientProvider>
     </PrivyProvider>
   );

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -13,6 +13,7 @@ import {
   getSupportedChains,
   PRIVY_APP_ID,
   PRIVY_LOGIN_METHODS,
+  PRIVY_SIGNATURE_REQUEST_TIMEOUTS,
   PRIVY_WALLET_LIST,
 } from "./walletConfig";
 
@@ -39,6 +40,9 @@ export default function WalletProvider({ children }: { children: React.ReactNode
       globalDisablePasskeys: true,
       defaultChain,
       supportedChains: [...supportedChains],
+      externalWallets: {
+        signatureRequestTimeouts: PRIVY_SIGNATURE_REQUEST_TIMEOUTS,
+      },
       embeddedWallets: {
         ethereum: {
           createOnLogin: "users-without-wallets" as const,

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -8,7 +8,6 @@ import { useTheme } from "context/ThemeContext/ThemeContext";
 
 import gmxLogo from "img/logo-icon.svg";
 
-import { getActiveWalletForWagmi } from "./privyWagmi";
 import {
   getWagmiConfig,
   getSupportedChains,
@@ -56,9 +55,7 @@ export default function WalletProvider({ children }: { children: React.ReactNode
   return (
     <PrivyProvider appId={PRIVY_APP_ID} config={privyConfig}>
       <QueryClientProvider client={queryClient}>
-        <WagmiProvider config={getWagmiConfig()} setActiveWalletForWagmi={getActiveWalletForWagmi}>
-          {children}
-        </WagmiProvider>
+        <WagmiProvider config={getWagmiConfig()}>{children}</WagmiProvider>
       </QueryClientProvider>
     </PrivyProvider>
   );

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -8,6 +8,7 @@ import { useTheme } from "context/ThemeContext/ThemeContext";
 
 import gmxLogo from "img/logo-icon.svg";
 
+import { getActiveWalletForWagmi } from "./privyWagmi";
 import {
   getWagmiConfig,
   getSupportedChains,
@@ -55,7 +56,9 @@ export default function WalletProvider({ children }: { children: React.ReactNode
   return (
     <PrivyProvider appId={PRIVY_APP_ID} config={privyConfig}>
       <QueryClientProvider client={queryClient}>
-        <WagmiProvider config={getWagmiConfig()}>{children}</WagmiProvider>
+        <WagmiProvider config={getWagmiConfig()} setActiveWalletForWagmi={getActiveWalletForWagmi}>
+          {children}
+        </WagmiProvider>
       </QueryClientProvider>
     </PrivyProvider>
   );

--- a/src/lib/wallets/privyWagmi.spec.ts
+++ b/src/lib/wallets/privyWagmi.spec.ts
@@ -1,20 +1,35 @@
 import type { ConnectedWallet } from "@privy-io/react-auth";
-import { describe, expect, it, vi } from "vitest";
+import type { User } from "@privy-io/react-auth";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "wagmi";
 
-import { disconnectPrivyWalletsFromWagmi, getPrivyWagmiConnectorId } from "./privyWagmi";
+import {
+  allowPrivyWalletForWagmi,
+  disconnectPrivyWalletsFromWagmi,
+  getActiveWalletForWagmi,
+  getPrivyWagmiConnectorId,
+} from "./privyWagmi";
 
 function createWallet({
   address = "0x0000000000000000000000000000000000000001",
+  connectedAt = 1,
+  linked = true,
   metaId = "io.metamask",
+  type = "ethereum",
   walletClientType = "metamask",
 }: {
   address?: string;
+  connectedAt?: number;
+  linked?: boolean;
   metaId?: string;
+  type?: string;
   walletClientType?: string;
 }) {
   return {
     address,
+    connectedAt,
+    linked,
+    type,
     walletClientType,
     meta: {
       id: metaId,
@@ -24,6 +39,11 @@ function createWallet({
 }
 
 describe("privyWagmi", () => {
+  afterEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
   it("uses Privy's embedded wallet connector id format", () => {
     const wallet = createWallet({
       address: "0x0000000000000000000000000000000000000002",
@@ -73,5 +93,61 @@ describe("privyWagmi", () => {
       true
     );
     expect(setItem).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an app-side disconnected marker that the active wallet selector respects", async () => {
+    const config = {
+      storage: {
+        key: "wagmi",
+        removeItem: vi.fn(),
+        setItem: vi.fn(),
+      },
+    } as unknown as Config;
+
+    const phantom = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
+    const metamask = createWallet({ connectedAt: 2, metaId: "io.metamask", walletClientType: "metamask" });
+
+    await disconnectPrivyWalletsFromWagmi([phantom], config);
+
+    expect(getActiveWalletForWagmi({ wallets: [phantom, metamask], user: {} as User }, config)).toBe(metamask);
+  });
+
+  it("allows a wallet again after an explicit Privy success", async () => {
+    const removeItem = vi.fn();
+    const setItem = vi.fn();
+    const config = {
+      storage: {
+        key: "wagmi",
+        removeItem,
+        setItem,
+      },
+    } as unknown as Config;
+    const phantom = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
+
+    await disconnectPrivyWalletsFromWagmi([phantom], config);
+    await allowPrivyWalletForWagmi(phantom, config);
+
+    expect(getActiveWalletForWagmi({ wallets: [phantom], user: {} as User }, config)).toBe(phantom);
+    expect(removeItem).toHaveBeenCalledWith("io.phantom.disconnected");
+    expect(setItem).toHaveBeenCalledWith("recentConnectorId", "io.phantom");
+  });
+
+  it("does not select any Privy wallet before the user is authenticated", () => {
+    const wallet = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
+
+    expect(getActiveWalletForWagmi({ wallets: [wallet], user: null })).toBeUndefined();
+  });
+
+  it("does not select wallets marked disconnected in wagmi storage", () => {
+    const wallet = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
+    const config = {
+      storage: {
+        key: "test-wagmi",
+      },
+    } as unknown as Config;
+
+    localStorage.setItem("test-wagmi.io.phantom.disconnected", "true");
+
+    expect(getActiveWalletForWagmi({ wallets: [wallet], user: {} as User }, config)).toBeUndefined();
   });
 });

--- a/src/lib/wallets/privyWagmi.spec.ts
+++ b/src/lib/wallets/privyWagmi.spec.ts
@@ -1,35 +1,20 @@
 import type { ConnectedWallet } from "@privy-io/react-auth";
-import type { User } from "@privy-io/react-auth";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Config } from "wagmi";
 
-import {
-  allowPrivyWalletForWagmi,
-  disconnectPrivyWalletsFromWagmi,
-  getActiveWalletForWagmi,
-  getPrivyWagmiConnectorId,
-} from "./privyWagmi";
+import { disconnectPrivyWalletsFromWagmi, getPrivyWagmiConnectorId } from "./privyWagmi";
 
 function createWallet({
   address = "0x0000000000000000000000000000000000000001",
-  connectedAt = 1,
-  linked = true,
   metaId = "io.metamask",
-  type = "ethereum",
   walletClientType = "metamask",
 }: {
   address?: string;
-  connectedAt?: number;
-  linked?: boolean;
   metaId?: string;
-  type?: string;
   walletClientType?: string;
 }) {
   return {
     address,
-    connectedAt,
-    linked,
-    type,
     walletClientType,
     meta: {
       id: metaId,
@@ -39,11 +24,6 @@ function createWallet({
 }
 
 describe("privyWagmi", () => {
-  afterEach(() => {
-    localStorage.clear();
-    vi.clearAllMocks();
-  });
-
   it("uses Privy's embedded wallet connector id format", () => {
     const wallet = createWallet({
       address: "0x0000000000000000000000000000000000000002",
@@ -93,61 +73,5 @@ describe("privyWagmi", () => {
       true
     );
     expect(setItem).toHaveBeenCalledTimes(2);
-  });
-
-  it("keeps an app-side disconnected marker that the active wallet selector respects", async () => {
-    const config = {
-      storage: {
-        key: "wagmi",
-        removeItem: vi.fn(),
-        setItem: vi.fn(),
-      },
-    } as unknown as Config;
-
-    const phantom = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
-    const metamask = createWallet({ connectedAt: 2, metaId: "io.metamask", walletClientType: "metamask" });
-
-    await disconnectPrivyWalletsFromWagmi([phantom], config);
-
-    expect(getActiveWalletForWagmi({ wallets: [phantom, metamask], user: {} as User }, config)).toBe(metamask);
-  });
-
-  it("allows a wallet again after an explicit Privy success", async () => {
-    const removeItem = vi.fn();
-    const setItem = vi.fn();
-    const config = {
-      storage: {
-        key: "wagmi",
-        removeItem,
-        setItem,
-      },
-    } as unknown as Config;
-    const phantom = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
-
-    await disconnectPrivyWalletsFromWagmi([phantom], config);
-    await allowPrivyWalletForWagmi(phantom, config);
-
-    expect(getActiveWalletForWagmi({ wallets: [phantom], user: {} as User }, config)).toBe(phantom);
-    expect(removeItem).toHaveBeenCalledWith("io.phantom.disconnected");
-    expect(setItem).toHaveBeenCalledWith("recentConnectorId", "io.phantom");
-  });
-
-  it("does not select any Privy wallet before the user is authenticated", () => {
-    const wallet = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
-
-    expect(getActiveWalletForWagmi({ wallets: [wallet], user: null })).toBeUndefined();
-  });
-
-  it("does not select wallets marked disconnected in wagmi storage", () => {
-    const wallet = createWallet({ connectedAt: 3, metaId: "io.phantom", walletClientType: "phantom" });
-    const config = {
-      storage: {
-        key: "test-wagmi",
-      },
-    } as unknown as Config;
-
-    localStorage.setItem("test-wagmi.io.phantom.disconnected", "true");
-
-    expect(getActiveWalletForWagmi({ wallets: [wallet], user: {} as User }, config)).toBeUndefined();
   });
 });

--- a/src/lib/wallets/privyWagmi.spec.ts
+++ b/src/lib/wallets/privyWagmi.spec.ts
@@ -1,0 +1,77 @@
+import type { ConnectedWallet } from "@privy-io/react-auth";
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "wagmi";
+
+import { disconnectPrivyWalletsFromWagmi, getPrivyWagmiConnectorId } from "./privyWagmi";
+
+function createWallet({
+  address = "0x0000000000000000000000000000000000000001",
+  metaId = "io.metamask",
+  walletClientType = "metamask",
+}: {
+  address?: string;
+  metaId?: string;
+  walletClientType?: string;
+}) {
+  return {
+    address,
+    walletClientType,
+    meta: {
+      id: metaId,
+      name: metaId,
+    },
+  } as ConnectedWallet;
+}
+
+describe("privyWagmi", () => {
+  it("uses Privy's embedded wallet connector id format", () => {
+    const wallet = createWallet({
+      address: "0x0000000000000000000000000000000000000002",
+      metaId: "io.privy.wallet",
+      walletClientType: "privy",
+    });
+
+    expect(getPrivyWagmiConnectorId(wallet)).toBe("io.privy.wallet.0x0000000000000000000000000000000000000002");
+  });
+
+  it("uses the wallet metadata id for external wallets", () => {
+    const wallet = createWallet({
+      metaId: "io.phantom",
+      walletClientType: "phantom",
+    });
+
+    expect(getPrivyWagmiConnectorId(wallet)).toBe("io.phantom");
+  });
+
+  it("marks all Privy-backed wagmi connectors disconnected", async () => {
+    const removeItem = vi.fn();
+    const setItem = vi.fn();
+    const config = {
+      storage: {
+        removeItem,
+        setItem,
+      },
+    } as unknown as Config;
+
+    await disconnectPrivyWalletsFromWagmi(
+      [
+        createWallet({ metaId: "io.phantom", walletClientType: "phantom" }),
+        createWallet({ metaId: "io.phantom", walletClientType: "phantom" }),
+        createWallet({
+          address: "0x0000000000000000000000000000000000000003",
+          metaId: "io.privy.wallet",
+          walletClientType: "privy",
+        }),
+      ],
+      config
+    );
+
+    expect(removeItem).toHaveBeenCalledWith("recentConnectorId");
+    expect(setItem).toHaveBeenCalledWith("io.phantom.disconnected", true);
+    expect(setItem).toHaveBeenCalledWith(
+      "io.privy.wallet.0x0000000000000000000000000000000000000003.disconnected",
+      true
+    );
+    expect(setItem).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/wallets/privyWagmi.ts
+++ b/src/lib/wallets/privyWagmi.ts
@@ -1,0 +1,25 @@
+import type { ConnectedWallet } from "@privy-io/react-auth";
+import type { Config } from "wagmi";
+
+import { getWagmiConfig } from "./walletConfig";
+
+type PrivyWagmiWallet = Pick<ConnectedWallet, "address" | "meta" | "walletClientType">;
+
+export function getPrivyWagmiConnectorId(wallet: PrivyWagmiWallet): string {
+  return wallet.walletClientType === "privy" ? `${wallet.meta.id}.${wallet.address}` : wallet.meta.id;
+}
+
+export async function disconnectPrivyWalletsFromWagmi(wallets: PrivyWagmiWallet[], config: Config = getWagmiConfig()) {
+  const storage = config.storage;
+
+  if (!storage) {
+    return;
+  }
+
+  const connectorIds = Array.from(new Set(wallets.map(getPrivyWagmiConnectorId)));
+
+  await Promise.allSettled([
+    storage.removeItem("recentConnectorId"),
+    ...connectorIds.map((connectorId) => storage.setItem(`${connectorId}.disconnected`, true)),
+  ]);
+}

--- a/src/lib/wallets/privyWagmi.ts
+++ b/src/lib/wallets/privyWagmi.ts
@@ -1,9 +1,58 @@
-import type { ConnectedWallet } from "@privy-io/react-auth";
+import type { BaseConnectedWalletType, ConnectedWallet, User } from "@privy-io/react-auth";
 import type { Config } from "wagmi";
 
 import { getWagmiConfig } from "./walletConfig";
 
-type PrivyWagmiWallet = Pick<ConnectedWallet, "address" | "meta" | "walletClientType">;
+const PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY = "privy-disconnected-wagmi-connectors";
+
+type PrivyWagmiWallet = Pick<BaseConnectedWalletType, "address" | "meta" | "type" | "walletClientType">;
+
+type GetActiveWalletForWagmiArgs = {
+  wallets: ConnectedWallet[];
+  user: User | null;
+};
+
+function readDisconnectedConnectorIds() {
+  if (typeof localStorage === "undefined") {
+    return new Set<string>();
+  }
+
+  try {
+    const raw = localStorage.getItem(PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+
+    return new Set(Array.isArray(parsed) ? parsed.filter((value) => typeof value === "string") : []);
+  } catch {
+    return new Set<string>();
+  }
+}
+
+function writeDisconnectedConnectorIds(connectorIds: Set<string>) {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  if (connectorIds.size === 0) {
+    localStorage.removeItem(PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY);
+    return;
+  }
+
+  localStorage.setItem(PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY, JSON.stringify(Array.from(connectorIds)));
+}
+
+function isWagmiConnectorMarkedDisconnected(connectorId: string, config: Config) {
+  if (typeof localStorage === "undefined") {
+    return false;
+  }
+
+  const storageKey = config.storage?.key ?? "wagmi";
+
+  return localStorage.getItem(`${storageKey}.${connectorId}.disconnected`) === "true";
+}
+
+function isPrivyConnectorAllowed(connectorId: string, config: Config) {
+  return !readDisconnectedConnectorIds().has(connectorId) && !isWagmiConnectorMarkedDisconnected(connectorId, config);
+}
 
 export function getPrivyWagmiConnectorId(wallet: PrivyWagmiWallet): string {
   return wallet.walletClientType === "privy" ? `${wallet.meta.id}.${wallet.address}` : wallet.meta.id;
@@ -11,15 +60,54 @@ export function getPrivyWagmiConnectorId(wallet: PrivyWagmiWallet): string {
 
 export async function disconnectPrivyWalletsFromWagmi(wallets: PrivyWagmiWallet[], config: Config = getWagmiConfig()) {
   const storage = config.storage;
+  const connectorIds = Array.from(
+    new Set(wallets.filter((wallet) => wallet.type === "ethereum").map(getPrivyWagmiConnectorId))
+  );
+  const disconnectedConnectorIds = readDisconnectedConnectorIds();
+
+  // Wagmi's injected shim can be cleared by provider events while Privy rebuilds connectors.
+  // Keep an app-side block until the user explicitly selects the wallet again.
+  connectorIds.forEach((connectorId) => disconnectedConnectorIds.add(connectorId));
+  writeDisconnectedConnectorIds(disconnectedConnectorIds);
 
   if (!storage) {
     return;
   }
 
-  const connectorIds = Array.from(new Set(wallets.map(getPrivyWagmiConnectorId)));
-
   await Promise.allSettled([
     storage.removeItem("recentConnectorId"),
     ...connectorIds.map((connectorId) => storage.setItem(`${connectorId}.disconnected`, true)),
   ]);
+}
+
+export async function allowPrivyWalletForWagmi(wallet: PrivyWagmiWallet, config: Config = getWagmiConfig()) {
+  if (wallet.type !== "ethereum") {
+    return;
+  }
+
+  const connectorId = getPrivyWagmiConnectorId(wallet);
+  const disconnectedConnectorIds = readDisconnectedConnectorIds();
+
+  disconnectedConnectorIds.delete(connectorId);
+  writeDisconnectedConnectorIds(disconnectedConnectorIds);
+
+  await Promise.allSettled([
+    config.storage?.removeItem(`${connectorId}.disconnected`),
+    config.storage?.setItem("recentConnectorId", connectorId),
+  ]);
+}
+
+export function getActiveWalletForWagmi(
+  { wallets, user }: GetActiveWalletForWagmiArgs,
+  config: Config = getWagmiConfig()
+) {
+  if (!user) {
+    return undefined;
+  }
+
+  // Returning undefined tells @privy-io/wagmi to reset wagmi instead of setting up stale wallets.
+  return wallets
+    .filter((wallet) => wallet.type === "ethereum")
+    .filter((wallet) => isPrivyConnectorAllowed(getPrivyWagmiConnectorId(wallet), config))
+    .sort((a, b) => b.connectedAt - a.connectedAt)[0];
 }

--- a/src/lib/wallets/privyWagmi.ts
+++ b/src/lib/wallets/privyWagmi.ts
@@ -1,58 +1,9 @@
-import type { BaseConnectedWalletType, ConnectedWallet, User } from "@privy-io/react-auth";
+import type { ConnectedWallet } from "@privy-io/react-auth";
 import type { Config } from "wagmi";
 
 import { getWagmiConfig } from "./walletConfig";
 
-const PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY = "privy-disconnected-wagmi-connectors";
-
-type PrivyWagmiWallet = Pick<BaseConnectedWalletType, "address" | "meta" | "type" | "walletClientType">;
-
-type GetActiveWalletForWagmiArgs = {
-  wallets: ConnectedWallet[];
-  user: User | null;
-};
-
-function readDisconnectedConnectorIds() {
-  if (typeof localStorage === "undefined") {
-    return new Set<string>();
-  }
-
-  try {
-    const raw = localStorage.getItem(PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY);
-    const parsed = raw ? JSON.parse(raw) : [];
-
-    return new Set(Array.isArray(parsed) ? parsed.filter((value) => typeof value === "string") : []);
-  } catch {
-    return new Set<string>();
-  }
-}
-
-function writeDisconnectedConnectorIds(connectorIds: Set<string>) {
-  if (typeof localStorage === "undefined") {
-    return;
-  }
-
-  if (connectorIds.size === 0) {
-    localStorage.removeItem(PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY);
-    return;
-  }
-
-  localStorage.setItem(PRIVY_DISCONNECTED_WAGMI_CONNECTORS_KEY, JSON.stringify(Array.from(connectorIds)));
-}
-
-function isWagmiConnectorMarkedDisconnected(connectorId: string, config: Config) {
-  if (typeof localStorage === "undefined") {
-    return false;
-  }
-
-  const storageKey = config.storage?.key ?? "wagmi";
-
-  return localStorage.getItem(`${storageKey}.${connectorId}.disconnected`) === "true";
-}
-
-function isPrivyConnectorAllowed(connectorId: string, config: Config) {
-  return !readDisconnectedConnectorIds().has(connectorId) && !isWagmiConnectorMarkedDisconnected(connectorId, config);
-}
+type PrivyWagmiWallet = Pick<ConnectedWallet, "address" | "meta" | "walletClientType">;
 
 export function getPrivyWagmiConnectorId(wallet: PrivyWagmiWallet): string {
   return wallet.walletClientType === "privy" ? `${wallet.meta.id}.${wallet.address}` : wallet.meta.id;
@@ -60,54 +11,15 @@ export function getPrivyWagmiConnectorId(wallet: PrivyWagmiWallet): string {
 
 export async function disconnectPrivyWalletsFromWagmi(wallets: PrivyWagmiWallet[], config: Config = getWagmiConfig()) {
   const storage = config.storage;
-  const connectorIds = Array.from(
-    new Set(wallets.filter((wallet) => wallet.type === "ethereum").map(getPrivyWagmiConnectorId))
-  );
-  const disconnectedConnectorIds = readDisconnectedConnectorIds();
-
-  // Wagmi's injected shim can be cleared by provider events while Privy rebuilds connectors.
-  // Keep an app-side block until the user explicitly selects the wallet again.
-  connectorIds.forEach((connectorId) => disconnectedConnectorIds.add(connectorId));
-  writeDisconnectedConnectorIds(disconnectedConnectorIds);
 
   if (!storage) {
     return;
   }
 
+  const connectorIds = Array.from(new Set(wallets.map(getPrivyWagmiConnectorId)));
+
   await Promise.allSettled([
     storage.removeItem("recentConnectorId"),
     ...connectorIds.map((connectorId) => storage.setItem(`${connectorId}.disconnected`, true)),
   ]);
-}
-
-export async function allowPrivyWalletForWagmi(wallet: PrivyWagmiWallet, config: Config = getWagmiConfig()) {
-  if (wallet.type !== "ethereum") {
-    return;
-  }
-
-  const connectorId = getPrivyWagmiConnectorId(wallet);
-  const disconnectedConnectorIds = readDisconnectedConnectorIds();
-
-  disconnectedConnectorIds.delete(connectorId);
-  writeDisconnectedConnectorIds(disconnectedConnectorIds);
-
-  await Promise.allSettled([
-    config.storage?.removeItem(`${connectorId}.disconnected`),
-    config.storage?.setItem("recentConnectorId", connectorId),
-  ]);
-}
-
-export function getActiveWalletForWagmi(
-  { wallets, user }: GetActiveWalletForWagmiArgs,
-  config: Config = getWagmiConfig()
-) {
-  if (!user) {
-    return undefined;
-  }
-
-  // Returning undefined tells @privy-io/wagmi to reset wagmi instead of setting up stale wallets.
-  return wallets
-    .filter((wallet) => wallet.type === "ethereum")
-    .filter((wallet) => isPrivyConnectorAllowed(getPrivyWagmiConnectorId(wallet), config))
-    .sort((a, b) => b.connectedAt - a.connectedAt)[0];
 }

--- a/src/lib/wallets/useConnectModal.spec.tsx
+++ b/src/lib/wallets/useConnectModal.spec.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConnectModalProvider, useConnectModal } from "./useConnectModal";
@@ -8,10 +8,8 @@ const mocks = vi.hoisted(() => ({
   isPrivyModalOpen: false,
   connectOrCreateWallet: vi.fn(),
   connectWallet: vi.fn(),
-  disconnectPrivyWalletsFromWagmi: vi.fn(),
   pushError: vi.fn(),
   switchNetwork: vi.fn(),
-  wallets: [{ address: "0x1", meta: { id: "io.phantom" }, walletClientType: "phantom" }],
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
@@ -26,9 +24,6 @@ vi.mock("@privy-io/react-auth", () => ({
   }),
   useConnectWallet: () => ({
     connectWallet: mocks.connectWallet,
-  }),
-  useWallets: () => ({
-    wallets: mocks.wallets,
   }),
 }));
 
@@ -48,10 +43,6 @@ vi.mock("lib/metrics", () => ({
 
 vi.mock("lib/wallets", () => ({
   switchNetwork: mocks.switchNetwork,
-}));
-
-vi.mock("lib/wallets/privyWagmi", () => ({
-  disconnectPrivyWalletsFromWagmi: mocks.disconnectPrivyWalletsFromWagmi,
 }));
 
 function setup() {
@@ -75,7 +66,6 @@ describe("ConnectModalProvider", () => {
   beforeEach(() => {
     mocks.authenticated = false;
     mocks.isPrivyModalOpen = false;
-    mocks.disconnectPrivyWalletsFromWagmi.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -83,20 +73,19 @@ describe("ConnectModalProvider", () => {
     vi.clearAllMocks();
   });
 
-  it("uses connectOrCreateWallet for unauthenticated users", async () => {
+  it("uses connectOrCreateWallet for unauthenticated users", () => {
     const getContext = setup();
 
     act(() => {
       getContext().openConnectModal?.();
     });
 
-    await waitFor(() => expect(mocks.connectOrCreateWallet).toHaveBeenCalledTimes(1));
-    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledWith(mocks.wallets);
+    expect(mocks.connectOrCreateWallet).toHaveBeenCalledTimes(1);
     expect(mocks.connectWallet).not.toHaveBeenCalled();
     expect(getContext().connectModalOpen).toBe(true);
   });
 
-  it("uses connectWallet for authenticated users after extension-side disconnects", async () => {
+  it("uses connectWallet for authenticated users after extension-side disconnects", () => {
     mocks.authenticated = true;
     const getContext = setup();
 
@@ -104,37 +93,12 @@ describe("ConnectModalProvider", () => {
       getContext().openConnectModal?.();
     });
 
-    await waitFor(() => expect(mocks.connectWallet).toHaveBeenCalledTimes(1));
-    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledWith(mocks.wallets);
+    expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
     expect(mocks.connectOrCreateWallet).not.toHaveBeenCalled();
     expect(getContext().connectModalOpen).toBe(true);
   });
 
-  it("marks stale Privy wallets disconnected before opening the modal", async () => {
-    let resolveDisconnect!: () => void;
-    mocks.disconnectPrivyWalletsFromWagmi.mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveDisconnect = resolve;
-      })
-    );
-
-    const getContext = setup();
-
-    act(() => {
-      getContext().openConnectModal?.();
-    });
-
-    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledWith(mocks.wallets);
-    expect(mocks.connectOrCreateWallet).not.toHaveBeenCalled();
-
-    await act(async () => {
-      resolveDisconnect();
-    });
-
-    await waitFor(() => expect(mocks.connectOrCreateWallet).toHaveBeenCalledTimes(1));
-  });
-
-  it("does not start another Privy wallet request while one is pending", async () => {
+  it("does not start another Privy wallet request while one is pending", () => {
     mocks.authenticated = true;
     const getContext = setup();
 
@@ -143,6 +107,6 @@ describe("ConnectModalProvider", () => {
       getContext().openConnectModal?.();
     });
 
-    await waitFor(() => expect(mocks.connectWallet).toHaveBeenCalledTimes(1));
+    expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/wallets/useConnectModal.spec.tsx
+++ b/src/lib/wallets/useConnectModal.spec.tsx
@@ -7,9 +7,12 @@ const mocks = vi.hoisted(() => ({
   authenticated: false,
   isPrivyModalOpen: false,
   connectOrCreateWallet: vi.fn(),
+  connectOrCreateWalletCallbacks: undefined as { onSuccess?: (params: { wallet: object }) => void } | undefined,
   connectWallet: vi.fn(),
+  connectWalletCallbacks: undefined as { onSuccess?: (params: { wallet: object }) => void } | undefined,
+  allowPrivyWalletForWagmi: vi.fn(),
   pushError: vi.fn(),
-  switchNetwork: vi.fn(),
+  switchNetwork: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
@@ -19,12 +22,18 @@ vi.mock("@privy-io/react-auth", () => ({
   useModalStatus: () => ({
     isOpen: mocks.isPrivyModalOpen,
   }),
-  useConnectOrCreateWallet: () => ({
-    connectOrCreateWallet: mocks.connectOrCreateWallet,
-  }),
-  useConnectWallet: () => ({
-    connectWallet: mocks.connectWallet,
-  }),
+  useConnectOrCreateWallet: (callbacks: { onSuccess?: (params: { wallet: object }) => void }) => {
+    mocks.connectOrCreateWalletCallbacks = callbacks;
+    return {
+      connectOrCreateWallet: mocks.connectOrCreateWallet,
+    };
+  },
+  useConnectWallet: (callbacks: { onSuccess?: (params: { wallet: object }) => void }) => {
+    mocks.connectWalletCallbacks = callbacks;
+    return {
+      connectWallet: mocks.connectWallet,
+    };
+  },
 }));
 
 vi.mock("context/GmxAccountContext/hooks", () => ({
@@ -43,6 +52,10 @@ vi.mock("lib/metrics", () => ({
 
 vi.mock("lib/wallets", () => ({
   switchNetwork: mocks.switchNetwork,
+}));
+
+vi.mock("lib/wallets/privyWagmi", () => ({
+  allowPrivyWalletForWagmi: mocks.allowPrivyWalletForWagmi,
 }));
 
 function setup() {
@@ -66,6 +79,9 @@ describe("ConnectModalProvider", () => {
   beforeEach(() => {
     mocks.authenticated = false;
     mocks.isPrivyModalOpen = false;
+    mocks.connectOrCreateWalletCallbacks = undefined;
+    mocks.connectWalletCallbacks = undefined;
+    mocks.switchNetwork.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -108,5 +124,17 @@ describe("ConnectModalProvider", () => {
     });
 
     expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the selected wallet for Privy wagmi sync on success", () => {
+    const wallet = { type: "ethereum", address: "0x1", meta: { id: "io.phantom" }, walletClientType: "phantom" };
+
+    setup();
+
+    act(() => {
+      mocks.connectWalletCallbacks?.onSuccess?.({ wallet });
+    });
+
+    expect(mocks.allowPrivyWalletForWagmi).toHaveBeenCalledWith(wallet);
   });
 });

--- a/src/lib/wallets/useConnectModal.spec.tsx
+++ b/src/lib/wallets/useConnectModal.spec.tsx
@@ -1,0 +1,112 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConnectModalProvider, useConnectModal } from "./useConnectModal";
+
+const mocks = vi.hoisted(() => ({
+  authenticated: false,
+  isPrivyModalOpen: false,
+  connectOrCreateWallet: vi.fn(),
+  connectWallet: vi.fn(),
+  pushError: vi.fn(),
+  switchNetwork: vi.fn(),
+}));
+
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => ({
+    authenticated: mocks.authenticated,
+  }),
+  useModalStatus: () => ({
+    isOpen: mocks.isPrivyModalOpen,
+  }),
+  useConnectOrCreateWallet: () => ({
+    connectOrCreateWallet: mocks.connectOrCreateWallet,
+  }),
+  useConnectWallet: () => ({
+    connectWallet: mocks.connectWallet,
+  }),
+}));
+
+vi.mock("context/GmxAccountContext/hooks", () => ({
+  useGmxAccountSettlementChainId: () => [42161],
+}));
+
+vi.mock("config/multichain", () => ({
+  isSourceChain: () => false,
+}));
+
+vi.mock("lib/metrics", () => ({
+  metrics: {
+    pushError: mocks.pushError,
+  },
+}));
+
+vi.mock("lib/wallets", () => ({
+  switchNetwork: mocks.switchNetwork,
+}));
+
+function setup() {
+  let context!: ReturnType<typeof useConnectModal>;
+
+  function TestComponent() {
+    context = useConnectModal();
+    return null;
+  }
+
+  render(
+    <ConnectModalProvider>
+      <TestComponent />
+    </ConnectModalProvider>
+  );
+
+  return () => context;
+}
+
+describe("ConnectModalProvider", () => {
+  beforeEach(() => {
+    mocks.authenticated = false;
+    mocks.isPrivyModalOpen = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("uses connectOrCreateWallet for unauthenticated users", () => {
+    const getContext = setup();
+
+    act(() => {
+      getContext().openConnectModal?.();
+    });
+
+    expect(mocks.connectOrCreateWallet).toHaveBeenCalledTimes(1);
+    expect(mocks.connectWallet).not.toHaveBeenCalled();
+    expect(getContext().connectModalOpen).toBe(true);
+  });
+
+  it("uses connectWallet for authenticated users after extension-side disconnects", () => {
+    mocks.authenticated = true;
+    const getContext = setup();
+
+    act(() => {
+      getContext().openConnectModal?.();
+    });
+
+    expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
+    expect(mocks.connectOrCreateWallet).not.toHaveBeenCalled();
+    expect(getContext().connectModalOpen).toBe(true);
+  });
+
+  it("does not start another Privy wallet request while one is pending", () => {
+    mocks.authenticated = true;
+    const getContext = setup();
+
+    act(() => {
+      getContext().openConnectModal?.();
+      getContext().openConnectModal?.();
+    });
+
+    expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/wallets/useConnectModal.spec.tsx
+++ b/src/lib/wallets/useConnectModal.spec.tsx
@@ -7,12 +7,9 @@ const mocks = vi.hoisted(() => ({
   authenticated: false,
   isPrivyModalOpen: false,
   connectOrCreateWallet: vi.fn(),
-  connectOrCreateWalletCallbacks: undefined as { onSuccess?: (params: { wallet: object }) => void } | undefined,
   connectWallet: vi.fn(),
-  connectWalletCallbacks: undefined as { onSuccess?: (params: { wallet: object }) => void } | undefined,
-  allowPrivyWalletForWagmi: vi.fn(),
   pushError: vi.fn(),
-  switchNetwork: vi.fn(() => Promise.resolve()),
+  switchNetwork: vi.fn(),
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
@@ -22,18 +19,12 @@ vi.mock("@privy-io/react-auth", () => ({
   useModalStatus: () => ({
     isOpen: mocks.isPrivyModalOpen,
   }),
-  useConnectOrCreateWallet: (callbacks: { onSuccess?: (params: { wallet: object }) => void }) => {
-    mocks.connectOrCreateWalletCallbacks = callbacks;
-    return {
-      connectOrCreateWallet: mocks.connectOrCreateWallet,
-    };
-  },
-  useConnectWallet: (callbacks: { onSuccess?: (params: { wallet: object }) => void }) => {
-    mocks.connectWalletCallbacks = callbacks;
-    return {
-      connectWallet: mocks.connectWallet,
-    };
-  },
+  useConnectOrCreateWallet: () => ({
+    connectOrCreateWallet: mocks.connectOrCreateWallet,
+  }),
+  useConnectWallet: () => ({
+    connectWallet: mocks.connectWallet,
+  }),
 }));
 
 vi.mock("context/GmxAccountContext/hooks", () => ({
@@ -52,10 +43,6 @@ vi.mock("lib/metrics", () => ({
 
 vi.mock("lib/wallets", () => ({
   switchNetwork: mocks.switchNetwork,
-}));
-
-vi.mock("lib/wallets/privyWagmi", () => ({
-  allowPrivyWalletForWagmi: mocks.allowPrivyWalletForWagmi,
 }));
 
 function setup() {
@@ -79,9 +66,6 @@ describe("ConnectModalProvider", () => {
   beforeEach(() => {
     mocks.authenticated = false;
     mocks.isPrivyModalOpen = false;
-    mocks.connectOrCreateWalletCallbacks = undefined;
-    mocks.connectWalletCallbacks = undefined;
-    mocks.switchNetwork.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -124,17 +108,5 @@ describe("ConnectModalProvider", () => {
     });
 
     expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
-  });
-
-  it("allows the selected wallet for Privy wagmi sync on success", () => {
-    const wallet = { type: "ethereum", address: "0x1", meta: { id: "io.phantom" }, walletClientType: "phantom" };
-
-    setup();
-
-    act(() => {
-      mocks.connectWalletCallbacks?.onSuccess?.({ wallet });
-    });
-
-    expect(mocks.allowPrivyWalletForWagmi).toHaveBeenCalledWith(wallet);
   });
 });

--- a/src/lib/wallets/useConnectModal.spec.tsx
+++ b/src/lib/wallets/useConnectModal.spec.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConnectModalProvider, useConnectModal } from "./useConnectModal";
@@ -8,8 +8,10 @@ const mocks = vi.hoisted(() => ({
   isPrivyModalOpen: false,
   connectOrCreateWallet: vi.fn(),
   connectWallet: vi.fn(),
+  disconnectPrivyWalletsFromWagmi: vi.fn(),
   pushError: vi.fn(),
   switchNetwork: vi.fn(),
+  wallets: [{ address: "0x1", meta: { id: "io.phantom" }, walletClientType: "phantom" }],
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
@@ -24,6 +26,9 @@ vi.mock("@privy-io/react-auth", () => ({
   }),
   useConnectWallet: () => ({
     connectWallet: mocks.connectWallet,
+  }),
+  useWallets: () => ({
+    wallets: mocks.wallets,
   }),
 }));
 
@@ -43,6 +48,10 @@ vi.mock("lib/metrics", () => ({
 
 vi.mock("lib/wallets", () => ({
   switchNetwork: mocks.switchNetwork,
+}));
+
+vi.mock("lib/wallets/privyWagmi", () => ({
+  disconnectPrivyWalletsFromWagmi: mocks.disconnectPrivyWalletsFromWagmi,
 }));
 
 function setup() {
@@ -66,6 +75,7 @@ describe("ConnectModalProvider", () => {
   beforeEach(() => {
     mocks.authenticated = false;
     mocks.isPrivyModalOpen = false;
+    mocks.disconnectPrivyWalletsFromWagmi.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -73,19 +83,20 @@ describe("ConnectModalProvider", () => {
     vi.clearAllMocks();
   });
 
-  it("uses connectOrCreateWallet for unauthenticated users", () => {
+  it("uses connectOrCreateWallet for unauthenticated users", async () => {
     const getContext = setup();
 
     act(() => {
       getContext().openConnectModal?.();
     });
 
-    expect(mocks.connectOrCreateWallet).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.connectOrCreateWallet).toHaveBeenCalledTimes(1));
+    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledWith(mocks.wallets);
     expect(mocks.connectWallet).not.toHaveBeenCalled();
     expect(getContext().connectModalOpen).toBe(true);
   });
 
-  it("uses connectWallet for authenticated users after extension-side disconnects", () => {
+  it("uses connectWallet for authenticated users after extension-side disconnects", async () => {
     mocks.authenticated = true;
     const getContext = setup();
 
@@ -93,12 +104,37 @@ describe("ConnectModalProvider", () => {
       getContext().openConnectModal?.();
     });
 
-    expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.connectWallet).toHaveBeenCalledTimes(1));
+    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledWith(mocks.wallets);
     expect(mocks.connectOrCreateWallet).not.toHaveBeenCalled();
     expect(getContext().connectModalOpen).toBe(true);
   });
 
-  it("does not start another Privy wallet request while one is pending", () => {
+  it("marks stale Privy wallets disconnected before opening the modal", async () => {
+    let resolveDisconnect!: () => void;
+    mocks.disconnectPrivyWalletsFromWagmi.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDisconnect = resolve;
+      })
+    );
+
+    const getContext = setup();
+
+    act(() => {
+      getContext().openConnectModal?.();
+    });
+
+    expect(mocks.disconnectPrivyWalletsFromWagmi).toHaveBeenCalledWith(mocks.wallets);
+    expect(mocks.connectOrCreateWallet).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveDisconnect();
+    });
+
+    await waitFor(() => expect(mocks.connectOrCreateWallet).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not start another Privy wallet request while one is pending", async () => {
     mocks.authenticated = true;
     const getContext = setup();
 
@@ -107,6 +143,6 @@ describe("ConnectModalProvider", () => {
       getContext().openConnectModal?.();
     });
 
-    expect(mocks.connectWallet).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.connectWallet).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useConnectOrCreateWallet, useConnectWallet, useModalStatus, usePrivy } from "@privy-io/react-auth";
+import { useConnectOrCreateWallet, useConnectWallet, useModalStatus, usePrivy, useWallets } from "@privy-io/react-auth";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -10,6 +10,7 @@ import { isSourceChain } from "config/multichain";
 import { useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
 import { metrics } from "lib/metrics";
 import { switchNetwork } from "lib/wallets";
+import { disconnectPrivyWalletsFromWagmi } from "lib/wallets/privyWagmi";
 
 type ConnectModalContextValue = {
   openConnectModal: (() => void) | undefined;
@@ -36,6 +37,7 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
   const connectRequestInFlightRef = useRef(false);
   const { isOpen: privyModalOpen } = useModalStatus();
   const { authenticated } = usePrivy();
+  const { wallets } = useWallets();
 
   const handleSuccess = useCallback(() => {
     connectRequestInFlightRef.current = false;
@@ -82,19 +84,26 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
 
     connectRequestInFlightRef.current = true;
     setConnectModalOpen(true);
-    try {
-      // Privy rejects connectOrCreateWallet for already-authenticated sessions.
-      if (authenticated) {
-        connectWallet();
-      } else {
-        connectOrCreateWallet();
+
+    void (async () => {
+      try {
+        // Prevent stale Privy wallets from auto-reconnecting when the modal opens.
+        // Privy's wagmi adapter clears this marker only after a real wallet selection.
+        await disconnectPrivyWalletsFromWagmi(wallets);
+
+        // Privy rejects connectOrCreateWallet for already-authenticated sessions.
+        if (authenticated) {
+          connectWallet();
+        } else {
+          connectOrCreateWallet();
+        }
+      } catch (error) {
+        connectRequestInFlightRef.current = false;
+        setConnectModalOpen(false);
+        metrics.pushError(error, "connectModal.open");
       }
-    } catch (error) {
-      connectRequestInFlightRef.current = false;
-      setConnectModalOpen(false);
-      metrics.pushError(error, "connectModal.open");
-    }
-  }, [authenticated, connectOrCreateWallet, connectWallet]);
+    })();
+  }, [authenticated, connectOrCreateWallet, connectWallet, wallets]);
 
   const value = useMemo(() => ({ openConnectModal, connectModalOpen }), [openConnectModal, connectModalOpen]);
 

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useConnectOrCreateWallet, useConnectWallet, useModalStatus, usePrivy, useWallets } from "@privy-io/react-auth";
+import { useConnectOrCreateWallet, useConnectWallet, useModalStatus, usePrivy } from "@privy-io/react-auth";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -10,7 +10,6 @@ import { isSourceChain } from "config/multichain";
 import { useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
 import { metrics } from "lib/metrics";
 import { switchNetwork } from "lib/wallets";
-import { disconnectPrivyWalletsFromWagmi } from "lib/wallets/privyWagmi";
 
 type ConnectModalContextValue = {
   openConnectModal: (() => void) | undefined;
@@ -37,7 +36,6 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
   const connectRequestInFlightRef = useRef(false);
   const { isOpen: privyModalOpen } = useModalStatus();
   const { authenticated } = usePrivy();
-  const { wallets } = useWallets();
 
   const handleSuccess = useCallback(() => {
     connectRequestInFlightRef.current = false;
@@ -84,26 +82,19 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
 
     connectRequestInFlightRef.current = true;
     setConnectModalOpen(true);
-
-    void (async () => {
-      try {
-        // Prevent stale Privy wallets from auto-reconnecting when the modal opens.
-        // Privy's wagmi adapter clears this marker only after a real wallet selection.
-        await disconnectPrivyWalletsFromWagmi(wallets);
-
-        // Privy rejects connectOrCreateWallet for already-authenticated sessions.
-        if (authenticated) {
-          connectWallet();
-        } else {
-          connectOrCreateWallet();
-        }
-      } catch (error) {
-        connectRequestInFlightRef.current = false;
-        setConnectModalOpen(false);
-        metrics.pushError(error, "connectModal.open");
+    try {
+      // Privy rejects connectOrCreateWallet for already-authenticated sessions.
+      if (authenticated) {
+        connectWallet();
+      } else {
+        connectOrCreateWallet();
       }
-    })();
-  }, [authenticated, connectOrCreateWallet, connectWallet, wallets]);
+    } catch (error) {
+      connectRequestInFlightRef.current = false;
+      setConnectModalOpen(false);
+      metrics.pushError(error, "connectModal.open");
+    }
+  }, [authenticated, connectOrCreateWallet, connectWallet]);
 
   const value = useMemo(() => ({ openConnectModal, connectModalOpen }), [openConnectModal, connectModalOpen]);
 

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,5 +1,4 @@
 import { useConnectOrCreateWallet, useConnectWallet, useModalStatus, usePrivy } from "@privy-io/react-auth";
-import type { PrivyEvents } from "@privy-io/react-auth";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -11,14 +10,11 @@ import { isSourceChain } from "config/multichain";
 import { useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
 import { metrics } from "lib/metrics";
 import { switchNetwork } from "lib/wallets";
-import { allowPrivyWalletForWagmi } from "lib/wallets/privyWagmi";
 
 type ConnectModalContextValue = {
   openConnectModal: (() => void) | undefined;
   connectModalOpen: boolean;
 };
-
-type ConnectWalletSuccessParams = Parameters<NonNullable<PrivyEvents["connectWallet"]["onSuccess"]>>[0];
 
 const ConnectModalContext = createContext<ConnectModalContextValue>({
   openConnectModal: undefined,
@@ -41,24 +37,20 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
   const { isOpen: privyModalOpen } = useModalStatus();
   const { authenticated } = usePrivy();
 
-  const handleSuccess = useCallback(
-    (params: ConnectWalletSuccessParams) => {
-      connectRequestInFlightRef.current = false;
-      setConnectModalOpen(false);
-      void allowPrivyWalletForWagmi(params.wallet);
+  const handleSuccess = useCallback(() => {
+    connectRequestInFlightRef.current = false;
+    setConnectModalOpen(false);
 
-      // @privy-io/wagmi already handles this callback by setting recentConnectorId
-      // and reconnecting wagmi. Calling setActiveWallet here can re-enter wagmi connect.
-      if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
-        return;
-      }
+    // @privy-io/wagmi already handles this callback by setting recentConnectorId
+    // and reconnecting wagmi. Calling setActiveWallet here can re-enter wagmi connect.
+    if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
+      return;
+    }
 
-      void switchNetwork(settlementChainId, true).catch((error) => {
-        metrics.pushError(error, "connectModal.switchNetwork");
-      });
-    },
-    [settlementChainId]
-  );
+    void switchNetwork(settlementChainId, true).catch((error) => {
+      metrics.pushError(error, "connectModal.switchNetwork");
+    });
+  }, [settlementChainId]);
 
   const { connectOrCreateWallet } = useConnectOrCreateWallet({
     onSuccess: handleSuccess,

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,4 +1,5 @@
-import { useConnectOrCreateWallet } from "@privy-io/react-auth";
+import { useConnectOrCreateWallet, type ConnectedWallet, type PrivyEvents } from "@privy-io/react-auth";
+import { useSetActiveWallet } from "@privy-io/wagmi";
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -10,6 +11,8 @@ import { isSourceChain } from "config/multichain";
 import { useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
 import { metrics } from "lib/metrics";
 import { switchNetwork } from "lib/wallets";
+
+type ConnectOrCreateWalletSuccessParams = Parameters<NonNullable<PrivyEvents["connectOrCreateWallet"]["onSuccess"]>>[0];
 
 type ConnectModalContextValue = {
   openConnectModal: (() => void) | undefined;
@@ -33,18 +36,33 @@ function shouldKeepAppSelectedSourceChain(settlementChainId: SettlementChainId) 
 export function ConnectModalProvider({ children }: { children: React.ReactNode }) {
   const [settlementChainId] = useGmxAccountSettlementChainId();
   const [connectModalOpen, setConnectModalOpen] = useState(false);
+  const { setActiveWallet } = useSetActiveWallet();
 
-  const handleSuccess = useCallback(() => {
-    setConnectModalOpen(false);
+  const handleSuccess = useCallback(
+    async ({ wallet }: ConnectOrCreateWalletSuccessParams) => {
+      setConnectModalOpen(false);
 
-    if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
-      return;
-    }
+      if (wallet.type !== "ethereum") {
+        return;
+      }
 
-    void switchNetwork(settlementChainId, true).catch((error) => {
-      metrics.pushError(error, "connectModal.switchNetwork");
-    });
-  }, [settlementChainId]);
+      try {
+        await setActiveWallet(wallet as ConnectedWallet);
+      } catch (error) {
+        metrics.pushError(error, "connectModal.setActiveWallet");
+        return;
+      }
+
+      if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
+        return;
+      }
+
+      void switchNetwork(settlementChainId, true).catch((error) => {
+        metrics.pushError(error, "connectModal.switchNetwork");
+      });
+    },
+    [setActiveWallet, settlementChainId]
+  );
 
   const { connectOrCreateWallet } = useConnectOrCreateWallet({
     onSuccess: handleSuccess,

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,4 +1,5 @@
 import { useConnectOrCreateWallet, useConnectWallet, useModalStatus, usePrivy } from "@privy-io/react-auth";
+import type { PrivyEvents } from "@privy-io/react-auth";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -10,11 +11,14 @@ import { isSourceChain } from "config/multichain";
 import { useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
 import { metrics } from "lib/metrics";
 import { switchNetwork } from "lib/wallets";
+import { allowPrivyWalletForWagmi } from "lib/wallets/privyWagmi";
 
 type ConnectModalContextValue = {
   openConnectModal: (() => void) | undefined;
   connectModalOpen: boolean;
 };
+
+type ConnectWalletSuccessParams = Parameters<NonNullable<PrivyEvents["connectWallet"]["onSuccess"]>>[0];
 
 const ConnectModalContext = createContext<ConnectModalContextValue>({
   openConnectModal: undefined,
@@ -37,20 +41,24 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
   const { isOpen: privyModalOpen } = useModalStatus();
   const { authenticated } = usePrivy();
 
-  const handleSuccess = useCallback(() => {
-    connectRequestInFlightRef.current = false;
-    setConnectModalOpen(false);
+  const handleSuccess = useCallback(
+    (params: ConnectWalletSuccessParams) => {
+      connectRequestInFlightRef.current = false;
+      setConnectModalOpen(false);
+      void allowPrivyWalletForWagmi(params.wallet);
 
-    // @privy-io/wagmi already handles this callback by setting recentConnectorId
-    // and reconnecting wagmi. Calling setActiveWallet here can re-enter wagmi connect.
-    if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
-      return;
-    }
+      // @privy-io/wagmi already handles this callback by setting recentConnectorId
+      // and reconnecting wagmi. Calling setActiveWallet here can re-enter wagmi connect.
+      if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
+        return;
+      }
 
-    void switchNetwork(settlementChainId, true).catch((error) => {
-      metrics.pushError(error, "connectModal.switchNetwork");
-    });
-  }, [settlementChainId]);
+      void switchNetwork(settlementChainId, true).catch((error) => {
+        metrics.pushError(error, "connectModal.switchNetwork");
+      });
+    },
+    [settlementChainId]
+  );
 
   const { connectOrCreateWallet } = useConnectOrCreateWallet({
     onSuccess: handleSuccess,

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,5 +1,4 @@
-import { useConnectOrCreateWallet, useModalStatus, type ConnectedWallet, type PrivyEvents } from "@privy-io/react-auth";
-import { useSetActiveWallet } from "@privy-io/wagmi";
+import { useConnectOrCreateWallet, useModalStatus } from "@privy-io/react-auth";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -11,8 +10,6 @@ import { isSourceChain } from "config/multichain";
 import { useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
 import { metrics } from "lib/metrics";
 import { switchNetwork } from "lib/wallets";
-
-type ConnectOrCreateWalletSuccessParams = Parameters<NonNullable<PrivyEvents["connectOrCreateWallet"]["onSuccess"]>>[0];
 
 type ConnectModalContextValue = {
   openConnectModal: (() => void) | undefined;
@@ -38,34 +35,21 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
   const [connectModalOpen, setConnectModalOpen] = useState(false);
   const connectRequestInFlightRef = useRef(false);
   const { isOpen: privyModalOpen } = useModalStatus();
-  const { setActiveWallet } = useSetActiveWallet();
 
-  const handleSuccess = useCallback(
-    async ({ wallet }: ConnectOrCreateWalletSuccessParams) => {
-      connectRequestInFlightRef.current = false;
-      setConnectModalOpen(false);
+  const handleSuccess = useCallback(() => {
+    connectRequestInFlightRef.current = false;
+    setConnectModalOpen(false);
 
-      if (wallet.type !== "ethereum") {
-        return;
-      }
+    // @privy-io/wagmi already handles this callback by setting recentConnectorId
+    // and reconnecting wagmi. Calling setActiveWallet here can re-enter wagmi connect.
+    if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
+      return;
+    }
 
-      try {
-        await setActiveWallet(wallet as ConnectedWallet);
-      } catch (error) {
-        metrics.pushError(error, "connectModal.setActiveWallet");
-        return;
-      }
-
-      if (shouldKeepAppSelectedSourceChain(settlementChainId)) {
-        return;
-      }
-
-      void switchNetwork(settlementChainId, true).catch((error) => {
-        metrics.pushError(error, "connectModal.switchNetwork");
-      });
-    },
-    [setActiveWallet, settlementChainId]
-  );
+    void switchNetwork(settlementChainId, true).catch((error) => {
+      metrics.pushError(error, "connectModal.switchNetwork");
+    });
+  }, [settlementChainId]);
 
   const { connectOrCreateWallet } = useConnectOrCreateWallet({
     onSuccess: handleSuccess,

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useConnectOrCreateWallet, useModalStatus } from "@privy-io/react-auth";
+import { useConnectOrCreateWallet, useConnectWallet, useModalStatus, usePrivy } from "@privy-io/react-auth";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
@@ -35,6 +35,7 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
   const [connectModalOpen, setConnectModalOpen] = useState(false);
   const connectRequestInFlightRef = useRef(false);
   const { isOpen: privyModalOpen } = useModalStatus();
+  const { authenticated } = usePrivy();
 
   const handleSuccess = useCallback(() => {
     connectRequestInFlightRef.current = false;
@@ -58,6 +59,13 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
       setConnectModalOpen(false);
     },
   });
+  const { connectWallet } = useConnectWallet({
+    onSuccess: handleSuccess,
+    onError: () => {
+      connectRequestInFlightRef.current = false;
+      setConnectModalOpen(false);
+    },
+  });
 
   useEffect(() => {
     if (!privyModalOpen) {
@@ -75,13 +83,18 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
     connectRequestInFlightRef.current = true;
     setConnectModalOpen(true);
     try {
-      connectOrCreateWallet();
+      // Privy rejects connectOrCreateWallet for already-authenticated sessions.
+      if (authenticated) {
+        connectWallet();
+      } else {
+        connectOrCreateWallet();
+      }
     } catch (error) {
       connectRequestInFlightRef.current = false;
       setConnectModalOpen(false);
       metrics.pushError(error, "connectModal.open");
     }
-  }, [connectOrCreateWallet]);
+  }, [authenticated, connectOrCreateWallet, connectWallet]);
 
   const value = useMemo(() => ({ openConnectModal, connectModalOpen }), [openConnectModal, connectModalOpen]);
 

--- a/src/lib/wallets/useConnectModal.tsx
+++ b/src/lib/wallets/useConnectModal.tsx
@@ -1,6 +1,6 @@
-import { useConnectOrCreateWallet, type ConnectedWallet, type PrivyEvents } from "@privy-io/react-auth";
+import { useConnectOrCreateWallet, useModalStatus, type ConnectedWallet, type PrivyEvents } from "@privy-io/react-auth";
 import { useSetActiveWallet } from "@privy-io/wagmi";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SettlementChainId } from "config/chains";
 import {
@@ -36,10 +36,13 @@ function shouldKeepAppSelectedSourceChain(settlementChainId: SettlementChainId) 
 export function ConnectModalProvider({ children }: { children: React.ReactNode }) {
   const [settlementChainId] = useGmxAccountSettlementChainId();
   const [connectModalOpen, setConnectModalOpen] = useState(false);
+  const connectRequestInFlightRef = useRef(false);
+  const { isOpen: privyModalOpen } = useModalStatus();
   const { setActiveWallet } = useSetActiveWallet();
 
   const handleSuccess = useCallback(
     async ({ wallet }: ConnectOrCreateWalletSuccessParams) => {
+      connectRequestInFlightRef.current = false;
       setConnectModalOpen(false);
 
       if (wallet.type !== "ethereum") {
@@ -66,12 +69,34 @@ export function ConnectModalProvider({ children }: { children: React.ReactNode }
 
   const { connectOrCreateWallet } = useConnectOrCreateWallet({
     onSuccess: handleSuccess,
-    onError: () => setConnectModalOpen(false),
+    onError: () => {
+      connectRequestInFlightRef.current = false;
+      setConnectModalOpen(false);
+    },
   });
 
+  useEffect(() => {
+    if (!privyModalOpen) {
+      connectRequestInFlightRef.current = false;
+      setConnectModalOpen(false);
+    }
+  }, [privyModalOpen]);
+
   const openConnectModal = useCallback(() => {
+    // MetaMask rejects duplicate connection requests while the first one is pending.
+    if (connectRequestInFlightRef.current) {
+      return;
+    }
+
+    connectRequestInFlightRef.current = true;
     setConnectModalOpen(true);
-    connectOrCreateWallet();
+    try {
+      connectOrCreateWallet();
+    } catch (error) {
+      connectRequestInFlightRef.current = false;
+      setConnectModalOpen(false);
+      metrics.pushError(error, "connectModal.open");
+    }
   }, [connectOrCreateWallet]);
 
   const value = useMemo(() => ({ openConnectModal, connectModalOpen }), [openConnectModal, connectModalOpen]);

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -16,6 +16,7 @@ import { isDevelopment } from "config/env";
 import { PRIVY_APP_ID } from "config/privy";
 import { getRpcProviders, RpcConfig } from "config/rpc";
 import { RpcPurpose } from "config/rpc";
+import { SECONDS_IN_DAY } from "lib/dates";
 import { metrics, ViemWsClientConnected, ViemWsClientDisconnected, ViemWsClientError } from "lib/metrics";
 import { getWsUrl } from "lib/rpc";
 import { AnyChainId, VIEM_CHAIN_BY_CHAIN_ID } from "sdk/configs/chains";
@@ -38,6 +39,14 @@ export const PRIVY_WALLET_LIST = [
 ] as const;
 
 export const PRIVY_LOGIN_METHODS = ["wallet", "email", "google", "twitter", "discord"] as const;
+
+const PRIVY_WALLET_REQUEST_TIMEOUT_MS = SECONDS_IN_DAY * 1000;
+
+// Privy looks this up by walletClientType and has no wildcard/default timeout setting.
+export const PRIVY_SIGNATURE_REQUEST_TIMEOUTS = new Proxy({} as Record<string, number>, {
+  get: (_target, walletClientType) =>
+    typeof walletClientType === "string" ? PRIVY_WALLET_REQUEST_TIMEOUT_MS : undefined,
+});
 
 export function getSupportedChains(): [Chain, ...Chain[]] {
   const defaultChain = getViemChain(DEFAULT_SETTLEMENT_CHAIN_ID);

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -25,16 +25,16 @@ import { LRUCache } from "sdk/utils/LruCache";
 export { PRIVY_APP_ID };
 
 export const PRIVY_WALLET_LIST = [
-  "detected_ethereum_wallets",
   "metamask",
+  "phantom",
   "rabby_wallet",
-  "wallet_connect_qr",
   "coinbase_wallet",
-  "safe",
-  "binance",
   "base_account",
   "okx_wallet",
-  "phantom",
+  "binance",
+  "safe",
+  "detected_ethereum_wallets",
+  "wallet_connect_qr",
   "wallet_connect",
 ] as const;
 

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -16,7 +16,6 @@ import { isDevelopment } from "config/env";
 import { PRIVY_APP_ID } from "config/privy";
 import { getRpcProviders, RpcConfig } from "config/rpc";
 import { RpcPurpose } from "config/rpc";
-import { SECONDS_IN_DAY } from "lib/dates";
 import { metrics, ViemWsClientConnected, ViemWsClientDisconnected, ViemWsClientError } from "lib/metrics";
 import { getWsUrl } from "lib/rpc";
 import { AnyChainId, VIEM_CHAIN_BY_CHAIN_ID } from "sdk/configs/chains";
@@ -39,14 +38,6 @@ export const PRIVY_WALLET_LIST = [
 ] as const;
 
 export const PRIVY_LOGIN_METHODS = ["wallet", "email", "google", "twitter", "discord"] as const;
-
-const PRIVY_WALLET_REQUEST_TIMEOUT_MS = SECONDS_IN_DAY * 1000;
-
-// Privy looks this up by walletClientType and has no wildcard/default timeout setting.
-export const PRIVY_SIGNATURE_REQUEST_TIMEOUTS = new Proxy({} as Record<string, number>, {
-  get: (_target, walletClientType) =>
-    typeof walletClientType === "string" ? PRIVY_WALLET_REQUEST_TIMEOUT_MS : undefined,
-});
 
 export function getSupportedChains(): [Chain, ...Chain[]] {
   const defaultChain = getViemChain(DEFAULT_SETTLEMENT_CHAIN_ID);

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -25,16 +25,16 @@ import { LRUCache } from "sdk/utils/LruCache";
 export { PRIVY_APP_ID };
 
 export const PRIVY_WALLET_LIST = [
+  "detected_ethereum_wallets",
   "metamask",
-  "phantom",
   "rabby_wallet",
+  "wallet_connect_qr",
   "coinbase_wallet",
+  "safe",
+  "binance",
   "base_account",
   "okx_wallet",
-  "binance",
-  "safe",
-  "detected_ethereum_wallets",
-  "wallet_connect_qr",
+  "phantom",
   "wallet_connect",
 ] as const;
 


### PR DESCRIPTION
## Summary
- remove the custom Privy wagmi active-wallet selector that picked the first linked or first detected wallet
- rely on `@privy-io/wagmi` connect/create success sync instead of re-entering wagmi connect from our modal callback
- call Privy's `connectWallet` for already-authenticated sessions, and keep `connectOrCreateWallet` for unauthenticated login/create flows
- guard the connect modal against duplicate user-triggered MetaMask connect requests while one is pending
- mark all Privy-backed wagmi connectors disconnected on account disconnect to avoid reconnecting stale injected wallets
- keep the global 24-hour Privy wallet request timeout guard
- restore the previous Privy wallet list ordering

## Root Cause Covered By This PR
The previous `setActiveWalletForWagmi` callback selected `wallets.find((wallet) => wallet.linked) ?? wallets[0]`. With multiple injected wallets, linked/detected order can be Phantom or another stale provider, and the custom adapter path bypasses Privy's recent-wallet handling.

Privy's wagmi adapter already handles `connectOrCreateWallet` success by removing the disconnected marker, setting `recentConnectorId`, and reconnecting wagmi. Calling `useSetActiveWallet` from our success callback can call wagmi `connect()` again before the adapter's reconnect has settled, which can trigger a second MetaMask connect prompt. Disconnect only affected the current wagmi connector, so another Privy wallet still present in `useWallets()` could reconnect.

A separate MetaMask reconnect issue happens after disconnecting directly inside the MetaMask extension: wagmi becomes disconnected, but the Privy session can remain authenticated. Privy's `connectOrCreateWallet` is only valid for unauthenticated sessions, so reconnecting from our button could no-op with Privy's "User must be unauthenticated" warning. The modal now uses `connectWallet` in that authenticated/disconnected state.

Linear: [FEDEV-3928](https://linear.app/gmx-io/issue/FEDEV-3928/fix-privy-active-wallet-intent-and-auto-connect-regressions)
