### PR TITLE
Fix infinite positions loading on delisted markets and large accounts fedev-3964

### DIFF
--- a/src/domain/synthetics/positions/usePositions.ts
+++ b/src/domain/synthetics/positions/usePositions.ts
@@ -6,7 +6,11 @@ import { getContract } from "config/contracts";
 import { hashedPositionKey } from "config/dataStore";
 import { FreshnessMetricId, metrics, MissedMarketPricesCounter } from "lib/metrics";
 import { freshnessMetrics } from "lib/metrics/reportFreshnessMetric";
-import { useMulticall } from "lib/multicall";
+import { executeMulticall, useMulticall } from "lib/multicall";
+import type { ContractCallConfig, MulticallRequestConfig } from "lib/multicall";
+import { serializeMulticallErrors } from "lib/multicall/utils";
+import { getByKey } from "lib/objects";
+import { sleep } from "lib/sleep";
 import { FREQUENT_MULTICALL_REFRESH_INTERVAL } from "lib/timeConstants";
 import { abis } from "sdk/abis";
 import { getContractMarketPrices } from "sdk/utils/markets";
@@ -19,10 +23,19 @@ import { useOptimisticPositions } from "./useOptimisticPositions";
 
 export { getPendingMockPosition } from "./useOptimisticPositions";
 
+const MAX_POSITIONS_COUNT = 1000n;
+const RAW_POSITIONS_TIMEOUT = 60_000;
+const POSITIONS_INFO_CHUNK_SIZE = 40;
+
 type PositionsResult = {
   positionsData?: PositionsData;
   allPossiblePositionsKeys?: string[];
   error?: Error;
+};
+
+type RawPositionResult = {
+  addresses: { account: string; market: string; collateralToken: string };
+  flags: { isLong: boolean };
 };
 
 type PositionInfoResult = {
@@ -51,6 +64,12 @@ type PositionInfoResult = {
   };
   basePnlUsd: bigint;
 };
