### PR TITLE
Hotfix: add markets staleness detection with global RPC fallback

### DIFF
--- a/sdk/src/utils/markets/types.ts
+++ b/sdk/src/utils/markets/types.ts
@@ -250,7 +250,9 @@ export type RawMarketsInfoData = {
   [marketAddress: string]: RawMarketInfo;
 };
 
-export type RawMarketValues = Pick<RawMarketInfo, "marketTokenAddress" | keyof MarketValues>;
+export type RawMarketValues = Pick<RawMarketInfo, "marketTokenAddress" | keyof MarketValues> & {
+  updatedAt: number | null;
+};
 
 export type RawMarketConfig = Omit<RawMarketInfo, keyof MarketValues>;
 

--- a/sdk/src/utils/markets/utils.ts
+++ b/sdk/src/utils/markets/utils.ts
@@ -490,10 +490,7 @@ export function composeRawMarketsInfoData({
   return data;
 }
 
-export function mergeMarketsConfigValues(
-  configs: RawMarketConfig[],
-  values: RawMarketValues[]
-): RawMarketsInfoData {
+export function mergeMarketsConfigValues(configs: RawMarketConfig[], values: RawMarketValues[]): RawMarketsInfoData {
   const valuesByAddress = new Map(values.map((value) => [value.marketTokenAddress, value]));
   const data: RawMarketsInfoData = {};
 
@@ -503,7 +500,8 @@ export function mergeMarketsConfigValues(
       continue;
     }
 
-    data[config.marketTokenAddress] = { ...config, ...value } as RawMarketInfo;
+    const { updatedAt: _updatedAt, ...valueFields } = value;
+    data[config.marketTokenAddress] = { ...config, ...valueFields } as RawMarketInfo;
   }
 
   return data;

--- a/src/domain/api/apiHealthTracker.spec.ts
+++ b/src/domain/api/apiHealthTracker.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ContractsChainId } from "sdk/configs/chains";
+
+import { ApiHealthTracker } from "./apiHealthTracker";
+
+const COOLDOWN_MS = 15_000;
+
+const tracker = ApiHealthTracker.getInstance();
+
+// Each test uses a distinct chainId so the shared singleton's per-chain state stays isolated.
+describe("ApiHealthTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is a singleton", () => {
+    expect(ApiHealthTracker.getInstance()).toBe(tracker);
+  });
+
+  it("defaults to healthy for an unseen chain", () => {
+    expect(tracker.isHealthy(111 as ContractsChainId)).toBe(true);
+  });
+
+  it("goes unhealthy immediately on a stale report", () => {
+    const chainId = 222 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(false);
+  });
+
+  it("stays unhealthy while fresh but within the restore cooldown", () => {
+    const chainId = 333 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(COOLDOWN_MS - 1);
+    tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(false);
+  });
+
+  it("restores once freshness holds continuously for the cooldown", () => {
+    const chainId = 444 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(COOLDOWN_MS);
+    tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+  });
+
+  it("resets the cooldown when staleness recurs during recovery", () => {
+    const chainId = 555 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(10_000);
+    tracker.reportMarketsFreshness(chainId, false);
+    vi.setSystemTime(12_000);
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(20_000);
+    tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(false);
+
+    vi.setSystemTime(12_000 + COOLDOWN_MS);
+    tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+  });
+
+  it("isolates health per chain", () => {
+    const chainA = 666 as ContractsChainId;
+    const chainB = 777 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainA, true);
+    expect(tracker.isHealthy(chainA)).toBe(false);
+    expect(tracker.isHealthy(chainB)).toBe(true);
+  });
+
+  it("notifies subscribers on a health flip", () => {
+    const chainId = 888 as ContractsChainId;
+    const listener = vi.fn();
+    const unsubscribe = tracker.subscribe(listener);
+
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    vi.setSystemTime(COOLDOWN_MS);
+    tracker.reportMarketsFreshness(chainId, false);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domain/api/apiHealthTracker.ts
+++ b/src/domain/api/apiHealthTracker.ts
@@ -1,0 +1,66 @@
+import { useSyncExternalStore } from "react";
+
+import type { ContractsChainId } from "sdk/configs/chains";
+
+// Require continuous freshness for this long before restoring, to avoid flapping at the threshold.
+const RESTORE_COOLDOWN_MS = 15_000;
+
+type ChainHealth = { healthy: boolean; lastStaleAt: number };
+
+export class ApiHealthTracker {
+  private static instance: ApiHealthTracker | null = null;
+
+  static getInstance(): ApiHealthTracker {
+    if (!ApiHealthTracker.instance) {
+      ApiHealthTracker.instance = new ApiHealthTracker();
+    }
+    return ApiHealthTracker.instance;
+  }
+
+  private readonly healthByChain = new Map<ContractsChainId, ChainHealth>();
+  private readonly listeners = new Set<() => void>();
+
+  reportMarketsFreshness(chainId: ContractsChainId, isStale: boolean): void {
+    const now = Date.now();
+    const current = this.healthByChain.get(chainId) ?? { healthy: true, lastStaleAt: 0 };
+
+    if (isStale) {
+      this.healthByChain.set(chainId, { healthy: false, lastStaleAt: now });
+      if (current.healthy) {
+        this.emit();
+      }
+      return;
+    }
+
+    if (!current.healthy && now - current.lastStaleAt >= RESTORE_COOLDOWN_MS) {
+      this.healthByChain.set(chainId, { healthy: true, lastStaleAt: 0 });
+      this.emit();
+    }
+  }
+
+  isHealthy(chainId: ContractsChainId): boolean {
+    return this.healthByChain.get(chainId)?.healthy ?? true;
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  private emit() {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export function useIsApiHealthy(chainId: ContractsChainId): boolean {
+  const tracker = ApiHealthTracker.getInstance();
+  return useSyncExternalStore(
+    tracker.subscribe,
+    () => tracker.isHealthy(chainId),
+    () => true
+  );
+}

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { RawMarketValues } from "sdk/utils/markets/types";
+import type { RawMarketConfig, RawMarketValues } from "sdk/utils/markets/types";
 
 import { MARKETS_STALE_THRESHOLD_MS, hasStaleMarketValues } from "./useApiMarketsInfoRequest";
 
@@ -8,43 +8,76 @@ function value(marketTokenAddress: string, updatedAt: number | null): RawMarketV
   return { marketTokenAddress, updatedAt } as RawMarketValues;
 }
 
+function config(marketTokenAddress: string, isDisabled = false): RawMarketConfig {
+  return { marketTokenAddress, isDisabled } as RawMarketConfig;
+}
+
 describe("hasStaleMarketValues", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("returns false when there is no values data", () => {
-    expect(hasStaleMarketValues(undefined, new Set())).toBe(false);
+  it("returns false when there is no config or values data", () => {
+    expect(hasStaleMarketValues(undefined, undefined, new Set())).toBe(false);
+    expect(hasStaleMarketValues([config("0xa")], undefined, new Set())).toBe(false);
+    expect(hasStaleMarketValues(undefined, [value("0xa", Date.now())], new Set())).toBe(false);
   });
 
   it("treats a recently-updated enabled market as fresh", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000_000);
-    expect(hasStaleMarketValues([value("0xa", 1_000_000 - 1_000)], new Set())).toBe(false);
+    expect(hasStaleMarketValues([config("0xa")], [value("0xa", 1_000_000 - 1_000)], new Set())).toBe(false);
   });
 
   it("flags an enabled market older than the threshold as stale", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000_000);
-    expect(hasStaleMarketValues([value("0xa", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)], new Set())).toBe(true);
+    expect(
+      hasStaleMarketValues([config("0xa")], [value("0xa", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)], new Set())
+    ).toBe(true);
   });
 
   it("flags an enabled market with null updatedAt as stale", () => {
-    expect(hasStaleMarketValues([value("0xa", null)], new Set())).toBe(true);
+    expect(hasStaleMarketValues([config("0xa")], [value("0xa", null)], new Set())).toBe(true);
   });
 
   it("ignores disabled markets even when their values are null or stale", () => {
     const disabled = new Set(["0xdisabled"]);
     vi.useFakeTimers();
     vi.setSystemTime(1_000_000);
-    expect(hasStaleMarketValues([value("0xdisabled", null)], disabled)).toBe(false);
-    expect(hasStaleMarketValues([value("0xdisabled", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)], disabled)).toBe(
-      false
-    );
+    expect(hasStaleMarketValues([config("0xdisabled", true)], [value("0xdisabled", null)], disabled)).toBe(false);
+    expect(
+      hasStaleMarketValues(
+        [config("0xdisabled", true)],
+        [value("0xdisabled", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)],
+        disabled
+      )
+    ).toBe(false);
   });
 
   it("flags stale when an enabled market is stale alongside a disabled one", () => {
     const disabled = new Set(["0xdisabled"]);
-    expect(hasStaleMarketValues([value("0xdisabled", null), value("0xenabled", null)], disabled)).toBe(true);
+    expect(
+      hasStaleMarketValues(
+        [config("0xdisabled", true), config("0xenabled")],
+        [value("0xdisabled", null), value("0xenabled", null)],
+        disabled
+      )
+    ).toBe(true);
+  });
+
+  it("flags stale when an enabled config market has no corresponding value", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    expect(hasStaleMarketValues([config("0xa"), config("0xmissing")], [value("0xa", 1_000_000)], new Set())).toBe(true);
+  });
+
+  it("does not flag stale when missing market is disabled", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const disabled = new Set(["0xmissing"]);
+    expect(
+      hasStaleMarketValues([config("0xa"), config("0xmissing", true)], [value("0xa", 1_000_000)], disabled)
+    ).toBe(false);
   });
 });

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { RawMarketValues } from "sdk/utils/markets/types";
+
+import { MARKETS_STALE_THRESHOLD_MS, hasStaleMarketValues } from "./useApiMarketsInfoRequest";
+
+function value(marketTokenAddress: string, updatedAt: number | null): RawMarketValues {
+  return { marketTokenAddress, updatedAt } as RawMarketValues;
+}
+
+describe("hasStaleMarketValues", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false when there is no values data", () => {
+    expect(hasStaleMarketValues(undefined, new Set())).toBe(false);
+  });
+
+  it("treats a recently-updated enabled market as fresh", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    expect(hasStaleMarketValues([value("0xa", 1_000_000 - 1_000)], new Set())).toBe(false);
+  });
+
+  it("flags an enabled market older than the threshold as stale", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    expect(hasStaleMarketValues([value("0xa", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)], new Set())).toBe(true);
+  });
+
+  it("flags an enabled market with null updatedAt as stale", () => {
+    expect(hasStaleMarketValues([value("0xa", null)], new Set())).toBe(true);
+  });
+
+  it("ignores disabled markets even when their values are null or stale", () => {
+    const disabled = new Set(["0xdisabled"]);
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    expect(hasStaleMarketValues([value("0xdisabled", null)], disabled)).toBe(false);
+    expect(hasStaleMarketValues([value("0xdisabled", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)], disabled)).toBe(
+      false
+    );
+  });
+
+  it("flags stale when an enabled market is stale alongside a disabled one", () => {
+    const disabled = new Set(["0xdisabled"]);
+    expect(hasStaleMarketValues([value("0xdisabled", null), value("0xenabled", null)], disabled)).toBe(true);
+  });
+});

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
@@ -18,18 +18,30 @@ function getApiMarketsConfigRequestKey(chainId: ContractsChainId) {
 }
 
 export function hasStaleMarketValues(
+  configData: RawMarketConfig[] | undefined,
   valuesData: RawMarketValues[] | undefined,
   disabledAddresses: Set<string>
 ): boolean {
-  if (!valuesData) {
+  if (!configData || !valuesData) {
     return false;
   }
+
   const now = Date.now();
-  return valuesData.some(
-    (value) =>
-      !disabledAddresses.has(value.marketTokenAddress) &&
-      (value.updatedAt == null || now - value.updatedAt > MARKETS_STALE_THRESHOLD_MS)
-  );
+  const valuesByAddress = new Map(valuesData.map((v) => [v.marketTokenAddress, v]));
+
+  for (const config of configData) {
+    if (disabledAddresses.has(config.marketTokenAddress)) {
+      continue;
+    }
+
+    const value = valuesByAddress.get(config.marketTokenAddress);
+
+    if (!value || value.updatedAt == null || now - value.updatedAt > MARKETS_STALE_THRESHOLD_MS) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = true }: { enabled?: boolean } = {}) {
@@ -92,19 +104,12 @@ export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = 
     [configData]
   );
 
-  const isMarketsDataStale = useMemo(
-    () => (configData ? hasStaleMarketValues(valuesData, disabledMarketAddresses) : false),
-    [configData, valuesData, disabledMarketAddresses]
-  );
-
-  useEffect(() => {
-    if (!configData) {
-      return;
+  const isMarketsDataStale = useMemo(() => {
+    const stale = hasStaleMarketValues(configData, valuesData, disabledMarketAddresses);
+    if (configData) {
+      ApiHealthTracker.getInstance().reportMarketsFreshness(chainId, stale);
     }
-    ApiHealthTracker.getInstance().reportMarketsFreshness(
-      chainId,
-      hasStaleMarketValues(valuesData, disabledMarketAddresses)
-    );
+    return stale;
   }, [chainId, configData, valuesData, disabledMarketAddresses]);
 
   return {

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
@@ -104,13 +104,10 @@ export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = 
     [configData]
   );
 
-  const isMarketsDataStale = useMemo(() => {
-    const stale = hasStaleMarketValues(configData, valuesData, disabledMarketAddresses);
-    if (configData) {
-      ApiHealthTracker.getInstance().reportMarketsFreshness(chainId, stale);
-    }
-    return stale;
-  }, [chainId, configData, valuesData, disabledMarketAddresses]);
+  const isMarketsDataStale = hasStaleMarketValues(configData, valuesData, disabledMarketAddresses);
+  if (configData) {
+    ApiHealthTracker.getInstance().reportMarketsFreshness(chainId, isMarketsDataStale);
+  }
 
   return {
     marketsInfoData,

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useSWRConfig } from "swr";
 
 import { useGmxSdk } from "context/GmxSdkContext/GmxSdkContext";
+import { ApiHealthTracker } from "domain/api/apiHealthTracker";
 import { useApiDataRequest } from "domain/synthetics/common/useApiDataRequest";
 import { FreshnessMetricId } from "lib/metrics";
 import { CONFIG_UPDATE_INTERVAL } from "lib/timeConstants";
@@ -10,9 +11,25 @@ import { mergeMarketsConfigValues } from "sdk/utils/markets";
 import type { RawMarketConfig, RawMarketsInfoData, RawMarketValues } from "sdk/utils/markets/types";
 
 const CONFIG_REVALIDATION_THROTTLE_MS = 10_000;
+export const MARKETS_STALE_THRESHOLD_MS = 10_000;
 
 function getApiMarketsConfigRequestKey(chainId: ContractsChainId) {
   return ["apiMarketsConfigRequest", chainId] as const;
+}
+
+export function hasStaleMarketValues(
+  valuesData: RawMarketValues[] | undefined,
+  disabledAddresses: Set<string>
+): boolean {
+  if (!valuesData) {
+    return false;
+  }
+  const now = Date.now();
+  return valuesData.some(
+    (value) =>
+      !disabledAddresses.has(value.marketTokenAddress) &&
+      (value.updatedAt == null || now - value.updatedAt > MARKETS_STALE_THRESHOLD_MS)
+  );
 }
 
 export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = true }: { enabled?: boolean } = {}) {
@@ -69,9 +86,30 @@ export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = 
     return mergeMarketsConfigValues(configData, valuesData);
   }, [configData, valuesData]);
 
+  // Exclude disabled markets — they are never pulled (updatedAt null) and would pin the API permanently stale.
+  const disabledMarketAddresses = useMemo(
+    () => new Set((configData ?? []).filter((config) => config.isDisabled).map((config) => config.marketTokenAddress)),
+    [configData]
+  );
+
+  const isMarketsDataStale = useMemo(
+    () => (configData ? hasStaleMarketValues(valuesData, disabledMarketAddresses) : false),
+    [configData, valuesData, disabledMarketAddresses]
+  );
+
+  useEffect(() => {
+    if (!configData) {
+      return;
+    }
+    ApiHealthTracker.getInstance().reportMarketsFreshness(
+      chainId,
+      hasStaleMarketValues(valuesData, disabledMarketAddresses)
+    );
+  }, [chainId, configData, valuesData, disabledMarketAddresses]);
+
   return {
     marketsInfoData,
-    isStale: isValuesStale || isConfigStale,
+    isStale: isValuesStale || isConfigStale || isMarketsDataStale,
     error: valuesError ?? configError,
   };
 }

