### PR TITLE
Warn when limit/stop increase may be liquidatable at trigger price FEDEV-2399

### DIFF
--- a/src/components/OrderEditor/OrderEditor.tsx
+++ b/src/components/OrderEditor/OrderEditor.tsx
@@ -80,6 +80,7 @@ import {
 } from "domain/synthetics/trade";
 import { useCloseSizeInput } from "domain/synthetics/trade/useCloseSizeInput";
 import { getExpressError, getIsMaxLeverageExceeded } from "domain/synthetics/trade/utils/validation";
+import { getIsPositionLiquidatableAtPrice } from "domain/synthetics/trade/utils/warnings";
 import { TokensRatioAndSlippage } from "domain/tokens";
 import {
   FULL_POSITION_CLOSE_SIZE_DELTA_USD,
@@ -124,6 +125,7 @@ import SpinnerIcon from "img/ic_spinner.svg?react";
 import { AllowedSwapSlippageInputRow } from "../AllowedSwapSlippageInputRowImpl/AllowedSwapSlippageInputRowImpl";
 import { SyntheticsInfoRow } from "../SyntheticsInfoRow";
 import { ExpressTradingWarningCard } from "../TradeBox/ExpressTradingWarningCard";
+import { LiquidatableIncreaseWarningCard } from "../TradeBox/LiquidatableIncreaseWarningCard";
 
 import "./OrderEditor.scss";
 
@@ -503,6 +505,25 @@ export function OrderEditor(p: Props) {
     expressParams,
     tokensData,
   ]);
