### PR TITLE
Hotfix move SPCX to Stocks after IPO FEDEV-3895

### DIFF
--- a/sdk/src/configs/tokens.ts
+++ b/sdk/src/configs/tokens.ts
@@ -1252,7 +1252,7 @@ export const TOKENS: { [chainId: number]: Token[] } = {
       address: "0x8CBd0d5d81e7957123E6D8fFaE657a40bDC5691b",
       isSynthetic: true,
       decimals: 18,
-      categories: ["tradfi", "pre-ipo"],
+      categories: ["tradfi", "stocks"],
       searchAliases: ["Space", "X"],
       explorerUrl: "https://arbiscan.io/token/0x8CBd0d5d81e7957123E6D8fFaE657a40bDC5691b",
     },

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -255,7 +255,7 @@ function MarketsList() {
   const populatedTradfiSubCats = useMemo(() => {
     const set = new Set<SubCategoryTab>();
     if (!options) return set;
-    for (const cat of ["pre-ipo", "commodities", "stocks", "indices", "fx"] as const) {
+    for (const cat of ["stocks", "pre-ipo", "commodities", "indices", "fx"] as const) {
       if (options.some((o) => o.categories?.includes(cat))) set.add(cat);
     }
     return set;

--- a/src/components/ChartTokenSelector/__tests__/marketFilters.spec.ts
+++ b/src/components/ChartTokenSelector/__tests__/marketFilters.spec.ts
@@ -15,7 +15,7 @@ const tokens = [
   { address: "0xfet", categories: ["ai"] },
   { address: "0xtao", categories: ["layer1", "ai"] },
   { address: "0xgold", categories: ["tradfi", "commodities"] },
-  { address: "0xspcx", categories: ["tradfi", "pre-ipo"] },
+  { address: "0xspcx", categories: ["tradfi", "stocks"] },
   { address: "0xusdc", categories: undefined },
 ] as any[];
 
@@ -85,12 +85,20 @@ describe("applySubCategoryFilter", () => {
     expect(result.map((t) => t.address)).toEqual(["0xgold"]);
   });
 
-  it("filters to pre-IPO within tradfi", () => {
+  it("filters to stocks within tradfi", () => {
+    const result = applySubCategoryFilter(tokens, {
+      topLevelTab: "tradfi",
+      subCategoryTab: "stocks",
+    });
+    expect(result.map((t) => t.address)).toEqual(["0xspcx"]);
+  });
+
+  it("returns empty pre-IPO after SPCX moves to stocks", () => {
     const result = applySubCategoryFilter(tokens, {
       topLevelTab: "tradfi",
       subCategoryTab: "pre-ipo",
     });
-    expect(result.map((t) => t.address)).toEqual(["0xspcx"]);
+    expect(result).toEqual([]);
   });
 
   it("ignores sub-cat when parent is not crypto/tradfi", () => {

--- a/src/components/GmList/GmList.tsx
+++ b/src/components/GmList/GmList.tsx
@@ -83,13 +83,8 @@ export function GmList({
   const { userEarnings } = useUserEarnings(chainId, srcChainId);
   const { orderBy, direction, getSorterProps } = useSorterHandlers<SortField>("gm-list");
   const [searchText, setSearchText] = useState("");
-  const {
-    topLevelTab,
-    subCategoryTab,
-    setSubCategoryTab,
-    favoriteTokens,
-    toggleFavoriteToken,
-  } = useTokensFavorites("gm-list");
+  const { topLevelTab, subCategoryTab, setSubCategoryTab, favoriteTokens, toggleFavoriteToken } =
+    useTokensFavorites("gm-list");
   const localizedSubCategoryLabels = useLocalizedMap(subCategoryTabLabels);
 
   const { listingDateByIndexToken } = useMarketsListingDates(chainId);
@@ -123,7 +118,7 @@ export function GmList({
   const populatedTradfiSubCats = useMemo(() => {
     const set = new Set<SubCategoryTab>();
     if (!marketsInfo) return set;
-    for (const cat of ["pre-ipo", "commodities", "stocks", "indices", "fx"] as const) {
+    for (const cat of ["stocks", "pre-ipo", "commodities", "indices", "fx"] as const) {
       const found = Object.values(marketsInfo).some(
         (m) => !m.isSpotOnly && !m.isDisabled && m.indexToken?.categories?.includes(cat)
       );

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -42,7 +42,7 @@ export const appEventsData: EventData[] = [
     startDate: "12 Jun 2026, 12:00",
     endDate: "19 Jun 2026, 12:00",
     chains: [ARBITRUM],
-    title: "SpaceX pre-IPO market is now a stock perp on Arbitrum",
+    title: "SpaceX pre-IPO market is now a 24/7 stock perp on Arbitrum",
     bodyText: (
       <>
         SpaceX pre-IPO market transitioned into a stock market. <Link to="/trade">Trade SPCX</Link> under TradFi &gt;

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -37,19 +37,16 @@ export const homeEventsData: EventData[] = [];
 
 export const appEventsData: EventData[] = [
   {
-    id: "spcx-pre-ipo-arbitrum-listing-updated",
+    id: "spcx-stock-arbitrum-transition",
     isActive: true,
-    startDate: "09 Jun 2026, 12:00",
-    endDate: "16 Jun 2026, 12:00",
-    flagId: "showSpcxPreIpoArbitrumListingUpdated",
+    startDate: "12 Jun 2026, 12:00",
+    endDate: "19 Jun 2026, 12:00",
     chains: [ARBITRUM],
-    title: "SPCX Pre-IPO market added on Arbitrum",
+    title: "SpaceX pre-IPO market is now a stock perp on Arbitrum",
     bodyText: (
       <>
-        <Link to="/trade">Trade</Link> pre-IPO SpaceX perpetuals with up to 10x leverage, 24/7. SPCX/USD is a new type
-        of market for GMX, launching with limited initial OI capacity. Caps and trading parameters may change around the
-        IPO, and opening or increasing positions may be unavailable when caps are reached.{" "}
-        <ExternalLink href="https://x.com/GMX_IO/status/2064418523657470193">Read more</ExternalLink>.
+        SpaceX pre-IPO market transitioned into a stock market. <Link to="/trade">Trade SPCX</Link> under TradFi &gt;
+        Stocks. Existing positions transitioned automatically.
       </>
     ),
   },

--- a/src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
+++ b/src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
@@ -46,9 +46,9 @@ export const cryptoSubCategoryOptions: CryptoSubCategory[] = ["all", "ai", "laye
 
 export const tradfiSubCategoryOptions: TradfiSubCategory[] = [
   "all",
+  "stocks",
   "pre-ipo",
   "commodities",
-  "stocks",
   "indices",
   "fx",
 ];


### PR DESCRIPTION
## Summary

- Move SPCX from TradFi > Pre-IPO to TradFi > Stocks for the post-IPO state.
- Replace the old pre-IPO announcement with the stock-transition announcement.
- Put populated Stocks before Commodities in TradFi filters and update the selector test for the emptied Pre-IPO category.

Linear: https://linear.app/gmx-io/issue/FEDEV-3895/list-spcx-spacex-pre-ipo-and-ipo-launch-stock-perp-on-arbitrum
