### PR TITLE
Hotfix update SPCX IPO event

### DIFF
--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -37,17 +37,17 @@ export const homeEventsData: EventData[] = [];
 
 export const appEventsData: EventData[] = [
   {
-    id: "spcx-pre-ipo-arbitrum-listing-updated",
+    id: "spcx-ipo-arbitrum-listing-updated",
     isActive: true,
     startDate: "09 Jun 2026, 12:00",
     endDate: "16 Jun 2026, 12:00",
     flagId: "showSpcxPreIpoArbitrumListingUpdated",
     chains: [ARBITRUM],
-    title: "SPCX Pre-IPO market added on Arbitrum",
+    title: "SPCX IPO market added on Arbitrum",
     bodyText: (
       <>
-        <Link to="/trade">Trade</Link> pre-IPO SpaceX perpetuals with up to 10x leverage, 24/7. SPCX/USD is a new type
-        of market for GMX, launching with limited initial OI capacity. Caps and trading parameters may change around the
+        <Link to="/trade">Trade</Link> SpaceX IPO perpetuals with up to 10x leverage, 24/7. SPCX/USD is a new type of
+        market for GMX, launching with limited initial OI capacity. Caps and trading parameters may change following the
         IPO, and opening or increasing positions may be unavailable when caps are reached.{" "}
         <ExternalLink href="https://x.com/GMX_IO/status/2064418523657470193">Read more</ExternalLink>.
       </>


### PR DESCRIPTION
Updates the active SPCX listing announcement to reflect that the SpaceX market is now an IPO market rather than a pre-IPO market.

The event ID is also updated so users who dismissed the old pre-IPO announcement can see the IPO wording, while the existing UI flag remains in place for remote activation.
