### PR TITLE
fix: include JIT liquidity in account dashboard resting order check FEDEV-4012

### DIFF
--- a/src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx
+++ b/src/context/SyntheticsStateContext/SyntheticsStateContextProvider.tsx
@@ -254,7 +254,7 @@ export function SyntheticsStateContextProvider({
   });
 
   const oracleSettings = useOracleSettingsData();
-  const jitLiquidityData = useJitLiquidityRequest(chainId, { enabled: isTradePage });
+  const jitLiquidityData = useJitLiquidityRequest(chainId, { enabled: isTradePage || isAccountPage });
 
   const [missedCoinsModalPlace, setMissedCoinsModalPlace] = useState<MissedCoinsPlace>();
 

--- a/src/domain/synthetics/markets/utils.spec.ts
+++ b/src/domain/synthetics/markets/utils.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+import { expandDecimals } from "lib/numbers";
+
+import { getAvailableUsdLiquidityForPosition, getMaxReservedUsd } from "./utils";
+
+describe("getAvailableUsdLiquidityForPosition JIT handling", () => {
+  const market = createMockMarketInfo();
+  const isLong = true;
+
+  const nativeMaxReserved = getMaxReservedUsd(market, isLong);
+  const nativeAvailable = getAvailableUsdLiquidityForPosition(market, isLong);
+
+  it("falls back to native liquidity when no JIT value is provided", () => {
+    expect(nativeAvailable).toBe(nativeMaxReserved);
+  });
+
+  it("adds the JIT delta on top of native liquidity, matching the header figure", () => {
+    const extraJit = expandDecimals(1_000_000, 30);
+    const jitMaxReserved = nativeMaxReserved + extraJit;
+
+    expect(getAvailableUsdLiquidityForPosition(market, isLong, jitMaxReserved)).toBe(nativeAvailable + extraJit);
+  });
+
+  it("never reports less than native liquidity when the JIT value is below native", () => {
+    const jitBelowNative = nativeMaxReserved - expandDecimals(1, 30);
+
+    expect(getAvailableUsdLiquidityForPosition(market, isLong, jitBelowNative)).toBe(nativeAvailable);
+  });
+
+  it("still caps available liquidity at the open interest limit when JIT is large", () => {
+    const oiCap = nativeMaxReserved / 2n;
+    const cappedMarket = { ...market, maxOpenInterestLong: oiCap };
+    const hugeJit = nativeMaxReserved + expandDecimals(100_000_000, 30);
+
+    expect(getAvailableUsdLiquidityForPosition(cappedMarket, isLong, hugeJit)).toBe(oiCap);
+  });
+});


### PR DESCRIPTION
## Problem

On JIT-backed markets (e.g. LDO/USD long, SILVER/USD long), resting limit-increase orders shown on the **Account Dashboard** (`/accounts/:account`, Positions/Orders tabs) were flagged with "Insufficient liquidity to execute order at trigger price" even for small sizes, while the market header shows ample available liquidity (native + JIT, capped by open interest).

## Root cause

The resting-order liquidity check in `getOrderErrors` already incorporates JIT liquidity via `getJitMaxReservedUsd(jitLiquidityMap, ...)`, matching the market header. But the JIT liquidity request was only enabled on the trade page (`enabled: isTradePage`). On the Account Dashboard (`pageType="accounts"`), `jitLiquidityMap` was `undefined`, so the check fell back to **native-only** liquidity — far smaller on JIT-backed markets — producing false warnings.

## Fix

Enable the JIT liquidity request on the account page as well (`enabled: isTradePage || isAccountPage`), so the resting-order check uses the same JIT-inclusive available liquidity shown in the market header. The comparison logic is unchanged, so the warning still fires when liquidity is genuinely insufficient (including when the open-interest cap is the binding limit).

Also adds a unit test for the JIT-inclusion contract in `getAvailableUsdLiquidityForPosition` (native fallback, JIT delta added on top, never below native, OI cap still binds).

https://linear.app/gmx-io/issue/FEDEV-4012/bug-resting-limit-orders-flagged-insufficient-liquidity-despite-header
