### PR TITLE
Update animated hero title to 7 blockchains

### DIFF
--- a/landing/src/pages/Home/HeroSection/AnimatedTitle.tsx
+++ b/landing/src/pages/Home/HeroSection/AnimatedTitle.tsx
@@ -18,7 +18,7 @@ const TRANSITION = {
   },
 };
 
-const BLOCKCHAIN_COUNT = 8;
+const BLOCKCHAIN_COUNT = 7;
 
 export function AnimatedTitle() {
   const [currentIndex, setCurrentIndex] = useState<number>(0);


### PR DESCRIPTION
Updates the homepage hero animated title to read "Trade from 7 blockchains" instead of 8.

Changes `BLOCKCHAIN_COUNT` from `8` to `7` in `landing/src/pages/Home/HeroSection/AnimatedTitle.tsx`. The count is interpolated into the localized `from {BLOCKCHAIN_COUNT} blockchains` string, so no locale changes are required.