### PR TITLE
Fix GLV simulation price path FEDEV-3971

### DIFF
--- a/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
@@ -633,6 +633,7 @@ export const useDepositTransactions = ({
           executionGasLimit: fees.gasLimit,
           skipSimulation: shouldDisableValidation,
           tokensData,
+          glvToken: glvInfo!.glvToken,
           blockTimestampData,
           setPendingTxns,
           setPendingDeposit,
@@ -649,6 +650,7 @@ export const useDepositTransactions = ({
     [
       isDeposit,
       getDepositMetricData,
+      glvInfo,
       tokensData,
       signer,
       rawParams,

--- a/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
@@ -592,7 +592,9 @@ export const useDepositTransactions = ({
           }
         });
       } else if (paySource === "settlementChain") {
-        if (!tokensData) {
+        const glvToken = glvInfo?.glvToken;
+
+        if (!tokensData || !glvToken) {
           helperToast.error(t`Error submitting order`, {
             tradingErrorInfo: {
               actionName: "GM Deposit",
@@ -633,7 +635,7 @@ export const useDepositTransactions = ({
           executionGasLimit: fees.gasLimit,
           skipSimulation: shouldDisableValidation,
           tokensData,
-          glvToken: glvInfo!.glvToken,
+          glvToken,
           blockTimestampData,
           setPendingTxns,
           setPendingDeposit,

--- a/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -325,6 +325,7 @@ export const useWithdrawalTransactions = ({
           params: params as CreateGlvWithdrawalParams,
           executionGasLimit: fees.gasLimit,
           tokensData,
+          glvToken: glvInfo!.glvToken,
           setPendingTxns,
           setPendingWithdrawal,
           blockTimestampData,
@@ -342,6 +343,7 @@ export const useWithdrawalTransactions = ({
     [
       isWithdrawal,
       getWithdrawalMetricData,
+      glvInfo,
       amounts,
       transferRequests,
       tokensData,

--- a/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -310,8 +310,9 @@ export const useWithdrawalTransactions = ({
         });
       } else if (paySource === "settlementChain") {
         const fees = technicalFees?.kind === "settlementChain" ? technicalFees.fees : undefined;
+        const glvToken = glvInfo?.glvToken;
 
-        if (!fees || !tokensData) {
+        if (!fees || !tokensData || !glvToken) {
           helperToast.error(t`Order submission failed`, {
             tradingErrorInfo: { actionName: "GM Withdrawal", requestId: metricData.requestId },
           });
@@ -325,7 +326,7 @@ export const useWithdrawalTransactions = ({
           params: params as CreateGlvWithdrawalParams,
           executionGasLimit: fees.gasLimit,
           tokensData,
-          glvToken: glvInfo!.glvToken,
+          glvToken,
           setPendingTxns,
           setPendingWithdrawal,
           blockTimestampData,

--- a/src/domain/synthetics/markets/createGlvDepositTxn.ts
+++ b/src/domain/synthetics/markets/createGlvDepositTxn.ts
@@ -15,7 +15,7 @@ import { validateSignerAddress } from "components/Errors/errorToasts";
 
 import { prepareOrderTxn } from "../orders/prepareOrderTxn";
 import { simulateExecuteTxn } from "../orders/simulateExecuteTxn";
-import type { TokensData } from "../tokens";
+import type { TokenData, TokensData } from "../tokens";
 import type { CreateGlvDepositParams } from "./types";
 
 export async function createGlvDepositTxn({
@@ -30,6 +30,7 @@ export async function createGlvDepositTxn({
   executionFee,
   executionGasLimit,
   tokensData,
+  glvToken,
   skipSimulation,
   metricId,
   blockTimestampData,
@@ -45,6 +46,7 @@ export async function createGlvDepositTxn({
   executionFee: bigint;
   executionGasLimit: bigint;
   tokensData: TokensData;
+  glvToken: TokenData;
   skipSimulation?: boolean;
   metricId?: OrderMetricId;
   blockTimestampData: BlockTimestampData | undefined;
@@ -111,11 +113,13 @@ export async function createGlvDepositTxn({
     })
   );
 
+  const simulationTokensData = { ...tokensData, [glvToken.address]: glvToken };
+
   const simulationPromise = !skipSimulation
     ? simulateExecuteTxn(chainId, {
         account: params.addresses.receiver,
         primaryPriceOverrides: {},
-        tokensData,
+        tokensData: simulationTokensData,
         createMulticallPayload: encodedPayload,
         method: "simulateExecuteLatestGlvDeposit",
         errorTitle: t`Deposit error`,

--- a/src/domain/synthetics/markets/createGlvDepositTxn.ts
+++ b/src/domain/synthetics/markets/createGlvDepositTxn.ts
@@ -113,6 +113,7 @@ export async function createGlvDepositTxn({
     })
   );
 
+  // GLV tokens are not regular tokensData entries; include the selected GLV price for simulation.
   const simulationTokensData = { ...tokensData, [glvToken.address]: glvToken };
 
   const simulationPromise = !skipSimulation

--- a/src/domain/synthetics/markets/createGlvWithdrawalTxn.ts
+++ b/src/domain/synthetics/markets/createGlvWithdrawalTxn.ts
@@ -17,7 +17,7 @@ import { validateSignerAddress } from "components/Errors/errorToasts";
 import { SwapPricingType } from "../orders";
 import { prepareOrderTxn } from "../orders/prepareOrderTxn";
 import { simulateExecuteTxn } from "../orders/simulateExecuteTxn";
-import type { TokensData } from "../tokens";
+import type { TokenData, TokensData } from "../tokens";
 import type { CreateGlvWithdrawalParams } from "./types";
 
 export async function createGlvWithdrawalTxn({
@@ -26,6 +26,7 @@ export async function createGlvWithdrawalTxn({
   executionGasLimit,
   skipSimulation,
   tokensData,
+  glvToken,
   metricId,
   blockTimestampData,
   params,
@@ -38,6 +39,7 @@ export async function createGlvWithdrawalTxn({
   executionGasLimit: bigint;
   skipSimulation?: boolean;
   tokensData: TokensData;
+  glvToken: TokenData;
   metricId?: OrderMetricId;
   blockTimestampData: BlockTimestampData | undefined;
   params: CreateGlvWithdrawalParams;
@@ -87,11 +89,13 @@ export async function createGlvWithdrawalTxn({
     })
   );
 
+  const simulationTokensData = { ...tokensData, [glvToken.address]: glvToken };
+
   const simulationPromise = !skipSimulation
     ? simulateExecuteTxn(chainId, {
         account: params.addresses.receiver,
         primaryPriceOverrides: {},
-        tokensData: tokensData,
+        tokensData: simulationTokensData,
         createMulticallPayload: encodedPayload,
         method: "simulateExecuteLatestGlvWithdrawal",
         errorTitle: t`Withdrawal error`,

--- a/src/domain/synthetics/markets/createGlvWithdrawalTxn.ts
+++ b/src/domain/synthetics/markets/createGlvWithdrawalTxn.ts
@@ -89,6 +89,7 @@ export async function createGlvWithdrawalTxn({
     })
   );
 
+  // GLV tokens are not regular tokensData entries; include the selected GLV price for simulation.
   const simulationTokensData = { ...tokensData, [glvToken.address]: glvToken };
 
   const simulationPromise = !skipSimulation

--- a/src/domain/synthetics/markets/useGlvMarkets.ts
+++ b/src/domain/synthetics/markets/useGlvMarkets.ts
@@ -32,6 +32,7 @@ import { getTokenBySymbol } from "sdk/configs/tokens";
 import { GlvInfoData, MarketsInfoData, getContractMarketPrices, getGlvMarketName } from ".";
 import { convertToContractTokenPrices, getBalanceTypeFromSrcChainId } from "../tokens";
 import { TokenData, TokensData } from "../tokens/types";
+import { useTokenRecentPricesRequest } from "../tokens/useTokenRecentPricesData";
 
 export type GlvList = {
   glv: {
@@ -74,6 +75,7 @@ export function useGlvMarketsInfo(
   } = params;
 
   const { websocketTokenBalancesUpdates, resetTokensBalancesUpdates } = useTokensBalancesUpdates();
+  const { pricesData } = useTokenRecentPricesRequest(chainId, { enabled });
 
   const dataStoreAddress = enabled ? getContract(chainId, "DataStore") : "";
   const glvReaderAddress = enabled ? getContract(chainId, "GlvReader") : "";
@@ -124,9 +126,7 @@ export function useGlvMarketsInfo(
           throw new Error("Not all required data is loaded");
         }
 
-        const request = glvs.reduce<
-          MulticallRequestConfig
-        >((acc, { glv, markets }) => {
+        const request = glvs.reduce<MulticallRequestConfig>((acc, { glv, markets }) => {
           const glvLongToken = tokensData[glv.longToken];
           const glvShortToken = tokensData[glv.shortToken];
 
@@ -290,6 +290,10 @@ export function useGlvMarketsInfo(
       const [valueMin] = glvRawData[glv.glvToken + "-glvValue"].glvValueMin.returnValues as [bigint, bigint, bigint];
       const [priceMin, , totalSupply] = pricesMin;
       const [priceMax] = pricesMax;
+      const glvTokenPrices = pricesData?.[glv.glvToken] ?? {
+        minPrice: priceMin,
+        maxPrice: priceMax,
+      };
 
       const glvName = getGlvMarketName(chainId, glv.glvToken)!;
 
@@ -312,10 +316,7 @@ export function useGlvMarketsInfo(
       } = {
         ...tokenConfig,
         address: glv.glvToken,
-        prices: {
-          minPrice: priceMin,
-          maxPrice: priceMax,
-        },
+        prices: glvTokenPrices,
         totalSupply,
         balanceType: getBalanceTypeFromSrcChainId(srcChainId),
         balance,
@@ -377,7 +378,7 @@ export function useGlvMarketsInfo(
     });
 
     return result;
-  }, [chainId, glvRawData, glvs, marketsInfoData, multichainMarketTokensBalances, srcChainId, tokensData]);
+  }, [chainId, glvRawData, glvs, marketsInfoData, multichainMarketTokensBalances, pricesData, srcChainId, tokensData]);
 
   // TODO MLTCH: use updated tokens balances hook
   // useUpdatedTokensBalances()

--- a/src/domain/synthetics/tokens/useTokenRecentPricesData.spec.ts
+++ b/src/domain/synthetics/tokens/useTokenRecentPricesData.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { ARBITRUM } from "config/chains";
+
+import { getPriceTokenConfig } from "./useTokenRecentPricesData";
+
+describe("getPriceTokenConfig", () => {
+  it("resolves known GLV ticker addresses", () => {
+    const glvToken = getPriceTokenConfig(ARBITRUM, "0x528a5bac7e746c9a509a1f4f6df58a03d44279f9");
+
+    expect(glvToken?.address).toBe("0x528A5bac7E746C9A509A1f4F6dF58A03d44279F9");
+    expect(glvToken?.symbol).toBe("GLV");
+    expect(glvToken?.decimals).toBe(18);
+  });
+
+  it("ignores unknown ticker addresses", () => {
+    const token = getPriceTokenConfig(ARBITRUM, "0x0000000000000000000000000000000000000001");
+
+    expect(token).toBeUndefined();
+  });
+});

--- a/src/domain/synthetics/tokens/useTokenRecentPricesData.ts
+++ b/src/domain/synthetics/tokens/useTokenRecentPricesData.ts
@@ -2,13 +2,14 @@ import { useMemo } from "react";
 import { useLocation } from "react-router-dom";
 
 import { ContractsChainId } from "config/chains";
+import { GLV_MARKETS } from "config/markets";
 import { parseContractPrice, TokenPricesData } from "domain/synthetics/tokens";
 import { FreshnessMetricId, metrics, TickersErrorsCounter, TickersPartialDataCounter } from "lib/metrics";
 import { freshnessMetrics } from "lib/metrics/reportFreshnessMetric";
 import { _debugOracleKeeper } from "lib/oracleKeeperFetcher/_debug";
 import { useOracleKeeperFetcher } from "lib/oracleKeeperFetcher/useOracleKeeperFetcher";
 import { LEADERBOARD_PRICES_UPDATE_INTERVAL, PRICES_CACHE_TTL, PRICES_UPDATE_INTERVAL } from "lib/timeConstants";
-import { getToken, getWrappedToken, NATIVE_TOKEN_ADDRESS } from "sdk/configs/tokens";
+import { getToken, getTokenBySymbol, getWrappedToken, NATIVE_TOKEN_ADDRESS } from "sdk/configs/tokens";
 import type { Token } from "sdk/utils/tokens/types";
 
 import { useSequentialTimedSWR } from "./useSequentialTimedSWR";
@@ -56,13 +57,8 @@ export function useTokenRecentPricesRequest(
       const result: TokenPricesData = {};
 
       priceItems.forEach((priceItem) => {
-        let tokenConfig: Token;
-
-        try {
-          tokenConfig = getToken(chainId, priceItem.tokenAddress);
-        } catch (e) {
-          // ignore unknown token errors
-
+        const tokenConfig = getPriceTokenConfig(chainId, priceItem.tokenAddress);
+        if (!tokenConfig) {
           return;
         }
 
@@ -129,4 +125,23 @@ export function useTokenRecentPricesRequest(
     error,
     isPriceDataLoading: isLoading,
   };
+}
+
+export function getPriceTokenConfig(chainId: ContractsChainId, tokenAddress: string): Token | undefined {
+  try {
+    return getToken(chainId, tokenAddress);
+  } catch (e) {
+    const glvConfig = Object.values(GLV_MARKETS[chainId] ?? {}).find(
+      (glv) => glv.glvTokenAddress.toLowerCase() === tokenAddress.toLowerCase()
+    );
+
+    if (!glvConfig) {
+      return undefined;
+    }
+
+    return {
+      ...getTokenBySymbol(chainId, "GLV"),
+      address: glvConfig.glvTokenAddress,
+    };
+  }
 }


### PR DESCRIPTION
Linear: https://linear.app/gmx-io/issue/FEDEV-3971/fix-glv-simulation-when-new-constituent-prices-are-not-ui-listed

## Root cause

GLV execution can use the GLV primary price to value the vault without requiring primary prices for every constituent market. The UI was dropping direct GLV ticker prices because concrete GLV addresses are not normal static tokens, so GLV simulation fell back to constituent prices and could fail with `EmptyPrimaryPrice` for newly staged markets such as SPCX.

## Changes

- Preserve ticker prices for configured GLV token addresses.
- Prefer direct GLV ticker prices in GLV market data when available.
- Include the selected GLV token price in settlement-chain GLV deposit and withdrawal simulations.
- Add a focused regression test for GLV ticker address handling.