--- a/src/domain/synthetics/orders/useOrders.ts
+++ b/src/domain/synthetics/orders/useOrders.ts
@@ -4,6 +4,7 @@ import { Address, ContractFunctionReturnType, getAddress, isAddressEqual } from 
 import { ContractsChainId } from "config/chains";
 import { getContract } from "config/contracts";
 import { accountOrderListKey } from "config/dataStore";
+import { useIsApiHealthy } from "domain/api/apiHealthTracker";
 import { useApiDataFallbackState } from "domain/api/useApiDataFallbackState";
 import type { MarketsInfoData } from "domain/synthetics/markets/types";
 import { OrderTypeFilterValue, convertOrderTypeFilterValues } from "domain/synthetics/orders/ordersFilters";
@@ -100,17 +101,16 @@ export function useOrders(
     [account, marketsDirectionsFilter, orderTypesFilter]
   );
 
-  const apiEnabled = useIsApiSdkEnabled(API_UI_FLAGS.orders);
+  // Stale markets ⇒ gmx-api unhealthy ⇒ orders fall back to RPC globally too.
+  const isApiHealthy = useIsApiHealthy(chainId);
+  const apiEnabled = useIsApiSdkEnabled(API_UI_FLAGS.orders) && isApiHealthy;
   const {
     ordersData: apiOrdersData,
     isStale: isApiStale,
     error: apiError,
   } = useApiOrdersRequest(chainId, { account, enabled: apiEnabled });
 
