### PR TITLE
Bug: Net rate value is cut off on mobile trade page FEDEV-3908

### DIFF
--- a/src/components/TVChart/ChartHeader.tsx
+++ b/src/components/TVChart/ChartHeader.tsx
@@ -69,82 +69,70 @@ function ChartHeaderMobile() {
 
     if (isSwap) {
       return (
-        <div className="grid grid-cols-[1fr_1fr] gap-14">
-          <div>
-            <div className="mb-4 text-[11px] font-medium uppercase text-typography-secondary">
-              <Trans>24h high</Trans>
-            </div>
-            <div className="numbers">{high24}</div>
-          </div>
-          <div>
-            <div className="mb-4 text-[11px] font-medium uppercase text-typography-secondary">
-              <Trans>24h low</Trans>
-            </div>
-            <div className="numbers">{low24}</div>
-          </div>
+        <div className="flex flex-col">
+          <ChartHeaderMobileRow label={<Trans>24h high</Trans>} value={high24} />
+          <ChartHeaderMobileRow label={<Trans>24h low</Trans>} value={low24} />
         </div>
       );
     }
 
     return (
-      <div className="grid grid-cols-[1fr_1fr] grid-rows-2 gap-16">
-        <div>
-          <div className="mb-4 text-[11px] font-medium uppercase text-typography-secondary">
-            <Trans>24h volume</Trans>
-          </div>
-          <div className="numbers">{dailyVolume}</div>
-        </div>
+      <div className="flex flex-col">
+        <ChartHeaderMobileRow label={<Trans>24h volume</Trans>} value={dailyVolume} />
 
-        <div>
-          <div className="mb-4 whitespace-nowrap text-[11px] font-medium text-typography-secondary">
-            <span className="whitespace-nowrap text-[11px] font-medium uppercase text-typography-secondary">
-              <Trans>Open interest</Trans>
-            </span>
-            <span>{" ("}</span>
-            <span className="text-green-500 numbers">{longOIPercentage}</span>
-            <span>/</span>
-            <span className="text-red-500 numbers">{shortOIPercentage}</span>
-            <span>{")"}</span>
-          </div>
-          <TooltipWithPortal
-            variant="none"
-            as="div"
-            className="inline-flex flex-row items-center gap-8"
-            position="bottom-end"
-            content={<OpenInterestTooltip />}
-          >
-            <div className="flex flex-row items-center gap-8 numbers">{longOIValue}</div>
-            <div className="flex flex-row items-center gap-8 numbers">{shortOIValue}</div>
-          </TooltipWithPortal>
-        </div>
+        <ChartHeaderMobileRow
+          label={
+            <Trans>
+              Open interest (<span className="text-green-500 numbers">{longOIPercentage}</span>/
+              <span className="text-red-500 numbers">{shortOIPercentage}</span>)
+            </Trans>
+          }
+          value={
+            <TooltipWithPortal
+              variant="none"
+              as="div"
+              className="flex items-center gap-8"
+              position="bottom-end"
+              content={<OpenInterestTooltip />}
+            >
+              <div className="flex items-center gap-4 numbers">{longOIValue}</div>
+              <span className="text-typography-inactive">/</span>
+              <div className="flex items-center gap-4 numbers">{shortOIValue}</div>
+            </TooltipWithPortal>
+          }
+        />
 
-        <div>
-          <div className="mb-4 text-[11px] font-medium uppercase text-typography-secondary">
-            <Trans>Available liquidity</Trans>
-          </div>
-          <div className="flex flex-row items-center gap-8">
-            <div className="flex flex-row items-center gap-8 numbers">{liquidityLong}</div>
-            <div className="flex flex-row items-center gap-8 numbers">{liquidityShort}</div>
-          </div>
-        </div>
+        <ChartHeaderMobileRow
+          label={<Trans>Available liquidity</Trans>}
+          value={
+            <div className="flex items-center gap-8">
+              <span className="numbers">{liquidityLong}</span>
+              <span className="text-typography-inactive">/</span>
+              <span className="numbers">{liquidityShort}</span>
+            </div>
+          }
+        />
 
-        <div>
-          <div className="mb-4 text-[11px] font-medium uppercase text-typography-secondary">
+        <ChartHeaderMobileRow
+          label={
             <TooltipWithPortal variant="none" renderContent={renderNetFeeHeaderTooltipContent}>
               <Trans>Net rate / 1h</Trans>
             </TooltipWithPortal>
-          </div>
-          <TooltipWithPortal
-            variant="none"
-            as="div"
-            className="inline-flex flex-row items-center gap-8"
-            position="bottom-end"
-            content={<NetRate1hTooltip />}
-          >
-            <div className="numbers">{netRateLong}</div>
-            <div className="numbers">{netRateShort}</div>
-          </TooltipWithPortal>
-        </div>
+          }
+          value={
+            <TooltipWithPortal
+              variant="none"
+              as="div"
+              className="flex items-center gap-8"
+              position="bottom-end"
+              content={<NetRate1hTooltip />}
+            >
+              <div className="flex items-center gap-4 numbers">{netRateLong}</div>
+              <span className="text-typography-inactive">/</span>
+              <div className="flex items-center gap-4 numbers">{netRateShort}</div>
+            </TooltipWithPortal>
+          }
+        />
       </div>
     );
   }, [
@@ -185,7 +173,7 @@ function ChartHeaderMobile() {
         </div>
       </div>
 
-      {details ? <div className="border-t-[1px] border-t-slate-600 p-16">{details}</div> : null}
+      {details ? <div className="border-t-1/2 border-t-slate-600 p-16">{details}</div> : null}
     </div>
   );
 }
