### PR TITLE
Fix Audit check: ignore dev-server vite advisories (1120784, 1120789)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run security audit
-        run: yarn npm audit --severity moderate --no-deprecations --ignore 1112686 --ignore 1116005 --ignore 1116229 --ignore 1120011 --ignore 1120126
+        run: yarn npm audit --severity moderate --no-deprecations --ignore 1112686 --ignore 1116005 --ignore 1116229 --ignore 1120011 --ignore 1120126 --ignore 1120784 --ignore 1120789
 
       - name: Install SDK dependencies
         run: |
@@ -38,4 +38,4 @@ jobs:
       - name: Run SDK security audit
         run: |
           cd sdk
-          yarn npm audit --severity moderate --no-deprecations --ignore 1112686 --ignore 1116005 --ignore 1116229 --ignore 1120011 --ignore 1120126
+          yarn npm audit --severity moderate --no-deprecations --ignore 1112686 --ignore 1116005 --ignore 1116229 --ignore 1120011 --ignore 1120126 --ignore 1120784 --ignore 1120789


### PR DESCRIPTION
## Summary

The `Audit` CI check fails on the main project. Two new `vite` advisories were published, and the app's vite tree is entirely `<=6.4.2` (vulnerable): direct dep `^5.4.18` → `5.4.21`, plus `@playwright/experimental-ct-core` → `6.4.1` and `vitest@2.1.9` → `5.4.0`.

| ID | Severity | Issue |
|----|----------|-------|
| 1120789 | high | vite `server.fs.deny` bypass on Windows alternate paths ([GHSA-fx2h-pf6j-xcff](https://github.com/advisories/GHSA-fx2h-pf6j-xcff)) |
| 1120784 | moderate | `launch-editor` NTLMv2 hash disclosure on Windows, pulled in via vite's dev-server "open in editor" ([GHSA-v6wh-96g9-6wx3](https://github.com/advisories/GHSA-v6wh-96g9-6wx3)) |

Both are **dev-server / Windows-only** issues in build tooling — they do not affect the production bundle shipped to users.

## Change

Add `1120784` and `1120789` to the `--ignore` list in both `yarn npm audit` commands in `.github/workflows/audit.yml`, matching the existing convention used for prior advisories. Both audit invocations pass after the change.

## Follow-up (separate, larger change)

Real remediation means upgrading vite `5 → ≥6.4.3 / 7.x`, likely `vitest 2 → 3` (note: the lockfile is on `2.1.9` while `package.json` declares `^3.0.5`), and revalidating the build, dev server, and Playwright component tests.