### PR TITLE
Fix mark price line flicker caused by zombie candle subscriptions FEDEV-3858

### DIFF
--- a/src/components/TVChartContainer/TVChartContainer.tsx
+++ b/src/components/TVChartContainer/TVChartContainer.tsx
@@ -569,7 +569,7 @@ export default function TVChartContainer({
 
   useEffect(() => {
     markPriceDirectionRef.current = undefined;
-  }, [theme]);
+  }, [chainId, datafeed, theme]);
 
   useEffect(() => {
     if (!datafeed) return;
@@ -578,11 +578,13 @@ export default function TVChartContainer({
       if (!chartReady || !tvWidgetRef.current) return;
 
       const detail = (event as CustomEvent).detail as {
+        symbol: string;
         resolution: ResolutionString;
         bar: { open: number; close: number };
       };
 
       if (tvWidgetRef.current.activeChart().resolution() !== detail.resolution) return;
+      if (tvWidgetRef.current.activeChart().symbolExt()?.name !== detail.symbol) return;
 
       const direction =
         detail.bar.close > detail.bar.open ? "up" : detail.bar.close < detail.bar.open ? "down" : "flat";

--- a/src/lib/PauseableInterval.spec.ts
+++ b/src/lib/PauseableInterval.spec.ts
@@ -176,6 +176,41 @@ describe("PauseableInterval", () => {
     expect(mockCallback).toHaveBeenCalledTimes(callCount);
   });
 
+  it("should stop calling callback when destroyed during async callback execution", async () => {
+    const mockCallback = vi.fn().mockImplementation(async ({ lastReturnedValue }) => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return ((lastReturnedValue as number) || 0) + 1;
+    });
+    const interval = 1000;
+
+    const pauseableInterval = new PauseableInterval<number>(mockCallback, interval);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+
+    pauseableInterval.destroy();
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not resume after destroy", async () => {
+    const mockCallback = vi.fn();
+    const interval = 1000;
+
+    const pauseableInterval = new PauseableInterval(mockCallback, interval);
+
+    await vi.advanceTimersByTimeAsync(0);
+    const callCount = mockCallback.mock.calls.length;
+
+    pauseableInterval.destroy();
+    pauseableInterval.resume();
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(mockCallback).toHaveBeenCalledTimes(callCount);
+  });
+
   it("should handle pause called during synchronous callback execution", async () => {
     let callbackStarted = false;
     const mockCallback = vi.fn().mockImplementation(({ lastReturnedValue }) => {

--- a/src/lib/PauseableInterval.ts
+++ b/src/lib/PauseableInterval.ts
@@ -7,7 +7,7 @@ export class PauseableInterval<T = undefined> {
   private timerId: number | undefined;
   private wasPausedSinceLastCall = false;
   private lastReturnedValue: Awaited<T> | undefined;
-  private state: "paused" | "running" = "running";
+  private state: "paused" | "running" | "destroyed" = "running";
 
   constructor(
     private cb: PauseableIntervalFunction<T>,
@@ -17,7 +17,7 @@ export class PauseableInterval<T = undefined> {
   }
 
   pause() {
-    if (this.state === "paused") {
+    if (this.state !== "running") {
       return;
     }
 
@@ -30,10 +30,11 @@ export class PauseableInterval<T = undefined> {
   destroy() {
     window.clearTimeout(this.timerId);
     this.timerId = undefined;
+    this.state = "destroyed";
   }
 
   resume() {
-    if (this.state === "running") {
+    if (this.state !== "paused") {
       return;
     }
 
@@ -65,7 +66,7 @@ export class PauseableInterval<T = undefined> {
         this.wasPausedSinceLastCall = false;
       }
 
-      if (this.state === "paused") {
+      if (this.state !== "running") {
         this.timerId = undefined;
         return;
       }


### PR DESCRIPTION
PauseableInterval.destroy() only cleared the pending timer: an in-flight async tick still saw state === "running" afterwards and rescheduled the loop forever. Every symbol/resolution/theme switch with a candles request in flight leaked such a poller, which kept dispatching currentCandle.update events. The mark price line handler filtered them by resolution only, so bars from leaked subscriptions of other symbols kept recoloring the line — green/red/grey flashes detached from the visible candle.

- Stop the polling loop for good on destroy()
- Drop currentCandle.update events whose symbol does not match the active chart
- Reset the cached line direction whenever the widget is re-created (chainId/datafeed/theme), not only on theme change