-  const {
-    shouldFallbackToRpc: rpcEnabled,
-    isInitialFallback,
-  } = useApiDataFallbackState({
+  const { shouldFallbackToRpc: rpcEnabled, isInitialFallback } = useApiDataFallbackState({
     chainId,
     apiEnabled,
     apiData: apiOrdersData,

--- a/src/domain/synthetics/positions/usePositionsInfo.ts
+++ b/src/domain/synthetics/positions/usePositionsInfo.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { useIsApiHealthy } from "domain/api/apiHealthTracker";
 import { useApiDataFallbackState } from "domain/api/useApiDataFallbackState";
 import { useUserReferralInfoRequest } from "domain/referrals";
 import { API_UI_FLAGS, useIsApiSdkEnabled } from "domain/synthetics/uiFlags/useIsApiSdkEnabled";
@@ -61,7 +62,9 @@ export function usePositionsInfoRequest(
 ): PositionsInfoResult {
   const { showPnlInLeverage, marketsInfoData, tokensData, account, skipLocalReferralCode = false } = p;
 
-  const isApiSdkEnabled = useIsApiSdkEnabled(API_UI_FLAGS.positions);
+  // Stale markets ⇒ gmx-api unhealthy ⇒ positions fall back to RPC globally too.
+  const isApiHealthy = useIsApiHealthy(chainId);
+  const isApiSdkEnabled = useIsApiSdkEnabled(API_UI_FLAGS.positions) && isApiHealthy;
 
   const {
     positionsInfoData: apiPositionsInfoData,


### PR DESCRIPTION
/markets/values now carries a per-market updatedAt; the UI flags a market stale when it is missing (disabled markets excluded) or older than 10s and reports to a per-chain ApiHealthTracker singleton. While markets are stale the gmx-api is treated as unhealthy and positions/orders fall back to RPC globally; markets keep polling as the recovery canary, restoring after a freshness cooldown.