### PR TITLE
Hotfix: in-app announcement to withdraw Botanix GM liquidity by July 9 FEDEV-4011

### DIFF
--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -3,7 +3,7 @@
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
 
-import { ARBITRUM, MEGAETH } from "config/chains";
+import { ARBITRUM, BOTANIX, MEGAETH } from "config/chains";
 
 import ExternalLink from "components/ExternalLink/ExternalLink";
 import TokenIcon from "components/TokenIcon/TokenIcon";
@@ -36,6 +36,28 @@ export type EventData = {
 export const homeEventsData: EventData[] = [];
 
 export const appEventsData: EventData[] = [
+  {
+    id: "botanix-withdraw-deadline",
+    isActive: true,
+    endDate: "01 Aug 2026, 0:00",
+    chains: [BOTANIX],
+    title: "Botanix network is shutting down",
+    bodyText: (
+      <>
+        Remove your GM liquidity and withdraw your funds from Botanix by July 9, 2026. In the swap interface, swap pBTC
+        to BTC, or stBTC to pBTC then pBTC to BTC. stBTC can also be unstaked to BTC directly on Botanix. Move your BTC
+        off the network before the deadline.
+        <br />
+        <br />
+        <Link to="/pools">Withdraw liquidity</Link>.
+        <br />
+        <ExternalLink href="https://yield.botanixlabs.com/" newTab>
+          stBTC to BTC
+        </ExternalLink>
+        .
+      </>
+    ),
+  },
   {
     id: "spcx-stock-arbitrum-transition",
     isActive: true,

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -42,17 +42,17 @@ export const appEventsData: EventData[] = [
     endDate: "01 Aug 2026, 0:00",
     chains: [BOTANIX],
     title: "Botanix network is shutting down",
-    link: {
-      text: "Withdraw liquidity",
-      href: "/pools",
-    },
     bodyText: (
       <>
         Remove your GM liquidity and withdraw your funds from Botanix by July 9, 2026.
         <br />
+        <br />
         In the swap interface, swap pBTC
         to BTC, or stBTC to pBTC then pBTC to BTC. stBTC can also be unstaked to BTC directly on Botanix. Move your BTC
         off the network before the deadline.
+        <br />
+        <br />
+        <Link to="/pools">Withdraw liquidity</Link>
       </>
     ),
   },

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -42,19 +42,17 @@ export const appEventsData: EventData[] = [
     endDate: "01 Aug 2026, 0:00",
     chains: [BOTANIX],
     title: "Botanix network is shutting down",
+    link: {
+      text: "Withdraw liquidity",
+      href: "/pools",
+    },
     bodyText: (
       <>
-        Remove your GM liquidity and withdraw your funds from Botanix by July 9, 2026. In the swap interface, swap pBTC
+        Remove your GM liquidity and withdraw your funds from Botanix by July 9, 2026.
+        <br />
+        In the swap interface, swap pBTC
         to BTC, or stBTC to pBTC then pBTC to BTC. stBTC can also be unstaked to BTC directly on Botanix. Move your BTC
         off the network before the deadline.
-        <br />
-        <br />
-        <Link to="/pools">Withdraw liquidity</Link>.
-        <br />
-        <ExternalLink href="https://yield.botanixlabs.com/" newTab>
-          stBTC to BTC
-        </ExternalLink>
-        .
       </>
     ),
   },


### PR DESCRIPTION
In-app announcement telling Botanix users to remove GM liquidity and withdraw funds by July 9, 2026. Scoped to the Botanix chain, shows from release (no start gate) through end of July (stops Aug 1). Embeds a Withdraw liquidity link to /pools and a stBTC to BTC link to yield.botanixlabs.com.

https://linear.app/gmx-io/issue/FEDEV-4011/p1-in-app-announcement-withdraw-botanix-gm-liquidity-by-july-9