### PR TITLE
Fix account position list order row FEDEV-3978

### DIFF
--- a/src/components/PositionItem/PositionItem.tsx
+++ b/src/components/PositionItem/PositionItem.tsx
@@ -55,6 +55,7 @@ export type Props = {
   isLarge: boolean;
   onOrdersClick?: (key?: string) => void;
   onCancelOrder?: (orderKey: string) => void;
+  hideOrderActions?: boolean;
 };
 
 export function PositionItem(p: Props) {
@@ -484,7 +485,11 @@ export function PositionItem(p: Props) {
                   )
                 : formatUsd(p.position.sizeInUsd)}
             </span>
-            <PositionItemOrdersLarge positionKey={p.position.key} onOrdersClick={p.onOrdersClick} />
+            <PositionItemOrdersLarge
+              positionKey={p.position.key}
+              onOrdersClick={p.onOrdersClick}
+              hideActions={p.hideOrderActions}
+            />
           </div>
         </TableTd>
         <TableTd>
@@ -729,12 +734,16 @@ export function PositionItem(p: Props) {
             </div>
           )}
         </AppCardSection>
-        <AppCardSection className="border-b-0">
+        <AppCardSection className="!border-b-0">
           <div className="font-medium text-typography-secondary">
             <Trans>Orders</Trans>
           </div>
 
-          <PositionItemOrdersSmall positionKey={p.position.key} onOrdersClick={p.onOrdersClick} />
+          <PositionItemOrdersSmall
+            positionKey={p.position.key}
+            onOrdersClick={p.onOrdersClick}
+            hideActions={p.hideOrderActions}
+          />
         </AppCardSection>
 
         <div ref={closeSentinelRef} />

