### PR TITLE
Hotfix: update Arbitrum Goldsky subgraph URL

### DIFF
--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -21,7 +21,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
     referrals:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-arbitrum-referrals/master-240506225935-51167d5/gn",
     syntheticsStats:
-      "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-250410222518-4486206/gn",
+      "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-260605170830-1049f5c/gn",
     subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
   },
 


### PR DESCRIPTION
## Summary
- Updates the Arbitrum `syntheticsStats` Goldsky endpoint to the new `master-260605170830-1049f5c` deployment.
- Replaces the previous deployment that returned `_meta.hasIndexingErrors: true` / `indexing_error`.

## Validation
- Probed the new Goldsky endpoint with `_meta { block { number } deployment hasIndexingErrors }`; response was `hasIndexingErrors: false`.
- `node node_modules/.bin/eslint src/config/indexers.ts --max-warnings=0`
- `git diff --check`
- Pre-push hook completed successfully, including Vitest suites, production build, and Playwright component tests.