+
+type PositionsInfoRequestConfig = MulticallRequestConfig<{
+  reader: {
+    calls: Record<string, ContractCallConfig>;
+  };
+}>;
 
 export function usePositions(
   chainId: ContractsChainId,
@@ -86,36 +105,99 @@ export function usePositions(
     keepPreviousData: true,
     disableBatching,
 
-    request: (requestChainId) => {
+    request: async (requestChainId): Promise<PositionsInfoRequestConfig> => {
+      const rawPositionsResult = await Promise.race([
+        sleep(RAW_POSITIONS_TIMEOUT).then(() => Promise.reject(new Error("getAccountPositions timeout"))),
+        executeMulticall(
+          requestChainId,
+          {
+            reader: {
+              contractAddress: getContract(requestChainId, "SyntheticsReader"),
+              abiId: "SyntheticsReader",
+              calls: {
+                positions: {
+                  methodName: "getAccountPositions",
+                  params: [
+                    getContract(requestChainId, "DataStore"),
+                    account!,
+                    0n,
+                    MAX_POSITIONS_COUNT,
+                  ] satisfies ContractFunctionParameters<
+                    typeof abis.SyntheticsReader,
+                    "view",
+                    "getAccountPositions"
+                  >["args"],
+                },
+              },
+            },
+          },
+          "urgent",
+          "usePositionsRaw"
+        ),
+      ]);
+
+      const rawPositions = rawPositionsResult.data.reader?.positions?.returnValues as RawPositionResult[] | undefined;
+
+      if (!rawPositionsResult.success || !rawPositions) {
+        throw new Error(`getAccountPositions request failed: ${serializeMulticallErrors(rawPositionsResult.errors)}`);
+      }
+
+      const positionsKeys: `0x${string}`[] = [];
+      const positionsPrices: ContractMarketPrices[] = [];
+
+      for (const rawPosition of rawPositions) {
+        const { account: positionAccount, market: marketAddress, collateralToken } = rawPosition.addresses;
+
+        const market = getByKey(marketsData, marketAddress);
+        const marketPrices = market && tokensData ? getContractMarketPrices(tokensData, market) : undefined;
+
+        if (!marketPrices) {
+          metrics.pushCounter<MissedMarketPricesCounter>("missedMarketPrices", {
+            marketName: market?.name ?? marketAddress,
+            source: "usePositions",
+          });
+          continue;
+        }
+
+        positionsKeys.push(
+          hashedPositionKey(positionAccount, marketAddress, collateralToken, rawPosition.flags.isLong) as `0x${string}`
+        );
+        positionsPrices.push(marketPrices);
+      }
+
+      const chunksCount = Math.max(1, Math.ceil(positionsKeys.length / POSITIONS_INFO_CHUNK_SIZE));
+      const standalone = chunksCount > 1;
+
+      const calls: Record<string, ContractCallConfig> = {};
+
+      for (let i = 0; i < chunksCount; i++) {
+        const from = i * POSITIONS_INFO_CHUNK_SIZE;
+        const to = from + POSITIONS_INFO_CHUNK_SIZE;
+
+        calls[`positions_${i}`] = {
+          methodName: "getPositionInfoList",
+          params: [
+            getContract(requestChainId, "DataStore"),
+            getContract(requestChainId, "ReferralStorage"),
+            positionsKeys.slice(from, to),
+            positionsPrices.slice(from, to),
+            // uiFeeReceiver
+            zeroAddress,
+          ] satisfies ContractFunctionParameters<typeof abis.SyntheticsReader, "view", "getPositionInfoList">["args"],
+          standalone,
+        };
+      }
+
       return {
         reader: {
           contractAddress: getContract(requestChainId, "SyntheticsReader"),
           abiId: "SyntheticsReader",
-          calls: {
-            positions: {
-              methodName: "getAccountPositionInfoList",
-              params: [
-                getContract(requestChainId, "DataStore"),
-                getContract(requestChainId, "ReferralStorage"),
-                account!,
-                keysAndPrices.marketsKeys,
-                keysAndPrices.marketsPrices,
-                // uiFeeReceiver
-                zeroAddress,
-                0n,
-                1000n,
-              ] satisfies ContractFunctionParameters<
-                typeof abis.SyntheticsReader,
-                "view",
-                "getAccountPositionInfoList"
-              >["args"],
-            },
-          },
+          calls,
         },
       };
     },
     parseResponse: (res, chainId) => {
-      const positions = res.data.reader.positions.returnValues;
+      const positions = Object.values(res.data.reader).flatMap((call) => call.returnValues as PositionInfoResult[]);
 
       freshnessMetrics.reportThrottled(chainId, FreshnessMetricId.Positions);
 
@@ -195,7 +277,6 @@ function useKeysAndPricesParams(p: {
   return useMemo(() => {
     const values = {
       allPositionsKeys: [] as string[],
-      marketsPrices: [] as ContractMarketPrices[],
       marketsKeys: [] as string[],
     };
 
@@ -221,7 +302,6 @@ function useKeysAndPricesParams(p: {
       }
 
       values.marketsKeys.push(market.marketTokenAddress);
-      values.marketsPrices.push(marketPrices);
 
       const collaterals = market.isSameCollaterals
         ? [market.longTokenAddress]

--- a/src/lib/multicall/Multicall.ts
+++ b/src/lib/multicall/Multicall.ts
@@ -76,6 +76,9 @@ export class Multicall {
 
     const encodedPayload: { address: string; abi: any; functionName: string; args: any }[] = [];
 
+    const batchedIndexes: number[] = [];
+    const standaloneIndexes: number[] = [];
+
     const contractKeys = Object.keys(request);
 
     contractKeys.forEach((contractKey) => {
@@ -106,6 +109,8 @@ export class Multicall {
           contractKey,
           callKey,
         });
+
+        (call.standalone ? standaloneIndexes : batchedIndexes).push(encodedPayload.length);
 
         encodedPayload.push({
           address: contractCallConfig.contractAddress,
@@ -233,6 +238,42 @@ export class Multicall {
 
         const timeoutController = new AbortController();
 
+        const batchSize =
+          typeof BATCH_CONFIGS[this.chainId]?.client?.multicall === "object"
+            ? (BATCH_CONFIGS[this.chainId].client!.multicall as { batchSize?: number }).batchSize
+            : undefined;
+
+        const executeCalls = async () => {
+          const response: MulticallResponseItem[] = new Array(encodedPayload.length);
+
+          await Promise.all([
+            batchedIndexes.length
+              ? client
+                  .multicall({
+                    contracts: batchedIndexes.map((index) => encodedPayload[index]) as any,
+                    batchSize,
+                  })
+                  .then((results) => {
+                    results.forEach((item, i) => {
+                      response[batchedIndexes[i]] = item as MulticallResponseItem;
+                    });
+                  })
+              : undefined,
+            ...standaloneIndexes.map((index) =>
+              client
+                .multicall({
+                  contracts: [encodedPayload[index]] as any,
+                  batchSize,
+                })
+                .then(([item]) => {
+                  response[index] = item as MulticallResponseItem;
+                })
+            ),
+          ]);
+
+          return response;
+        };
+
         return await Promise.race([
           sleepWithSignal(debugShouldTimeout ? 100 : MAX_PRIMARY_TIMEOUT, timeoutController.signal).then(() => {
             sendDebugEvent("primary-timeout", { providerUrl });
@@ -261,13 +302,7 @@ export class Multicall {
 
             return Promise.reject(new Error("multicall timeout"));
           }),
-          client.multicall({
-            contracts: encodedPayload as any,
-            batchSize:
-              typeof BATCH_CONFIGS[this.chainId]?.client?.multicall === "object"
-                ? (BATCH_CONFIGS[this.chainId].client!.multicall as { batchSize?: number }).batchSize
-                : undefined,
-          }),
+          executeCalls(),
         ])
           .then((response) => {
             timeoutController.abort();

--- a/src/lib/multicall/executeMulticall.ts
+++ b/src/lib/multicall/executeMulticall.ts
@@ -35,6 +35,7 @@ type MulticallFetcherConfig = {
         abiId: AbiId;
         methodName: string;
         params: any[];
+        standalone?: boolean;
       };
       handlers: {
         [requestId: string]: {
@@ -265,6 +266,7 @@ export async function executeMulticall<TConfig extends MulticallRequestConfig<an
             abiId: callGroup.abiId,
             methodName: call.methodName,
             params: call.params,
+            standalone: call.standalone,
           },
           handlers: {},
         };
@@ -368,6 +370,7 @@ function getRequest(callEntries: [string, { callData: MulticallFetcherConfig[num
     requests[contractAbiKey].calls[callId] = {
       methodName: callData.methodName,
       params: callData.params,
+      standalone: callData.standalone,
     };
   }
 

--- a/src/lib/multicall/types.ts
+++ b/src/lib/multicall/types.ts
@@ -8,6 +8,8 @@ export type SkipKey = null | undefined | false;
 export type ContractCallConfig = {
   methodName: string;
   params: any[];
+  /** Execute in a dedicated RPC request with its own gas budget, instead of the shared Multicall3 call. */
+  standalone?: boolean;
 };
 
 export type ContractCallsConfig<T extends { calls: any }> = {


### PR DESCRIPTION
A position on a market without an oracle keeper price (e.g. delisted WELL/OM) made getAccountPositionInfoList revert the whole call with EmptyMarketPrice on every RPC, so the Positions tab loaded forever. Accounts with ~90+ positions also exceeded the eth_call gas cap of public RPCs, with the same outcome.

Read the raw positions list via getAccountPositions first, skip positions on markets without known prices, then query infos with getPositionInfoList by explicit position keys. Positions on priceless markets are hidden until prices are available and reported via the missedMarketPrices counter.

Position infos are queried in chunks of 40: a single chunk stays in the shared Multicall3 aggregation, several chunks are executed as standalone eth_calls (new `standalone` flag in multicall) so each gets its own gas budget and stays under the ~50M eth_call cap of public RPCs (empirically 90 positions fit a single call, 100 do not).

The raw positions read is raced with a 60s timeout: the batched executeMulticall promise never settles if the whole batch fails (e.g. all RPC endpoints are down), and useMulticall's built-in timeout covers only the main request, so without the race one such episode would freeze positions loading permanently.