--- a/src/components/PositionItem/PositionItemOrders.tsx
+++ b/src/components/PositionItem/PositionItemOrders.tsx
@@ -34,9 +34,11 @@ import { TwapOrderProgress } from "../OrderItem/OrderItem";
 export function PositionItemOrdersSmall({
   positionKey,
   onOrdersClick,
+  hideActions,
 }: {
   positionKey: string;
   onOrdersClick?: (key?: string) => void;
+  hideActions?: boolean;
 }) {
   const ordersWithErrors = usePositionOrdersWithErrors(positionKey);
 
@@ -45,7 +47,12 @@ export function PositionItemOrdersSmall({
   return (
     <div className="flex flex-col gap-8">
       {ordersWithErrors.map((params) => (
-        <PositionItemOrder key={params.order.key} onOrdersClick={onOrdersClick} {...params} />
+        <PositionItemOrder
+          key={params.order.key}
+          onOrdersClick={onOrdersClick}
+          hideActions={hideActions}
+          {...params}
+        />
       ))}
     </div>
   );
@@ -54,9 +61,11 @@ export function PositionItemOrdersSmall({
 export function PositionItemOrdersLarge({
   positionKey,
   onOrdersClick,
+  hideActions,
 }: {
   positionKey: string;
   onOrdersClick?: (key?: string) => void;
+  hideActions?: boolean;
 }) {
   const ordersWithErrors = usePositionOrdersWithErrors(positionKey);
 
@@ -100,7 +109,12 @@ export function PositionItemOrdersLarge({
               <Trans>Active orders</Trans>
             </div>
             {ordersWithErrors.map((params) => (
-              <PositionItemOrder key={params.order.key} onOrdersClick={onOrdersClick} {...params} />
+              <PositionItemOrder
+                key={params.order.key}
+                onOrdersClick={onOrdersClick}
+                hideActions={hideActions}
+                {...params}
+              />
             ))}
           </div>
         }
@@ -113,10 +127,12 @@ function PositionItemOrder({
   order,
   orderErrors,
   onOrdersClick,
+  hideActions,
 }: {
   order: PositionOrderInfo;
   orderErrors: OrderErrors;
   onOrdersClick?: (key?: string) => void;
+  hideActions?: boolean;
 }) {
   const [, setEditingOrderState] = useEditingOrderState();
   const [isCancelling, cancel] = useCancelOrder(order);
@@ -150,16 +166,17 @@ function PositionItemOrder({
             <ChevronRightIcon className="ml-4 size-14" />
           </div>
         </Button>
-        {!isTwapOrder(order) && !isMarketOrderType(order.orderType) && (
+        {!hideActions && !isTwapOrder(order) && !isMarketOrderType(order.orderType) && (
           <Button variant="secondary" onClick={handleEditClick} className="px-8">
             <EditIcon className="size-16" />
           </Button>
         )}
-        {disabledCancelMarketOrderMessage ? (
-          <TooltipWithPortal handle={cancelButton} content={disabledCancelMarketOrderMessage} />
-        ) : (
-          cancelButton
-        )}
+        {!hideActions &&
+          (disabledCancelMarketOrderMessage ? (
+            <TooltipWithPortal handle={cancelButton} content={disabledCancelMarketOrderMessage} />
+          ) : (
+            cancelButton
+          ))}
       </div>
 
       {errors.length !== 0 && (

--- a/src/components/PositionList/PositionList.tsx
+++ b/src/components/PositionList/PositionList.tsx
@@ -33,10 +33,18 @@ type Props = {
   onCancelOrder: (key: string) => void;
   openSettings: () => void;
   hideActions?: boolean;
+  hideOrderActions?: boolean;
 };
 
 export function PositionList(p: Props) {
-  const { onClosePositionClick, onOrdersClick, onSelectPositionClick, onCancelOrder, hideActions } = p;
+  const {
+    onClosePositionClick,
+    onOrdersClick,
+    onSelectPositionClick,
+    onCancelOrder,
+    hideActions,
+    hideOrderActions,
+  } = p;
   const positionsInfoData = usePositionsInfoData();
   const chainId = useSelector(selectChainId);
   const showPnlAfterFees = useSelector(selectShowPnlAfterFees);
@@ -87,6 +95,7 @@ export function PositionList(p: Props) {
                   isLarge={false}
                   onShareClick={handleSharePositionClick}
                   hideActions={hideActions}
+                  hideOrderActions={hideOrderActions}
                   onCancelOrder={onCancelOrder}
                 />
               ))}
@@ -157,6 +166,7 @@ export function PositionList(p: Props) {
                     isLarge
                     onShareClick={handleSharePositionClick}
                     hideActions={hideActions}
+                    hideOrderActions={hideOrderActions}
                     onCancelOrder={onCancelOrder}
                   />
                 ))}
@@ -206,6 +216,7 @@ const PositionItemWrapper = memo(
     onSelectPositionClick,
     onShareClick,
     onCancelOrder,
+    hideOrderActions,
   }: {
     position: PositionInfo;
     onEditCollateralClick: (positionKey: string) => void;
@@ -216,6 +227,7 @@ const PositionItemWrapper = memo(
     onShareClick: (positionKey: string) => void;
     hideActions: boolean | undefined;
     onCancelOrder: (orderKey: string) => void;
+    hideOrderActions: boolean | undefined;
   }) => {
     const { account } = useWallet();
     const showPnlAfterFees = useSelector(selectShowPnlAfterFees);
@@ -241,7 +253,7 @@ const PositionItemWrapper = memo(
       [onOrdersClick, position.key]
     );
 
-    const isShareAvailable = account === position.account;
+    const isPositionOwner = account === position.account;
 
     return (
       <PositionItem
@@ -253,8 +265,9 @@ const PositionItemWrapper = memo(
         showPnlAfterFees={showPnlAfterFees}
         isLarge={isLarge}
         hideActions={hideActions}
+        hideOrderActions={hideOrderActions}
         onCancelOrder={handleCancelOrder}
-        onShareClick={isShareAvailable ? handleShareClick : undefined}
+        onShareClick={isPositionOwner ? handleShareClick : undefined}
       />
     );
   }

--- a/src/pages/AccountDashboard/HistoricalLists.tsx
+++ b/src/pages/AccountDashboard/HistoricalLists.tsx
@@ -11,6 +11,7 @@ import { selectOrdersCount } from "context/SyntheticsStateContext/selectors/orde
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { OrderTypeFilterValue } from "domain/synthetics/orders/ordersFilters";
 import { useLocalStorageSerializeKey } from "lib/localStorage";
+import useWallet from "lib/wallets/useWallet";
 import type { ContractsChainId } from "sdk/configs/chains";
 
 import Badge, { BadgeIndicator } from "components/Badge/Badge";
@@ -95,11 +96,13 @@ function useTabLabels(): Record<TabKey, React.ReactNode> {
 
 export function HistoricalLists({ chainId, account }: Props) {
   const [tabKey, setTabKey] = useLocalStorageSerializeKey(getAccountDashboardTabKey(chainId), TabKey.Positions);
+  const { account: walletAccount } = useWallet();
 
   const tabLabels = useTabLabels();
 
   const [marketsDirectionsFilter, setMarketsDirectionsFilter] = useState<MarketFilterLongShortItemData[]>([]);
   const [orderTypesFilter, setOrderTypesFilter] = useState<OrderTypeFilterValue[]>([]);
+  const hideOrderActions = !walletAccount || walletAccount !== account;
 
   const handleOrdersClick = useCallback(() => {
     setTabKey(TabKey.Orders);
@@ -143,6 +146,7 @@ export function HistoricalLists({ chainId, account }: Props) {
           openSettings={noop}
           onCancelOrder={noop}
           hideActions
+          hideOrderActions={hideOrderActions}
         />
       )}
       {tabKey === TabKey.Orders && (


### PR DESCRIPTION
## Summary
- Hide account page position-list order actions for unauthenticated viewers or when the connected account does not own the viewed account.
- Keep order edit/cancel actions available in the trade/synthetics position list.
- Explicitly suppress the final Orders section bottom border in the mobile/card position layout.

## Root Cause
The Orders card section inherited the shared `AppCardSection` bottom border. The account dashboard also used the shared position-list order row without an ownership-aware read-only gate, so unauthenticated/non-owner viewers could see edit and cancel actions.

Linear: https://linear.app/gmx-io/issue/FEDEV-3978/fix-account-position-list-order-row-visual-and-actions