### PR TITLE
GMX Account modal: cross-chain wallet Send via Stargate

### DIFF
--- a/src/components/GmxAccountModal/WalletSendView.tsx
+++ b/src/components/GmxAccountModal/WalletSendView.tsx
@@ -2,10 +2,22 @@ import { Trans, t } from "@lingui/macro";
 import { ReactNode, useCallback, useMemo, useState } from "react";
 import { Address, encodeFunctionData, isAddress } from "viem";
 
+import { AnyChainId, getChainName, isTestnetChain, SettlementChainId, SourceChainId } from "config/chains";
+import { CHAIN_ID_TO_NETWORK_ICON } from "config/icons";
+import { getMappedTokenId, getMultichainTokenId, MULTICHAIN_FUNDING_SLIPPAGE_BPS } from "config/multichain";
 import { useGmxAccountModalOpen, useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
+import { getMultichainTransferSendParams } from "domain/multichain/getSendParams";
+import { showWalletCrossChainSendStatusToast } from "domain/multichain/progress/walletCrossChainSendToast";
+import { sendCrossChainDepositTxn } from "domain/multichain/sendCrossChainDepositTxn";
+import { SendParam } from "domain/multichain/types";
+import { useMultichainQuoteFeeUsd } from "domain/multichain/useMultichainQuoteFeeUsd";
+import { useQuoteOft } from "domain/multichain/useQuoteOft";
+import { useQuoteOftLimits } from "domain/multichain/useQuoteOftLimits";
+import { useQuoteSendNativeFeeWithGasLimit } from "domain/multichain/useQuoteSend";
 import { getBalanceByBalanceType, useTokensDataRequest } from "domain/synthetics/tokens";
 import { convertToUsd, TokenBalanceType, TokenData } from "domain/tokens";
 import { useMaxAvailableAmount } from "domain/tokens/useMaxAvailableAmount";
+import { useTokenApproval } from "domain/tokens/useTokenApproval";
 import { useChainId } from "lib/chains";
 import { helperToast } from "lib/helperToast";
 import { formatUsd, parseValue } from "lib/numbers";
@@ -15,8 +27,11 @@ import useWallet from "lib/wallets/useWallet";
 import { abis } from "sdk/abis";
 import { NATIVE_TOKEN_ADDRESS } from "sdk/configs/tokens";
 import { getMidPrice } from "sdk/utils/tokens";
+import { applySlippageToMinOut } from "sdk/utils/trade";
 
+import { AlertInfoCard } from "components/AlertInfo/AlertInfoCard";
 import { Amount } from "components/Amount/Amount";
+import { AmountWithUsdBalance } from "components/AmountWithUsd/AmountWithUsd";
 import Button from "components/Button/Button";
 import { DropdownSelector } from "components/DropdownSelector/DropdownSelector";
 import NumberInput from "components/NumberInput/NumberInput";
@@ -24,6 +39,7 @@ import { SyntheticsInfoRow } from "components/SyntheticsInfoRow";
 import TokenIcon from "components/TokenIcon/TokenIcon";
 import { ValueTransition } from "components/ValueTransition/ValueTransition";
 
+import { useGmxAccountWithdrawNetworks } from "./hooks";
 import { wrapChainAction } from "./wrapChainAction";
 
 function getWalletBalanceUsd(token: TokenData): bigint {
@@ -56,6 +72,41 @@ function getWalletTokenOptions(tokensData: Record<string, TokenData> | undefined
   });
 }
 
