### PR TITLE
Update Avalanche synthetics stats subgraph URL

### DIFF
--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -31,7 +31,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
     referrals:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-avalanche-referrals/master-240415215829-f6877d6/gn",
     syntheticsStats:
-      "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-avalanche-stats/master-250410222549-4486206/gn",
+      "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-avalanche-stats/master-260605222642-1049f5c/gn",
     subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche:prod/api/graphql",
   },
 


### PR DESCRIPTION
Update the Avalanche `syntheticsStats` indexer to the new Goldsky subgraph deployment `master-260605222642-1049f5c` (previously `master-250410222549-4486206`) in `src/config/indexers.ts`.