### PR TITLE
Hotfix SPCX pre-IPO announcement copy

### DIFF
--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -45,14 +45,15 @@ export const appEventsData: EventData[] = [
     isActive: true,
     startDate: "08 Jun 2026, 12:00",
     endDate: "09 Jun 2026, 12:00",
-    flagId: "showSpcxPreIpoArbitrumListing",
+    flagId: "showSpcxPreIpoArbitrumListingUpdated",
     chains: [ARBITRUM],
     title: "SPCX Pre-IPO market added on Arbitrum",
     bodyText: (
       <>
-        <Link to="/trade">Trade</Link> SpaceX (SPCX) Pre-IPO perpetuals 24/7 with up to 10x leverage, or{" "}
-        <Link to="/pools">provide liquidity</Link> via GLV <span className="text-slate-100">[WETH-USDC]</span>. Find it
-        under the TradFi Pre-IPO category in the market dropdown.
+        <Link to="/trade">Trade</Link> pre-IPO SpaceX perpetuals with up to 10x leverage, 24/7. SPCX/USD is a new type
+        of market for GMX, launching with limited initial OI capacity. Caps and trading parameters may change around the
+        IPO, and opening or increasing positions may be unavailable when caps are reached.{" "}
+        <ExternalLink href="https://x.com/GMX_IO/status/2064418523657470193">Read more</ExternalLink>.
       </>
     ),
   },

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -41,10 +41,10 @@ export const WELL_DELISTING_EVENT_ID = "well-delisting";
 
 export const appEventsData: EventData[] = [
   {
-    id: "spcx-pre-ipo-arbitrum-listing",
+    id: "spcx-pre-ipo-arbitrum-listing-updated",
     isActive: true,
-    startDate: "08 Jun 2026, 12:00",
-    endDate: "09 Jun 2026, 12:00",
+    startDate: "09 Jun 2026, 12:00",
+    endDate: "16 Jun 2026, 12:00",
     flagId: "showSpcxPreIpoArbitrumListingUpdated",
     chains: [ARBITRUM],
     title: "SPCX Pre-IPO market added on Arbitrum",


### PR DESCRIPTION
## Summary

- Updates the SPCX pre-IPO announcement copy with the current limited initial OI capacity guidance.
- Adds the GMX X post as a `Read more` link.
- Updates the KLI flag id to `showSpcxPreIpoArbitrumListingUpdated` so the refreshed banner can be controlled separately.

## Notes

This targets `master` using the `hotfix-*` branch and `Hotfix` title required by the PR naming check.