+type SendNetworkOption = { id: number; name: string; disabled?: boolean };
+
+function getSendNetworkOptions({
+  networks,
+  selectedToken,
+  chainId,
+}: {
+  networks: { id: number; name: string }[];
+  selectedToken: TokenData | undefined;
+  chainId: number;
+}): SendNetworkOption[] {
+  if (!selectedToken) {
+    return networks;
+  }
+
+  return networks
+    .map((network): SendNetworkOption => {
+      if (network.id === chainId) {
+        return network;
+      }
+
+      const mappedTokenId = getMappedTokenId(
+        chainId as SettlementChainId,
+        selectedToken.address,
+        network.id as SourceChainId
+      );
+
+      return {
+        ...network,
+        disabled: mappedTokenId === undefined,
+      };
+    })
+    .sort((a, b) => (a.disabled ? 1 : b.disabled ? -1 : 0));
+}
+
 export function WalletSendView() {
   const { chainId } = useChainId();
   const { account } = useWallet();
@@ -65,6 +116,7 @@ export function WalletSendView() {
   const { tokensData } = useTokensDataRequest(chainId);
 
   const [selectedTokenAddress, setSelectedTokenAddress] = useState<string | undefined>(undefined);
+  const [selectedNetwork, setSelectedNetwork] = useState<number | undefined>(undefined);
   const [recipient, setRecipient] = useState("");
   const [inputValue, setInputValue] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -74,6 +126,25 @@ export function WalletSendView() {
   const selectedToken = getByKey(tokensData, selectedTokenAddress);
   const nativeToken = getByKey(tokensData, NATIVE_TOKEN_ADDRESS);
   const walletBalance = getBalanceByBalanceType(selectedToken, TokenBalanceType.Wallet);
+
+  const networks = useGmxAccountWithdrawNetworks();
+  const networkOptions = useMemo(
+    () => getSendNetworkOptions({ networks, selectedToken, chainId }),
+    [networks, selectedToken, chainId]
+  );
+
+  const destinationChainId = (selectedNetwork ?? chainId) as AnyChainId;
+  const isSameChain = destinationChainId === chainId;
+
+  const selectedTokenMultichainId =
+    selectedToken !== undefined ? getMultichainTokenId(chainId, selectedToken.address) : undefined;
+  const stargateAddress = selectedTokenMultichainId?.stargate;
+
+  const destinationNetworkOption = useMemo(
+    () => networkOptions.find((option) => option.id === destinationChainId),
+    [networkOptions, destinationChainId]
+  );
+  const isDestinationUnsupported = !isSameChain && Boolean(destinationNetworkOption?.disabled);
 
   const amount =
     selectedToken && inputValue !== "" ? parseValue(inputValue, selectedToken.decimals) ?? undefined : undefined;
@@ -92,6 +163,88 @@ export function WalletSendView() {
   const isInputEmpty = amount === undefined || amount <= 0n;
   const isInsufficientBalance = walletBalance !== undefined && amount !== undefined && amount > walletBalance;
 
+  const sendParamsWithoutSlippage: SendParam | undefined = useMemo(() => {
+    if (
+      isSameChain ||
+      isDestinationUnsupported ||
+      !isRecipientValid ||
+      amount === undefined ||
+      amount <= 0n ||
+      stargateAddress === undefined
+    ) {
+      return undefined;
+    }
+
+    return getMultichainTransferSendParams({
+      dstChainId: destinationChainId,
+      account: recipient,
+      amountLD: amount,
+      isToGmx: false,
+    });
+  }, [isSameChain, isDestinationUnsupported, isRecipientValid, amount, stargateAddress, destinationChainId, recipient]);
+
+  const { data: quoteOft } = useQuoteOft({
+    sendParams: sendParamsWithoutSlippage,
+    fromStargateAddress: stargateAddress,
+    fromChainId: chainId,
+    toChainId: destinationChainId,
+  });
+
+  const { isBelowLimit, lowerLimitFormatted, isAboveLimit, upperLimitFormatted } = useQuoteOftLimits({
+    quoteOft,
+    amountLD: amount,
+    isStable: selectedToken?.isStable,
+    decimals: selectedToken?.decimals,
+    enabled: !isSameChain,
+  });
+
+  const sendParamsWithSlippage: SendParam | undefined = useMemo(() => {
+    if (!quoteOft || !sendParamsWithoutSlippage) {
+      return undefined;
+    }
+
+    return {
+      ...sendParamsWithoutSlippage,
+      minAmountLD: applySlippageToMinOut(MULTICHAIN_FUNDING_SLIPPAGE_BPS, quoteOft.receipt.amountReceivedLD as bigint),
+    };
+  }, [quoteOft, sendParamsWithoutSlippage]);
+
+  const { data: quoteSendData } = useQuoteSendNativeFeeWithGasLimit({
+    sendParams: sendParamsWithSlippage,
+    fromStargateAddress: stargateAddress,
+    fromChainId: chainId,
+    toChainId: destinationChainId,
+    fromTokenAddress: selectedToken?.address,
+  });
+
+  const quoteSendNativeFee = quoteSendData?.nativeFee;
+
+  const { networkFee, networkFeeUsd } = useMultichainQuoteFeeUsd({
+    quoteSendNativeFee,
+    quoteOft,
+    unwrappedTokenAddress: selectedToken?.address,
+    sourceChainId: chainId,
+    targetChainId: destinationChainId,
+    initialTxGasLimit: quoteSendData?.gasLimit,
+    waitForTxGasLimit: true,
+  });
+
+  const approvalTokens = useMemo(
+    () =>
+      !isSameChain && selectedToken && !selectedToken.isNative && amount !== undefined
+        ? [{ tokenAddress: selectedToken.address, amount }]
+        : [],
+    [isSameChain, selectedToken, amount]
+  );
+
+  const { needsApproval, isApproving, isAllowanceLoaded, handleApprove } = useTokenApproval({
+    chainId,
+    spenderAddress: stargateAddress,
+    tokens: approvalTokens,
+    approveAmount: amount,
+    skip: isSameChain || isDestinationUnsupported || selectedToken?.isNative || stargateAddress === undefined,
+  });
+
   const { formattedMaxAvailableAmount, showClickMax } = useMaxAvailableAmount({
     fromToken: selectedToken,
     fromTokenBalance: walletBalance,
@@ -99,13 +252,14 @@ export function WalletSendView() {
     fromTokenInputValue: inputValue,
     gasPaymentToken: nativeToken,
     gasPaymentTokenBalance: nativeToken?.walletBalance,
+    gasPaymentTokenAmount: !isSameChain && selectedToken?.isNative ? quoteSendNativeFee : undefined,
   });
 
   const handleMaxClick = useCallback(() => {
     setInputValue(formattedMaxAvailableAmount);
   }, [formattedMaxAvailableAmount]);
 
-  const handleSend = useCallback(async () => {
+  const handleSameChainSend = useCallback(async () => {
     if (
       selectedToken === undefined ||
       account === undefined ||
@@ -142,6 +296,115 @@ export function WalletSendView() {
     }
   }, [account, amount, chainId, recipient, selectedToken, setIsVisibleOrView, setSettlementChainId]);
 
+  const handleCrossChainSend = useCallback(async () => {
+    if (
+      selectedToken === undefined ||
+      account === undefined ||
+      amount === undefined ||
+      amount <= 0n ||
+      !isAddress(recipient) ||
+      stargateAddress === undefined ||
+      sendParamsWithSlippage === undefined ||
+      quoteSendNativeFee === undefined
+    ) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      let sourceTxHash: string | undefined;
+
+      await wrapChainAction(chainId, setSettlementChainId, async (signer) => {
+        const result = await sendCrossChainDepositTxn({
+          chainId: chainId as SourceChainId,
+          signer,
+          tokenAddress: selectedToken.address,
+          stargateAddress,
+          amount,
+          quoteSendNativeFee,
+          sendParams: sendParamsWithSlippage,
+          account,
+        });
+
+        sourceTxHash = result.transactionHash;
+      });
+
+      if (sourceTxHash !== undefined) {
+        showWalletCrossChainSendStatusToast({
+          sourceChainId: chainId,
+          destinationChainId,
+          token: selectedToken,
+          amount,
+          txHash: sourceTxHash,
+        });
+      } else {
+        helperToast.success(t`Sent`);
+      }
+
+      setIsVisibleOrView("main");
+    } catch (error) {
+      helperToast.error(t`Send failed`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    account,
+    amount,
+    chainId,
+    destinationChainId,
+    quoteSendNativeFee,
+    recipient,
+    selectedToken,
+    sendParamsWithSlippage,
+    setIsVisibleOrView,
+    setSettlementChainId,
+    stargateAddress,
+  ]);
+
+  const handleSend = useCallback(() => {
+    if (isSameChain) {
+      void handleSameChainSend();
+    } else {
+      void handleCrossChainSend();
+    }
+  }, [isSameChain, handleSameChainSend, handleCrossChainSend]);
+
+  const networkItemDisabledMessage = useCallback(
+    (option: SendNetworkOption) => t`Sending ${selectedToken?.symbol} to ${option.name} is not supported`,
+    [selectedToken?.symbol]
+  );
+
+  const isTestnet = isTestnetChain(chainId);
+
+  const estimatedTimeValue = useMemo(() => {
+    if (isSameChain) {
+      return <Trans>Instant</Trans>;
+    }
+
+    if (amount === undefined || amount === 0n) {
+      return "...";
+    }
+
+    return isTestnet ? <Trans>1m 40s</Trans> : <Trans>20s</Trans>;
+  }, [isSameChain, amount, isTestnet]);
+
+  const networkFeeValue = useMemo(() => {
+    if (networkFee === undefined || networkFeeUsd === undefined || nativeToken === undefined) {
+      return "...";
+    }
+
+    return (
+      <AmountWithUsdBalance
+        className="leading-1"
+        amount={networkFee}
+        decimals={nativeToken.decimals}
+        usd={networkFeeUsd}
+        symbol={nativeToken.symbol}
+      />
+    );
+  }, [networkFee, networkFeeUsd, nativeToken]);
+
   let buttonState: { text: ReactNode; disabled?: boolean; onClick?: () => void } = {
     text: t`Send`,
     onClick: handleSend,
@@ -151,6 +414,11 @@ export function WalletSendView() {
     buttonState = { text: t`Sending...`, disabled: true };
   } else if (selectedToken === undefined) {
     buttonState = { text: t`Select token`, disabled: true };
+  } else if (isDestinationUnsupported) {
+    buttonState = {
+      text: t`Sending ${selectedToken.symbol} to ${getChainName(destinationChainId)} is not supported`,
+      disabled: true,
+    };
   } else if (recipient === "") {
     buttonState = { text: t`Enter recipient address`, disabled: true };
   } else if (!isRecipientValid) {
@@ -159,6 +427,16 @@ export function WalletSendView() {
     buttonState = { text: t`Enter amount`, disabled: true };
   } else if (isInsufficientBalance) {
     buttonState = { text: t`Insufficient balance`, disabled: true };
+  } else if (!isSameChain) {
+    if (isAboveLimit || isBelowLimit) {
+      buttonState = { text: t`Send`, disabled: true };
+    } else if (isApproving) {
+      buttonState = { text: t`Approving...`, disabled: true };
+    } else if (needsApproval) {
+      buttonState = { text: t`Approve ${selectedToken.symbol}`, onClick: handleApprove };
+    } else if (!isAllowanceLoaded || sendParamsWithSlippage === undefined || quoteSendNativeFee === undefined) {
+      buttonState = { text: t`Send`, disabled: true };
+    }
   }
 
   return (
@@ -183,6 +461,32 @@ export function WalletSendView() {
             options={tokenOptions}
             item={SendAssetItem}
             itemKey={sendAssetItemKey}
+          />
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <div className="text-body-medium text-typography-secondary">
+            <Trans>Network</Trans>
+          </div>
+          <DropdownSelector
+            value={destinationChainId}
+            onChange={(value) => setSelectedNetwork(Number(value))}
+            placeholder={t`Select network`}
+            button={
+              <div className="flex items-center gap-8">
+                <img
+                  src={CHAIN_ID_TO_NETWORK_ICON[destinationChainId]}
+                  alt={getChainName(destinationChainId)}
+                  className="size-20"
+                />
+                <span className="text-16 leading-base">{getChainName(destinationChainId)}</span>
+              </div>
+            }
+            options={networkOptions}
+            item={NetworkItem}
+            itemKey={networkItemKey}
+            itemDisabled={networkItemDisabled}
+            itemDisabledMessage={networkItemDisabledMessage}
           />
         </div>
 
@@ -244,11 +548,41 @@ export function WalletSendView() {
         </div>
       </div>
 
+      {!isSameChain && !isInsufficientBalance && (
+        <>
+          {isAboveLimit && (
+            <AlertInfoCard type="warning" className="my-4" hideClose>
+              <div>
+                <Trans>
+                  Amount exceeds the transfer limit. Try an amount smaller than{" "}
+                  <span className="numbers">{upperLimitFormatted}</span>.
+                </Trans>
+              </div>
+            </AlertInfoCard>
+          )}
+          {isBelowLimit && (
+            <AlertInfoCard type="warning" className="my-4" hideClose>
+              <div>
+                <Trans>
+                  Amount is below the transfer limit. Try an amount larger than{" "}
+                  <span className="numbers">{lowerLimitFormatted}</span>.
+                </Trans>
+              </div>
+            </AlertInfoCard>
+          )}
+        </>
+      )}
+
       <div className="h-32 shrink-0 grow" />
 
       {selectedTokenAddress && (
         <div className="mb-16 flex flex-col gap-10">
-          <SyntheticsInfoRow label={<Trans>Estimated time</Trans>} value={<Trans>Instant</Trans>} />
+          <SyntheticsInfoRow
+            label={<Trans>Estimated time</Trans>}
+            valueClassName="numbers"
+            value={estimatedTimeValue}
+          />
+          {!isSameChain && <SyntheticsInfoRow label={<Trans>Network fee</Trans>} value={networkFeeValue} />}
           <SyntheticsInfoRow
             label={<Trans>Wallet balance</Trans>}
             value={<ValueTransition from={formatUsd(walletBalanceUsd)} to={formatUsd(nextWalletBalanceUsd)} />}
@@ -290,4 +624,23 @@ function SendAssetItem({ option }: { option: TokenData }) {
 
 function sendAssetItemKey(option: TokenData) {
   return option.address;
+}
+
+function networkItemKey(option: SendNetworkOption) {
+  return option.id;
+}
+
+function networkItemDisabled(option: SendNetworkOption): boolean {
+  return !!option.disabled;
+}
+
+function NetworkItem({ option }: { option: SendNetworkOption }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-8">
+        <img src={CHAIN_ID_TO_NETWORK_ICON[option.id as AnyChainId]} alt={option.name} className="size-20" />
+        <span className="text-body-large">{option.name}</span>
+      </div>
+    </div>
+  );
 }

--- a/src/domain/multichain/progress/walletCrossChainSendToast.tsx
+++ b/src/domain/multichain/progress/walletCrossChainSendToast.tsx
@@ -1,0 +1,171 @@
+import { Trans } from "@lingui/macro";
+import { ReactNode } from "react";
+import { toast } from "react-toastify";
+
+import { AnyChainId, getChainName, isTestnetChain } from "config/chains";
+import { TokenData } from "domain/tokens";
+import { CHAIN_ID_TO_TX_URL_BUILDER } from "lib/chains/blockExplorers";
+import { shortenAddressOrEns } from "lib/wallets";
+import { formatTokenAmount } from "sdk/utils/numbers";
+
+import ExternalLink from "components/ExternalLink/ExternalLink";
+import { StatusNotification } from "components/StatusNotification/StatusNotification";
+import { SyntheticsInfoRow } from "components/SyntheticsInfoRow";
+import TokenIcon from "components/TokenIcon/TokenIcon";
+import { TransactionStatus, TransactionStatusType } from "components/TransactionStatus/TransactionStatus";
+
+import { LzStatus, watchLzTx } from "./watchLzTx";
+
+type LzPhase = "pending" | "confirmed" | "failed";
+
+type WalletCrossChainSendStatusToastParams = {
+  sourceChainId: AnyChainId;
+  destinationChainId: AnyChainId;
+  token: TokenData;
+  amount: bigint;
+  txHash: string;
+};
+
+const TERMINAL_AUTO_CLOSE_MS = 7000;
+
+export function showWalletCrossChainSendStatusToast({
+  sourceChainId,
+  destinationChainId,
+  token,
+  amount,
+  txHash,
+}: WalletCrossChainSendStatusToastParams) {
+  const toastId = `wallet-cross-chain-send:${txHash}`;
+  const isTestnet = isTestnetChain(sourceChainId);
+
+  const render = (status: LzStatus | undefined): ReactNode => (
+    <WalletCrossChainSendToastContent
+      sourceChainId={sourceChainId}
+      destinationChainId={destinationChainId}
+      token={token}
+      amount={amount}
+      txHash={txHash}
+      isTestnet={isTestnet}
+      status={status}
+    />
+  );
+
+  toast(render(undefined), {
+    toastId,
+    type: "success",
+    autoClose: false,
+  });
+
+  let lastStatus: LzStatus | undefined;
+
+  const update = (status: LzStatus | undefined, autoClose: number | false) => {
+    if (!toast.isActive(toastId)) {
+      return;
+    }
+
+    const failed = status !== undefined && (status.source === "failed" || status.destination === "failed");
+
+    toast.update(toastId, {
+      render: render(status),
+      type: failed ? "error" : "success",
+      autoClose,
+    });
+  };
+
+  watchLzTx({
+    chainId: sourceChainId,
+    txHash,
+    withLzCompose: false,
+    onUpdate: (data) => {
+      const status = data[0];
+      if (status === undefined) {
+        return;
+      }
+
+      lastStatus = status;
+      const failed = status.source === "failed" || status.destination === "failed";
+      const completed = status.source === "confirmed" && status.destination === "confirmed";
+      update(status, failed || completed ? TERMINAL_AUTO_CLOSE_MS : false);
+    },
+  })
+    .catch(() => undefined)
+    .finally(() => update(lastStatus, TERMINAL_AUTO_CLOSE_MS));
+}
+
+function getSourceTransactionStatus(phase: LzPhase): TransactionStatusType {
+  if (phase === "confirmed") {
+    return "success";
+  }
+
+  if (phase === "failed") {
+    return "error";
+  }
+
+  return "loading";
+}
+
+function getDestinationTransactionStatus(sourcePhase: LzPhase, destinationPhase: LzPhase): TransactionStatusType {
+  if (sourcePhase !== "confirmed") {
+    return "muted";
+  }
+
+  if (destinationPhase === "confirmed") {
+    return "success";
+  }
+
+  if (destinationPhase === "failed") {
+    return "error";
+  }
+
+  return "loading";
+}
+
+function WalletCrossChainSendToastContent({
+  sourceChainId,
+  destinationChainId,
+  token,
+  amount,
+  txHash,
+  isTestnet,
+  status,
+}: WalletCrossChainSendStatusToastParams & { isTestnet: boolean; status: LzStatus | undefined }) {
+  const sourcePhase: LzPhase = status?.source ?? "pending";
+  const destinationPhase: LzPhase = status?.destination ?? "pending";
+
+  const scanUrl = isTestnet
+    ? CHAIN_ID_TO_TX_URL_BUILDER["layerzero-testnet"](txHash)
+    : CHAIN_ID_TO_TX_URL_BUILDER["layerzero"](txHash);
+
+  return (
+    <StatusNotification
+      title={
+        <div className="flex items-center gap-4">
+          <TokenIcon symbol={token.symbol} displaySize={16} className="size-16" />
+          <Trans>
+            Sending {formatTokenAmount(amount, token.decimals, token.symbol)} to {getChainName(destinationChainId)}
+          </Trans>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-8">
+        <TransactionStatus
+          status={getSourceTransactionStatus(sourcePhase)}
+          text={<Trans>Sent on {getChainName(sourceChainId)}</Trans>}
+        />
+        <TransactionStatus
+          status={getDestinationTransactionStatus(sourcePhase, destinationPhase)}
+          text={<Trans>Received on {getChainName(destinationChainId)}</Trans>}
+        />
+        <SyntheticsInfoRow
+          label={<Trans>Transaction</Trans>}
+          valueClassName="flex items-center"
+          value={
+            <ExternalLink href={scanUrl} variant="icon">
+              {shortenAddressOrEns(txHash, 13)}
+            </ExternalLink>
+          }
+        />
+      </div>
+    </StatusNotification>
+  );
+}

--- a/src/domain/multichain/sendCrossChainDepositTxn.ts
+++ b/src/domain/multichain/sendCrossChainDepositTxn.ts
@@ -31,7 +31,7 @@ export async function sendCrossChainDepositTxn({
   const isNative = tokenAddress === zeroAddress;
   const value = quoteSendNativeFee + (isNative ? amount : 0n);
 
-  await sendWalletTransaction({
+  return await sendWalletTransaction({
     chainId: chainId,
     to: stargateAddress,
     signer: signer,

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "Täglicher und kumulierter PnL"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "Der Betrag liegt unter dem Transferlimit. Versuchen Sie einen Betrag größer als <0>{lowerLimitFormatted}</0>."
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "{longOrShort}-Positionen zahlen keine Finanzierungsgebühr und zahlen eine Leihgebühr von {borrowRate} pro Stunde"
@@ -3764,6 +3768,10 @@ msgstr "Finanzierungsgebühr"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "Senden von {0} an {1}"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "Akzeptablen Preiseinfluss festlegen"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "Entstaken abgeschlossen"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20s"
@@ -4183,6 +4194,10 @@ msgstr "Smart Wallets werden bei Express Trading oder One-Click Trading nicht un
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "Ausgeführt"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "Der Betrag überschreitet das Transferlimit. Versuchen Sie einen Betrag kleiner als <0>{upperLimitFormatted}</0>."
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "Orderdaten konnten nicht geladen werden:"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "Netzwerk"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX Vault"
 msgid "Sending settle request..."
 msgstr "Abrechnungsanfrage wird gesendet..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "Das Senden von {0} nach {1} wird nicht unterstützt"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "Sicherheit kann nicht abgehoben werden. Verbleibende Sicherheit wäre unter dem Minimum"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1m 40s"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "TWAP-Swap stornieren"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "Transaktion"
 
@@ -7619,6 +7643,7 @@ msgstr "Einzahlungsbetrag eingeben"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "der Eröffnungsgebühr"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "Gesendet"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "Empfangen (ungefähr)"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "Senden fehlgeschlagen"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "Hebel-Handelsterminal"
 msgid "Receiver address"
 msgstr "Empfängeradresse"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "Empfangen auf {0}"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Netzwerk auswählen"
@@ -10887,6 +10919,7 @@ msgstr "Guthaben wird übertragen nach..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "Aktives Management"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "Gesendet auf {0}"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "Daily and cumulative PnL"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
@@ -3764,6 +3768,10 @@ msgstr "Funding fee"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "Sending {0} to {1}"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "Set acceptable price impact"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr "Send"
@@ -4054,6 +4064,7 @@ msgstr "Unstake completed"
 msgid "Export wallet"
 msgstr "Export wallet"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20s"
@@ -4183,6 +4194,10 @@ msgstr "Smart wallets are not supported on Express Trading or One-Click Trading"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "Executed"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "Failed to load order data:"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "Network"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX vault"
 msgid "Sending settle request..."
 msgstr "Sending settle request..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "Sending {0} to {1} is not supported"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "Can't withdraw collateral. Remaining collateral would be below minimum"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr "How do I share my code?"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1m 40s"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "Cancel TWAP Swap"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "Transaction"
 
@@ -7619,6 +7643,7 @@ msgstr "Enter deposit amount"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7882,6 +7907,7 @@ msgstr "Execution prices for increasing shorts<0/>and decreasing longs"
 msgid "of open fee"
 msgstr "of open fee"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
 msgstr "Sent"
@@ -8840,6 +8866,7 @@ msgid "Receive (approximate)"
 msgstr "Receive (approximate)"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
 msgstr "Send failed"
 
@@ -9547,6 +9574,10 @@ msgstr "Leverage trading terminal"
 msgid "Receiver address"
 msgstr "Receiver address"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "Received on {0}"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr "Allow all tokens to transfer to the new account"
@@ -9736,6 +9767,7 @@ msgstr "<0>Tried <1>@GMX_IO</1> for the first time. </0><2> Pretty impressive ex
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Select network"
@@ -10887,6 +10919,7 @@ msgstr "Funds bridging to..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr "Set trigger price below mark price"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "Active management"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "Sent on {0}"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "PnL diario y acumulado"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "El importe está por debajo del límite de transferencia. Pruebe con un importe superior a <0>{lowerLimitFormatted}</0>."
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "Las posiciones {longOrShort} no pagan comisión de financiación y pagan una comisión de préstamo del {borrowRate} por hora"
@@ -3764,6 +3768,10 @@ msgstr "Comisión de financiación"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "Enviando {0} a {1}"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "Establecer impacto en el precio aceptable"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "Unstakear completado"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20s"
@@ -4183,6 +4194,10 @@ msgstr "Los monederos inteligentes no son compatibles con Express Trading ni con
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "Ejecutada"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "El importe excede el límite de transferencia. Pruebe con un importe inferior a <0>{upperLimitFormatted}</0>."
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "Error al cargar los datos de la orden:"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "Red"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX vault"
 msgid "Sending settle request..."
 msgstr "Enviando solicitud de liquidación..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "El envío de {0} a {1} no está soportado"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "No se puede retirar la garantía. La garantía restante quedaría por debajo del mínimo"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1m 40s"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "Cancelar Intercambio TWAP"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "Transacción"
 
@@ -7619,6 +7643,7 @@ msgstr "Ingresa cantidad de depósito"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "de comisión de apertura"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "Enviado"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "Recibir (aproximado)"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "Envío fallido"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "Terminal de trading con apalancamiento"
 msgid "Receiver address"
 msgstr "Dirección del destinatario"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "Recibido en {0}"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Seleccionar red"
@@ -10887,6 +10919,7 @@ msgstr "Fondos transfiriéndose a..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "Gestión activa"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "Enviado en {0}"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "PnL quotidien et cumulé"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "Le montant est inférieur à la limite de transfert. Essayez un montant supérieur à <0>{lowerLimitFormatted}</0>."
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "Les positions {longOrShort} ne paient pas de frais de financement et paient des frais d'emprunt de {borrowRate} par heure"
@@ -3764,6 +3768,10 @@ msgstr "Frais de financement"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "Envoi de {0} vers {1}"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "Définir l'impact sur le prix acceptable"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "Unstake terminé"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20s"
@@ -4183,6 +4194,10 @@ msgstr "Les portefeuilles intelligents ne sont pas pris en charge avec Express T
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "Exécutée"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "Le montant dépasse la limite de transfert. Essayez un montant inférieur à <0>{upperLimitFormatted}</0>."
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "Échec du chargement des données de l'ordre :"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "Réseau"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX vault"
 msgid "Sending settle request..."
 msgstr "Envoi de la demande de règlement..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "L'envoi de {0} vers {1} n'est pas pris en charge"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "Impossible de retirer la garantie. La garantie restante serait inférieure au minimum"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1m 40s"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "Annuler le swap TWAP"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "Transaction"
 
@@ -7619,6 +7643,7 @@ msgstr "Entrez le montant de dépôt"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "des frais d'ouverture"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "Envoyé"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "Réception (approximative)"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "Échec de l'envoi"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "Terminal de trading avec effet de levier"
 msgid "Receiver address"
 msgstr "Adresse du destinataire"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "Reçu sur {0}"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Sélectionner le réseau"
@@ -10887,6 +10919,7 @@ msgstr "Transfert des fonds vers..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "Gestion active"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "Envoyé sur {0}"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "日次および累積 PnL"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "金額が送金下限を下回っています。<0>{lowerLimitFormatted}</0>より大きい金額をお試しください。"
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "{longOrShort} ポジションはファンディング手数料を支払わず、1時間あたり {borrowRate} の借入手数料を支払います"
@@ -3764,6 +3768,10 @@ msgstr "ファンディング手数料"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "{0}を{1}へ送信中"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "許容可能な価格への影響を設定する"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "アンステーク完了"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20秒"
@@ -4183,6 +4194,10 @@ msgstr "スマートウォレットは Express Trading および One-Click Tradi
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "実行済み"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "金額が送金上限を超えています。<0>{upperLimitFormatted}</0>未満の金額をお試しください。"
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "注文データの読み込みに失敗しました:"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "ネットワーク"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX ボールト"
 msgid "Sending settle request..."
 msgstr "精算リクエストを送信中..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "{0}の{1}への送信はサポートされていません"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "担保を出金できません。残りの担保が最低額を下回ります"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1分40秒"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "TWAPスワップをキャンセル"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "取引"
 
@@ -7619,6 +7643,7 @@ msgstr "入金額を入力"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "オープン手数料の"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "送信済み"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "受取（概算）"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "送信に失敗しました"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "レバレッジ取引ターミナル"
 msgid "Receiver address"
 msgstr "受取人アドレス"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "{0}で受信済み"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "ネットワークを選択"
@@ -10887,6 +10919,7 @@ msgstr "ブリッジ送金中..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "アクティブ運用"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "{0}で送信済み"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "일별 및 누적 PnL"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "금액이 전송 한도 미만입니다. <0>{lowerLimitFormatted}</0>보다 큰 금액을 입력하십시오."
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "{longOrShort} 포지션은 펀딩 수수료를 지불하지 않으며, 시간당 {borrowRate}의 차입 수수료를 지불합니다"
@@ -3764,6 +3768,10 @@ msgstr "펀딩 수수료"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "{0}을(를) {1}(으)로 보내는 중"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "허용 가격 영향 설정"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "언스테이킹 완료"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20초"
@@ -4183,6 +4194,10 @@ msgstr "스마트 지갑은 Express Trading 또는 One-Click Trading에서 지�
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "실행됨"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "전송 한도를 초과했습니다. <0>{upperLimitFormatted}</0>보다 작은 금액을 입력하십시오."
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "주문 데이터 로드 실패:"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "네트워크"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX 볼트"
 msgid "Sending settle request..."
 msgstr "정산 요청 전송 중..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "{0}을(를) {1}(으)로 보내는 것은 지원되지 않습니다"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "담보를 출금할 수 없습니다. 잔여 담보가 최소 기준 미만이 됩니다"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1분 40초"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "TWAP 스왑 취소"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "거래"
 
@@ -7619,6 +7643,7 @@ msgstr "입금 금액 입력"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "개설 수수료의"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "전송됨"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "수령 (근사치)"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "전송 실패"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "레버리지 거래 터미널"
 msgid "Receiver address"
 msgstr "수신자 주소"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "{0}에서 수신됨"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "네트워크 선택"
@@ -10887,6 +10919,7 @@ msgstr "자금 브릿징 중..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "능동적 운용"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "{0}에서 전송됨"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -2189,6 +2189,10 @@ msgstr ""
 msgid "Daily and cumulative PnL"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr ""
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr ""
@@ -3764,6 +3768,10 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr ""
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr ""
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr ""
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr ""
@@ -4182,6 +4193,10 @@ msgstr ""
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
+msgstr ""
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
 msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr ""
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr ""
 
@@ -5652,6 +5668,11 @@ msgstr ""
 msgid "Sending settle request..."
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr ""
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr ""
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr ""
 
@@ -7619,6 +7643,7 @@ msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7882,6 +7907,7 @@ msgstr ""
 msgid "of open fee"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
 msgstr ""
@@ -8840,6 +8866,7 @@ msgid "Receive (approximate)"
 msgstr ""
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
 msgstr ""
 
@@ -9547,6 +9574,10 @@ msgstr ""
 msgid "Receiver address"
 msgstr ""
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr ""
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr ""
@@ -10887,6 +10919,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11168,6 +11201,10 @@ msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
+msgstr ""
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "Ежедневный и совокупный PnL"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "Сумма ниже лимита перевода. Попробуйте сумму больше <0>{lowerLimitFormatted}</0>."
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "Позиции {longOrShort} не платят комиссию за финансирование и платят комиссию за заимствование {borrowRate} в час"
@@ -3764,6 +3768,10 @@ msgstr "Комиссия за финансирование"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "Отправка {0} на {1}"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "Установить допустимое влияние на цену"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "Вывод из стейкинга завершён"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20с"
@@ -4183,6 +4194,10 @@ msgstr "Смарт-кошельки не поддерживаются в Express
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "Исполнено"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "Сумма превышает лимит на перевод. Попробуйте сумму меньше <0>{upperLimitFormatted}</0>."
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "Не удалось загрузить данные ордера:"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "Сеть"
 
@@ -5652,6 +5668,11 @@ msgstr "Хранилище GMX"
 msgid "Sending settle request..."
 msgstr "Отправка запроса на расчёт..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "Отправка {0} на {1} не поддерживается"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "Невозможно вывести обеспечение. Оставшееся обеспечение будет ниже минимума"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1м 40с"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "Отменить TWAP обмен"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "Транзакция"
 
@@ -7619,6 +7643,7 @@ msgstr "Введите сумму внесения"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "от комиссии открытия"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "Отправлено"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "Получение (приблизительно)"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "Не удалось отправить"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "Терминал торговли с кредитным плечом"
 msgid "Receiver address"
 msgstr "Адрес получателя"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "Получено в {0}"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Выберите сеть"
@@ -10887,6 +10919,7 @@ msgstr "Перевод средств в..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "Активное управление"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "Отправлено в {0}"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "每日與累計 PnL"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "金額低於轉帳下限。請嘗試大於 <0>{lowerLimitFormatted}</0> 的金額。"
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "{longOrShort} 倉位不需支付資金費用，每小時支付借貸費用 {borrowRate}"
@@ -3764,6 +3768,10 @@ msgstr "資金費用"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "正在傳送 {0} 至 {1}"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "設定可接受的價格影響"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "解除質押完成"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20 秒"
@@ -4183,6 +4194,10 @@ msgstr "智能錢包不支援 Express Trading 或 One-Click Trading"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "已執行"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "金額超過轉帳上限。請嘗試小於 <0>{upperLimitFormatted}</0> 的金額。"
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "無法載入訂單資料："
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "網路"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX 金庫"
 msgid "Sending settle request..."
 msgstr "正在發送結算請求..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "不支援將 {0} 傳送至 {1}"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "無法提取抵押品。剩餘抵押品將低於最低要求"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1分40秒"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "取消 TWAP 兌換"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "交易"
 
@@ -7619,6 +7643,7 @@ msgstr "請輸入存入金額"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "開倉手續費的"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "已傳送"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "收到（估計）"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "傳送失敗"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "槓桿交易終端"
 msgid "Receiver address"
 msgstr "接收地址"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "已在 {0} 接收"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "選擇網路"
@@ -10887,6 +10919,7 @@ msgstr "資金正在跨鏈至..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "主動管理"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "已在 {0} 傳送"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2189,6 +2189,10 @@ msgstr "DefiLlama"
 msgid "Daily and cumulative PnL"
 msgstr "每日及累计 PnL"
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount is below the transfer limit. Try an amount larger than <0>{lowerLimitFormatted}</0>."
+msgstr "金额低于转账限额。请尝试大于 <0>{lowerLimitFormatted}</0> 的金额。"
+
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "{longOrShort} positions do not pay a funding fee and pay a borrow fee of {borrowRate} per hour"
 msgstr "{longOrShort} 仓位无需支付资金费用，每小时支付 {borrowRate} 的借贷费用"
@@ -3764,6 +3768,10 @@ msgstr "资金费用"
 msgid "{0}"
 msgstr "{0}"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sending {0} to {1}"
+msgstr "正在发送 {0} 至 {1}"
+
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 #: src/components/Earn/BuybackTracker/BuybackChart.tsx
 msgid "Cumulative"
@@ -3865,6 +3873,8 @@ msgstr "设置可接受的价格影响"
 #: src/components/GmxAccountModal/GmxAccountModalDesktop.tsx
 #: src/components/GmxAccountModal/GmxAccountModalMobile.tsx
 #: src/components/GmxAccountModal/MainView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send"
 msgstr ""
@@ -4054,6 +4064,7 @@ msgstr "解除质押完成"
 msgid "Export wallet"
 msgstr ""
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "20s"
 msgstr "20 秒"
@@ -4183,6 +4194,10 @@ msgstr "智能钱包不支持 Express Trading 或 One-Click Trading"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
 msgstr "已执行"
+
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Amount exceeds the transfer limit. Try an amount smaller than <0>{upperLimitFormatted}</0>."
+msgstr "金额超出转账限额。请尝试低于 <0>{upperLimitFormatted}</0> 的金额。"
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 msgid "V2 volume"
@@ -4638,6 +4653,7 @@ msgid "Failed to load order data:"
 msgstr "加载订单数据失败："
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Network"
 msgstr "网络"
 
@@ -5652,6 +5668,11 @@ msgstr "GMX 金库"
 msgid "Sending settle request..."
 msgstr "正在发送结算请求..."
 
+#: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
+msgid "Sending {0} to {1} is not supported"
+msgstr "不支持将 {0} 发送至 {1}"
+
 #: src/pages/Ecosystem/Ecosystem.tsx
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Creator"
@@ -6348,6 +6369,7 @@ msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgstr "无法提取抵押品。剩余抵押品将低于最低要求"
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
@@ -6711,6 +6733,7 @@ msgid "How do I share my code?"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "1m 40s"
 msgstr "1 分 40 秒"
@@ -6788,6 +6811,7 @@ msgid "Cancel TWAP Swap"
 msgstr "取消 TWAP 交换"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
 msgid "Transaction"
 msgstr "交易"
 
@@ -7619,6 +7643,7 @@ msgstr "输入存入金额"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
@@ -7883,8 +7908,9 @@ msgid "of open fee"
 msgstr "开仓费用"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Sent"
-msgstr ""
+msgstr "已发送"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Only use this for full account transfers.<0/>This will transfer all your GMX, esGMX, GLP, Multiplier Points and voting power to your new account.<1/>Transfers are only supported if the receiving account has not staked GMX or GLP tokens before.<2/>Transfers are one-way, you will not be able to transfer staked tokens back to the sending account."
@@ -8840,8 +8866,9 @@ msgid "Receive (approximate)"
 msgstr "收到（近似值）"
 
 #: src/components/GmxAccountModal/WalletSendView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 msgid "Send failed"
-msgstr ""
+msgstr "发送失败"
 
 #: src/pages/AccountDashboard/AccountDashboard.tsx
 msgid "Invalid Ethereum address"
@@ -9547,6 +9574,10 @@ msgstr "杠杆交易终端"
 msgid "Receiver address"
 msgstr "接收地址"
 
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Received on {0}"
+msgstr "已在 {0} 接收"
+
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Allow all tokens to transfer to the new account"
 msgstr ""
@@ -9736,6 +9767,7 @@ msgstr ""
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "选择网络"
@@ -10887,6 +10919,7 @@ msgstr "资金正在跨链转移至..."
 #: src/components/BridgeModal/BridgeOutModal.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/InfoRows.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
+#: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -11169,6 +11202,10 @@ msgstr ""
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Active management"
 msgstr "主动管理"
+
+#: src/domain/multichain/progress/walletCrossChainSendToast.tsx
+msgid "Sent on {0}"
+msgstr "已在 {0} 发送"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "DeBank"


### PR DESCRIPTION
- Add destination network selector to WalletSendView; bridge via Stargate OFT when the chosen network differs from the current chain
- Keep same-chain transfer as before; disable unsupported token/network routes with a button message matching the dropdown tooltip
- Track delivery by source tx hash (watchLzTx) and show a live LayerZero status toast (Sent / Received) styled like the GM/Order status toasts
- Return the source tx hash from sendCrossChainDepositTxn
- Translate new UI strings across all locales