@@ -453,6 +441,15 @@ const ChartHeaderItem = ({ label, value }: { label: ReactNode; value: ReactNode 
         {label}
       </div>
       <div className="text-body-medium numbers">{value}</div>
+    </div>
+  );
+};
+
+const ChartHeaderMobileRow = ({ label, value }: { label: ReactNode; value: ReactNode }) => {
+  return (
+    <div className="flex items-center justify-between gap-8 py-2 text-12">
+      <div className="min-w-0 font-medium text-typography-secondary">{label}</div>
+      <div className="flex shrink-0 items-center text-typography-primary numbers">{value}</div>
     </div>
   );
 };

--- a/src/components/TVChart/ChartHeader.tsx
+++ b/src/components/TVChart/ChartHeader.tsx
@@ -69,18 +69,18 @@ function ChartHeaderMobile() {
 
     if (isSwap) {
       return (
-        <div className="flex flex-col">
-          <ChartHeaderMobileRow label={<Trans>24h high</Trans>} value={high24} />
-          <ChartHeaderMobileRow label={<Trans>24h low</Trans>} value={low24} />
+        <div className="flex flex-wrap gap-16 min-[440px]:grid min-[440px]:grid-cols-2">
+          <ChartHeaderMobileItem label={<Trans>24h high</Trans>} value={high24} />
+          <ChartHeaderMobileItem label={<Trans>24h low</Trans>} value={low24} />
         </div>
       );
     }
 
     return (
-      <div className="flex flex-col">
-        <ChartHeaderMobileRow label={<Trans>24h volume</Trans>} value={dailyVolume} />
+      <div className="flex flex-wrap gap-16 min-[440px]:grid min-[440px]:grid-cols-2">
+        <ChartHeaderMobileItem label={<Trans>24h volume</Trans>} value={dailyVolume} />
 
-        <ChartHeaderMobileRow
+        <ChartHeaderMobileItem
           label={
             <Trans>
               Open interest (<span className="text-green-500 numbers">{longOIPercentage}</span>/
@@ -102,7 +102,7 @@ function ChartHeaderMobile() {
           }
         />
 
-        <ChartHeaderMobileRow
+        <ChartHeaderMobileItem
           label={<Trans>Available liquidity</Trans>}
           value={
             <div className="flex items-center gap-8">
@@ -113,7 +113,7 @@ function ChartHeaderMobile() {
           }
         />
 
-        <ChartHeaderMobileRow
+        <ChartHeaderMobileItem
           label={
             <TooltipWithPortal variant="none" renderContent={renderNetFeeHeaderTooltipContent}>
               <Trans>Net rate / 1h</Trans>
@@ -445,11 +445,11 @@ const ChartHeaderItem = ({ label, value }: { label: ReactNode; value: ReactNode 
   );
 };
 
-const ChartHeaderMobileRow = ({ label, value }: { label: ReactNode; value: ReactNode }) => {
+const ChartHeaderMobileItem = ({ label, value }: { label: ReactNode; value: ReactNode }) => {
   return (
-    <div className="flex items-center justify-between gap-8 py-2 text-12">
-      <div className="min-w-0 font-medium text-typography-secondary">{label}</div>
-      <div className="flex shrink-0 items-center text-typography-primary numbers">{value}</div>
+    <div className="flex flex-col gap-8 text-12 leading-[1.25]">
+      <div className="font-medium capitalize text-typography-secondary">{label}</div>
+      <div className="flex items-center text-typography-primary numbers">{value}</div>
     </div>
   );
 };

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "rPnL nach Gebühren anzeigen"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "Open Interest"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "Betrag"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "Open Interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "Show rPnL after fees"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "Open interest"
@@ -7970,6 +7969,7 @@ msgstr "Copy"
 msgid "Amount"
 msgstr "Amount"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "Mostrar rPnL después de comisiones"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "Interés abierto"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "Interés abierto (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "Afficher le rPnL après frais"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "Positions ouvertes"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "Montant"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "Positions ouvertes (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "手数料控除後のrPnLを表示"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "建玉"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "金額"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "建玉（<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>）"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "수수료 차감 후 실현 PnL 표시"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "미결제약정"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "수량"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "미결제약정 (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr ""
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "Показывать rPnL за вычетом комиссий"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "Открытый интерес"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "Сумма"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "Открытый интерес (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "顯示扣除費用後的已實現盈虧"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "未平倉量"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "金額"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "未平倉量（<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>）"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4170,7 +4170,6 @@ msgid "Show rPnL after fees"
 msgstr "显示扣除费用后的已实现 PnL"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
-#: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Open interest"
 msgstr "未平仓量"
@@ -7970,6 +7969,7 @@ msgstr ""
 msgid "Amount"
 msgstr "金额"
 
+#: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
 msgstr "未平仓量（<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>）"


### PR DESCRIPTION
Fixes the mobile market-stats card clipping the right-side **Net rate / 1h** value (and the same pattern on Open interest / Available liquidity) at narrow viewport widths.

## Changes
- Introduces a shared `ChartHeaderMobileRow` (label left, value right) and converts the mobile `details` rows — 24h high/low/volume, Open interest, Available liquidity, Net rate / 1h — from a fixed 2-column grid to vertical label/value rows. The label gets `min-w-0` and the value `shrink-0`, so long/short values stay fully visible and no longer overflow the card.
- Long/short values are separated with a muted `/` divider for readability.

[FEDEV-3908](https://linear.app/gmx-io/issue/FEDEV-3908/bug-net-rate-value-is-cut-off-on-mobile-trade-page)
