### PR TITLE
Make divider lines consistent across the claim page modals FEDEV-3925

### DIFF
--- a/src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
+++ b/src/components/AccruedPositionPriceImpactRebateModal/AccruedPositionPriceImpactRebateModal.tsx
@@ -34,9 +34,9 @@ export const AccruedPositionPriceImpactRebateModal = memo(
             <Trans>Total {formatDeltaUsd(totalUsd)}</Trans>
           </div>
         </div>
+        <div className="mb-20 mt-15 h-1 bg-slate-700" />
         <div>
           <div className="App-card-content">
-            <div className="App-card-divider" />
             <div className="ClaimSettleModal-header">
               <div>
                 <Trans>MARKET</Trans>

--- a/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
+++ b/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -333,10 +333,9 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
           <Trans>Settle {totalStr}</Trans>
         </div>
       </div>
-      <div className="App-card-divider ClaimModal-divider FeeModal-divider ClaimSettleModal-divider" />
+      <div className="mb-20 mt-15 h-1 bg-slate-700" />
       <div className="ClaimModal-content ClaimSettleModal-modal-content">
         <div className="App-card-content">
-          <div className="App-card-divider" />
           <div className="ClaimSettleModal-header">
             <div className="ClaimSettleModal-header-left">
               <Trans>POSITION</Trans>


### PR DESCRIPTION
Standardizes the divider treatment across the claim-page confirmation modals so they look consistent side by side.

## Changes
- **Settle Accrued Funding Fees** modal: replaced the thick `App-card-divider` (and dropped the duplicate second divider) with the single thin divider already used by the Confirm claim modals.
- **Accrued Price Impact Rebates** modal: replaced its thick inner `App-card-divider` with the same thin divider, under the total / above the market list.
- Shared `.App-card-divider` styling is left untouched, so non-claim modals and cards are unaffected.

[FEDEV-3925](https://linear.app/gmx-io/issue/FEDEV-3925/make-divider-lines-consistent-across-the-claim-page-modals)
