### PR TITLE
Show visual multiplier prefix in tradebox size amount FEDEV-3970

### DIFF
--- a/src/components/TradeboxMarginFields/SizeField.tsx
+++ b/src/components/TradeboxMarginFields/SizeField.tsx
@@ -32,22 +32,24 @@ export function SizeField({
   onFocus,
   qa,
 }: Props) {
+  const tokenLabel = indexToken ? `${getTokenVisualMultiplier(indexToken)}${indexToken.symbol}` : undefined;
+
   const alternateValue = useMemo(() => {
     if (displayMode === "token") {
       return formatUsd(sizeInUsd ?? 0n, { fallbackToZero: true });
     } else {
       if (sizeInTokens === undefined || !indexToken) return "0";
       const visualMultiplier = BigInt(indexToken.visualMultiplier ?? 1);
-      return formatTokenAmount(sizeInTokens / visualMultiplier, indexToken.decimals, indexToken.symbol);
+      return formatTokenAmount(sizeInTokens / visualMultiplier, indexToken.decimals, tokenLabel);
     }
-  }, [displayMode, sizeInUsd, sizeInTokens, indexToken]);
+  }, [displayMode, sizeInUsd, sizeInTokens, indexToken, tokenLabel]);
 
   return (
     <TradeInputField
       label={<Trans>Size</Trans>}
       alternateValue={alternateValue}
       tokenSymbol={indexToken?.symbol}
-      tokenLabel={indexToken ? `${getTokenVisualMultiplier(indexToken)}${indexToken.symbol}` : undefined}
+      tokenLabel={tokenLabel}
       displayMode={displayMode}
       onDisplayModeChange={onDisplayModeChange}
       inputValue={inputValue}

--- a/src/components/TradeboxMarginFields/__tests__/SizeField.spec.tsx
+++ b/src/components/TradeboxMarginFields/__tests__/SizeField.spec.tsx
@@ -1,0 +1,43 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { expandDecimals } from "lib/numbers";
+import type { TokenData } from "sdk/utils/tokens/types";
+
+import { SizeField } from "../SizeField";
+
+beforeAll(() => {
+  i18n.load("en", {});
+  i18n.activate("en");
+});
+
+afterEach(cleanup);
+
+const pepeToken = {
+  symbol: "PEPE",
+  decimals: 18,
+  visualMultiplier: 1000,
+  visualPrefix: "k",
+} as TokenData;
+
+describe("SizeField", () => {
+  it("shows the visual multiplier prefix in the alternate token amount", () => {
+    render(
+      <I18nProvider i18n={i18n}>
+        <SizeField
+          sizeInTokens={expandDecimals(1000, 18)}
+          sizeInUsd={expandDecimals(4, 30)}
+          indexToken={pepeToken}
+          displayMode="usd"
+          onDisplayModeChange={vi.fn()}
+          inputValue="4"
+          onInputValueChange={vi.fn()}
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.getByText(/≈1\.0000\s*kPEPE/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Reuse the visual multiplier token label when rendering the tradebox Size alternate token amount.
- Add a regression test for a PEPE-like token using `kPEPE`.

## Details
The amount was already scaled by `visualMultiplier`, but the formatted symbol used `indexToken.symbol`, so visually scaled markets could show the raw token symbol in the approximate size text.

Linear: https://linear.app/gmx-io/issue/FEDEV-3970/show-visual-multiplier-prefix-in-tradebox-size-token-amount