+
+  const showLiquidationRiskWarning = useMemo(() => {
+    if (error || !positionOrder || !existingPosition) {
+      return false;
+    }
+
+    const isIncreaseLimitOrStop =
+      isLimitIncreaseOrderType(positionOrder.orderType) || isStopIncreaseOrderType(positionOrder.orderType);
+
+    if (!isIncreaseLimitOrStop) {
+      return false;
+    }
+
+    return getIsPositionLiquidatableAtPrice({
+      liqPrice: nextPositionValuesForIncrease?.nextLiqPrice,
+      price: triggerPrice,
+      isLong: positionOrder.isLong,
+    });
+  }, [error, positionOrder, existingPosition, nextPositionValuesForIncrease, triggerPrice]);
 
   const onSubmit = useCallback(async () => {
     if (!batchParams || !signer || !tokensData || !marketsInfoData || !provider) {
@@ -1022,6 +1043,8 @@ export function OrderEditor(p: Props) {
               />
             </>
           )}
+
+          {showLiquidationRiskWarning && <LiquidatableIncreaseWarningCard />}
 
           <ExpressTradingWarningCard
             expressParams={expressParams}

--- a/src/components/OrderEditor/OrderEditor.tsx
+++ b/src/components/OrderEditor/OrderEditor.tsx
@@ -507,6 +507,7 @@ export function OrderEditor(p: Props) {
   ]);
 
   const showLiquidationRiskWarning = useMemo(() => {
+    // Suppress the warning while a blocking error is shown (mirrors the tradebox selector).
     if (error || !positionOrder || !existingPosition) {
       return false;
     }

--- a/src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+++ b/src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
@@ -1,0 +1,14 @@
+import { Trans } from "@lingui/macro";
+
+import { AlertInfoCard } from "components/AlertInfo/AlertInfoCard";
+
+export function LiquidatableIncreaseWarningCard() {
+  return (
+    <AlertInfoCard type="warning" hideClose>
+      <Trans>
+        This order may fail to execute with the current position state. Add collateral or reduce leverage before it
+        triggers.
+      </Trans>
+    </AlertInfoCard>
+  );
+}

--- a/src/components/TradeBox/TradeBox.tsx
+++ b/src/components/TradeBox/TradeBox.tsx
@@ -56,6 +56,7 @@ import {
   selectTradeboxTradeFlags,
   selectTradeboxTradeRatios,
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
+import { selectTradeboxIncreaseLiquidationRiskWarning } from "context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxTradeErrors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { toastEnableExpress } from "domain/multichain/toastEnableExpress";
 import { useGmxAccountShowDepositButton } from "domain/multichain/useGmxAccountShowDepositButton";
@@ -122,6 +123,7 @@ import ArrowDownIcon from "img/ic_arrow_down.svg?react";
 
 import { useIsCurtainOpen } from "./Curtain";
 import { ExpressTradingWarningCard } from "./ExpressTradingWarningCard";
+import { LiquidatableIncreaseWarningCard } from "./LiquidatableIncreaseWarningCard";
 import { useMultichainTokens } from "../GmxAccountModal/hooks";
 import { HighPriceImpactOrFeesWarningCard } from "../HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard";
 import TradeInfoIcon from "../TradeInfoIcon/TradeInfoIcon";
@@ -242,6 +244,7 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
   const decreaseAmounts = useSelector(selectTradeboxDecreasePositionAmounts);
   const selectedPositionKey = useSelector(selectTradeboxSelectedPositionKey);
   const selectedPosition = useSelector(selectTradeboxSelectedPosition);
+  const showIncreaseLiquidationRiskWarning = useSelector(selectTradeboxIncreaseLiquidationRiskWarning);
 
   const closeSizeHook = useCloseSizeInput({
     positionSizeInUsd: selectedPosition?.sizeInUsd,
@@ -1222,6 +1225,7 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
               </Trans>
             </AlertInfoCard>
           )}
+          {showIncreaseLiquidationRiskWarning && <LiquidatableIncreaseWarningCard />}
           {gasPaymentTokenWarningContent && (
             <AlertInfoCard hideClose type="warning">
               {gasPaymentTokenWarningContent}

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxTradeErrors.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/selectTradeboxTradeErrors.ts
@@ -33,6 +33,7 @@ import {
   getIncreaseError,
   getSwapError,
 } from "domain/synthetics/trade/utils/validation";
+import { getIsPositionLiquidatableAtPrice } from "domain/synthetics/trade/utils/warnings";
 
 const selectTradeboxSwapTradeError = createSelector((q) => {
   const fromToken = q(selectTradeboxFromToken);
@@ -174,4 +175,32 @@ export const selectTradeboxTradeTypeError = createSelector((q) => {
   }
 
   return tradeError;
+});
+
+export const selectTradeboxIncreaseLiquidationRiskWarning = createSelector((q) => {
+  const { isIncrease, isLimit, isLong } = q(selectTradeboxTradeFlags);
+
+  if (!isIncrease || !isLimit) {
+    return false;
+  }
+
+  const existingPosition = q(selectTradeboxSelectedPosition);
+
+  if (!existingPosition) {
+    return false;
+  }
+
+  // Don't stack the warning on top of a blocking error.
+  if (q(selectTradeboxIncreaseTradeError).buttonErrorMessage) {
+    return false;
+  }
+
+  const nextPositionValues = q(selectTradeboxNextPositionValues);
+  const triggerPrice = q(selectTradeboxTriggerPrice);
+
+  return getIsPositionLiquidatableAtPrice({
+    liqPrice: nextPositionValues?.nextLiqPrice,
+    price: triggerPrice,
+    isLong,
+  });
 });

--- a/src/domain/synthetics/trade/utils/__tests__/validation.spec.ts
+++ b/src/domain/synthetics/trade/utils/__tests__/validation.spec.ts
@@ -4,6 +4,7 @@ import { ARBITRUM } from "config/chains";
 import { mockExternalSwapQuote } from "domain/synthetics/testUtils/mocks";
 import { expandDecimals } from "lib/numbers";
 import { mockMarketsInfoData, mockTokensData } from "sdk/test/mock";
+import { TriggerThresholdType } from "sdk/utils/trade/types";
 
 import { getIncreaseError, getSwapError } from "../validation";
 
@@ -145,5 +146,36 @@ describe("getIncreaseError — isExternalSwapLoading gate", () => {
       } as any,
     });
     expect(result.buttonErrorMessage).not.toBe("Insufficient liquidity to swap collateral");
+  });
+});
+
+describe("getIncreaseError — increase liquidation guard is Market-only", () => {
+  const liqGuardParams = {
+    ...baseIncreaseParams,
+    initialCollateralToken: toToken, // USDC == targetCollateralToken → no swap path needed
+    targetCollateralToken: toToken,
+    initialCollateralAmount: expandDecimals(1000, 6), // USDC has 6 decimals; within the mock balance
+    collateralLiquidity: expandDecimals(1_000_000, 30),
+    nextPositionValues: {
+      nextCollateralUsd: expandDecimals(1000, 30),
+      nextLiqPrice: expandDecimals(60000, 30), // > markPrice (50000) → liquidatable for a long
+    } as any,
+    markPrice: expandDecimals(50000, 30),
+    isLong: true,
+  };
+
+  it("Market Increase: blocks with 'Invalid liquidation price' when liquidatable at mark", () => {
+    const result = getIncreaseError({ ...liqGuardParams, isLimit: false, triggerPrice: undefined });
+    expect(result.buttonErrorMessage).toBe("Invalid liquidation price");
+  });
+
+  it("Limit Increase: does NOT block with 'Invalid liquidation price'", () => {
+    const result = getIncreaseError({
+      ...liqGuardParams,
+      isLimit: true,
+      triggerPrice: expandDecimals(49000, 30), // long limit trigger below mark → valid resting
+      thresholdType: TriggerThresholdType.Below,
+    });
+    expect(result.buttonErrorMessage).not.toBe("Invalid liquidation price");
   });
 });

--- a/src/domain/synthetics/trade/utils/__tests__/warnings.spec.ts
+++ b/src/domain/synthetics/trade/utils/__tests__/warnings.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { getIsPositionLiquidatableAtPrice } from "../warnings";
+
+describe("getIsPositionLiquidatableAtPrice", () => {
+  it("long: liquidatable when liqPrice is above the price", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: 110n, price: 100n, isLong: true })).toBe(true);
+  });
+
+  it("long: not liquidatable when liqPrice is below the price", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: 90n, price: 100n, isLong: true })).toBe(false);
+  });
+
+  it("long: not liquidatable at exact equality", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: 100n, price: 100n, isLong: true })).toBe(false);
+  });
+
+  it("short: liquidatable when liqPrice is below the price", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: 90n, price: 100n, isLong: false })).toBe(true);
+  });
+
+  it("short: not liquidatable when liqPrice is above the price", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: 110n, price: 100n, isLong: false })).toBe(false);
+  });
+
+  it("short: not liquidatable at exact equality", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: 100n, price: 100n, isLong: false })).toBe(false);
+  });
+
+  it("returns false when liqPrice is undefined", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: undefined, price: 100n, isLong: true })).toBe(false);
+  });
+
+  it("returns false when price is undefined", () => {
+    expect(getIsPositionLiquidatableAtPrice({ liqPrice: 100n, price: undefined, isLong: true })).toBe(false);
+  });
+});

