### PR TITLE
remove sendTokens from relay oracle params fedev-3950

### DIFF
--- a/sdk/src/utils/express/utils/oracleParamsUtils.ts
+++ b/sdk/src/utils/express/utils/oracleParamsUtils.ts
@@ -5,7 +5,6 @@ import { getContract } from "configs/contracts";
 import { MARKETS } from "configs/markets";
 import { convertTokenAddress } from "configs/tokens";
 import { getOppositeCollateralFromConfig } from "utils/markets";
-import type { ExternalCallsPayload } from "utils/orderTransactions";
 
 import type { OracleParamsPayload } from "../types";
 
@@ -27,19 +26,13 @@ export function getOracleParamsForRelayParams({
   gasPaymentTokenAddress,
   relayerFeeTokenAddress,
   feeSwapPath,
-  externalCalls,
 }: {
   chainId: ContractsChainId;
   gasPaymentTokenAddress: string;
   relayerFeeTokenAddress: string;
   feeSwapPath: string[];
-  externalCalls: ExternalCallsPayload | undefined;
 }): OracleParamsPayload {
   const tokenAddresses = [gasPaymentTokenAddress, relayerFeeTokenAddress];
-
-  if (externalCalls) {
-    tokenAddresses.push(...externalCalls.sendTokens);
-  }
 
   if (feeSwapPath.length) {
     tokenAddresses.push(

--- a/sdk/src/utils/express/utils/relayParamsUtils.ts
+++ b/sdk/src/utils/express/utils/relayParamsUtils.ts
@@ -228,7 +228,6 @@ export function getRawRelayerParams({
 }): RawRelayParamsPayload {
   const oracleParams = getOracleParamsForRelayParams({
     chainId,
-    externalCalls,
     feeSwapPath: feeParams.feeSwapPath,
     gasPaymentTokenAddress,
     relayerFeeTokenAddress,


### PR DESCRIPTION
Send tokens of external swaps don't need atomic prices: the external call executes at aggregator prices and the order itself is executed by keepers. Including them assigns ChainlinkPriceFeedProvider to tokens without a Chainlink feed (e.g. MEGA on MegaETH), reverting every express tx with EmptyChainlinkPriceFeed.