--- a/src/domain/synthetics/trade/utils/validation.ts
+++ b/src/domain/synthetics/trade/utils/validation.ts
@@ -44,6 +44,7 @@ import {
   TriggerThresholdType,
 } from "sdk/utils/trade/types";
 
+import { getIsPositionLiquidatableAtPrice } from "./warnings";
 import { getMaxUsdBuyableAmountInMarketWithGm, getSellableInfoGlvInMarket, isGlvInfo } from "../../markets/glv";
 
 export enum ValidationButtonTooltipName {
@@ -480,20 +481,17 @@ export function getIncreaseError(p: {
     return { buttonErrorMessage: t`Min position size: ${formatUsd(minPositionSizeUsd)}` };
   }
 
-  if (nextPositionValues?.nextLiqPrice !== undefined && markPrice !== undefined) {
-    if (isLong && nextPositionValues.nextLiqPrice > markPrice) {
-      return {
-        buttonErrorMessage: t`Invalid liquidation price`,
-        buttonTooltipName: ValidationButtonTooltipName.liqPriceGtMarkPrice,
-      };
-    }
-
-    if (!isLong && nextPositionValues.nextLiqPrice < markPrice) {
-      return {
-        buttonErrorMessage: t`Invalid liquidation price`,
-        buttonTooltipName: ValidationButtonTooltipName.liqPriceGtMarkPrice,
-      };
-    }
+  // Market Increase executes at the mark price, so block immediately if the resulting
+  // position would be liquidatable now. Limit/Stop Increase orders rest and are handled
+  // by the non-blocking trigger-price warning instead.
+  if (
+    !isLimit &&
+    getIsPositionLiquidatableAtPrice({ liqPrice: nextPositionValues?.nextLiqPrice, price: markPrice, isLong })
+  ) {
+    return {
+      buttonErrorMessage: t`Invalid liquidation price`,
+      buttonTooltipName: ValidationButtonTooltipName.liqPriceGtMarkPrice,
+    };
   }
 
   if (isTwap && numberOfParts < MIN_TWAP_NUMBER_OF_PARTS) {

--- a/src/domain/synthetics/trade/utils/warnings.ts
+++ b/src/domain/synthetics/trade/utils/warnings.ts
@@ -25,3 +25,17 @@ export function getIsHighExternalSwapFees(externalSwapFees?: FeeItem) {
       bigMath.abs(externalSwapFees.bps) >= HIGH_EXTERNAL_SWAP_FEES_BPS
   );
 }
+
+export function getIsPositionLiquidatableAtPrice(p: {
+  liqPrice: bigint | undefined;
+  price: bigint | undefined;
+  isLong: boolean;
+}): boolean {
+  const { liqPrice, price, isLong } = p;
+
+  if (liqPrice === undefined || price === undefined) {
+    return false;
+  }
+
+  return isLong ? liqPrice > price : liqPrice < price;
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -8372,7 +8372,7 @@ msgstr "Start unrealisierte Gebühren"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr "Diese Order kann mit dem aktuellen Positionsstatus möglicherweise nicht ausgeführt werden. Füge Sicherheiten hinzu oder reduziere den Hebel, bevor sie ausgelöst wird."
+msgstr "Diese Order kann mit dem aktuellen Positionsstatus möglicherweise nicht ausgeführt werden. Fügen Sie Sicherheiten hinzu oder reduzieren Sie den Hebel, bevor sie ausgelöst wird."
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -10109,7 +10109,6 @@ msgstr "Token-Permit-Tests"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "Ungültiger Liquidationspreis"
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -8370,6 +8370,10 @@ msgstr "Unbekannter Wert"
 msgid "Start unrealized fees"
 msgstr "Start unrealisierte Gebühren"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -8372,7 +8372,7 @@ msgstr "Start unrealisierte Gebühren"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "Diese Order kann mit dem aktuellen Positionsstatus möglicherweise nicht ausgeführt werden. Füge Sicherheiten hinzu oder reduziere den Hebel, bevor sie ausgelöst wird."
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -8370,6 +8370,10 @@ msgstr "Unknown value"
 msgid "Start unrealized fees"
 msgstr "Start unrealized fees"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -10109,7 +10109,6 @@ msgstr "Token permit testing"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "Invalid liquidation price"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -10109,7 +10109,6 @@ msgstr "Pruebas de permisos de tokens"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "Precio de liquidación no válido"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -8372,7 +8372,7 @@ msgstr "Comisiones no realizadas iniciales"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "Esta orden podría no ejecutarse con el estado actual de la posición. Añade garantía o reduce el apalancamiento antes de que se active."
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -8370,6 +8370,10 @@ msgstr "Valor desconocido"
 msgid "Start unrealized fees"
 msgstr "Comisiones no realizadas iniciales"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -10109,7 +10109,6 @@ msgstr "Test de permis de jeton"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "Prix de liquidation invalide"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -8372,7 +8372,7 @@ msgstr "Frais non réalisés de départ"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "Cet ordre pourrait ne pas s'exécuter avec l'état actuel de la position. Ajoutez de la garantie ou réduisez l'effet de levier avant son déclenchement."
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -8370,6 +8370,10 @@ msgstr "Valeur inconnue"
 msgid "Start unrealized fees"
 msgstr "Frais non réalisés de départ"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -8370,6 +8370,10 @@ msgstr "不明な値"
 msgid "Start unrealized fees"
 msgstr "未実現手数料開始"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -10109,7 +10109,6 @@ msgstr "トークンパーミットテスト"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "無効な清算価格"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -8372,7 +8372,7 @@ msgstr "未実現手数料開始"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "このオーダーは現在のポジション状態では約定しない可能性があります。トリガー前に担保を追加するか、レバレッジを下げてください。"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -8372,7 +8372,7 @@ msgstr "시작 미실현 수수료"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "이 주문은 현재 포지션 상태에서는 체결되지 않을 수 있습니다. 트리거되기 전에 담보를 추가하거나 레버리지를 낮추세요."
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -10109,7 +10109,6 @@ msgstr "토큰 허용 테스트"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "유효하지 않은 청산가"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -8370,6 +8370,10 @@ msgstr "알 수 없는 값"
 msgid "Start unrealized fees"
 msgstr "시작 미실현 수수료"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -10109,7 +10109,6 @@ msgstr ""
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr ""
 

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -8370,6 +8370,10 @@ msgstr ""
 msgid "Start unrealized fees"
 msgstr ""
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -8372,7 +8372,7 @@ msgstr "Начальные нереализованные комиссии"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "Этот ордер может не исполниться при текущем состоянии позиции. Добавьте обеспечение или уменьшите кредитное плечо до его срабатывания."
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -8370,6 +8370,10 @@ msgstr "Неизвестное значение"
 msgid "Start unrealized fees"
 msgstr "Начальные нереализованные комиссии"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -10109,7 +10109,6 @@ msgstr "Тестирование разрешений токенов"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "Недопустимая цена ликвидации"
 

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -8372,7 +8372,7 @@ msgstr "起始未實現費用"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "在目前倉位狀態下，此訂單可能無法成交。請在觸發前增加抵押品或降低槓桿。"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -10109,7 +10109,6 @@ msgstr "代幣許可測試"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "無效的清算價格"
 

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -8370,6 +8370,10 @@ msgstr "未知值"
 msgid "Start unrealized fees"
 msgstr "起始未實現費用"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -8370,6 +8370,10 @@ msgstr "未知值"
 msgid "Start unrealized fees"
 msgstr "起始未实现费用"
 
+#: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
+msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Vested GMX not withdrawn"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -8372,7 +8372,7 @@ msgstr "起始未实现费用"
 
 #: src/components/TradeBox/LiquidatableIncreaseWarningCard.tsx
 msgid "This order may fail to execute with the current position state. Add collateral or reduce leverage before it triggers."
-msgstr ""
+msgstr "在当前仓位状态下，此订单可能无法成交。请在触发前增加抵押品或降低杠杆。"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -10109,7 +10109,6 @@ msgstr "代币许可测试"
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
-#: src/domain/synthetics/trade/utils/validation.ts
 msgid "Invalid liquidation price"
 msgstr "无效的清算价格"
 


### PR DESCRIPTION
Warns users when a **Limit Increase / Stop Increase** order that increases an existing position would be liquidatable at its **trigger (execution) price**, so they can add collateral or reduce leverage before it triggers.

Linear: https://linear.app/gmx-io/issue/FEDEV-2399

### Behavior
- **Warn (non-blocking)** for a resting Limit/Stop Increase on an existing position when the simulated resulting position would be liquidatable at the trigger price — submit/update stays enabled. Shown in the tradebox and the order editor (and via the editor that a chart-line drag opens).
- **Block (unchanged)** remains the existing Market Increase guard (liquidatable at the mark price).
- The check compares the next-position liquidation price against the **trigger price** (execution price) rather than the current mark price.

### Changes
- `getIsPositionLiquidatableAtPrice` shared helper (+ unit tests).
- Tradebox increase liquidation guard scoped to Market Increase only (`!isLimit`); new `selectTradeboxIncreaseLiquidationRiskWarning` selector.
- Shared `LiquidatableIncreaseWarningCard`, reused in the tradebox and the order editor.
- Order editor computes the warning inline (non-blocking); the chart-line drag path is unchanged, so the warning surfaces in the editor it opens.
- Warning copy translated across all locales.

### Out of scope
- Dynamic volatility / near-liquidation distance buffers (FEDEV-3906).
- Failed-order `LiquidatablePosition` messaging and the Market Increase block copy (already implemented).
