### PR TITLE
Skip flaky live-network SDK multicall tests FEDEV-4029

### DIFF
--- a/sdk/src/clients/v1/modules/markets/markets.spec.ts
+++ b/sdk/src/clients/v1/modules/markets/markets.spec.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import { GmxSdk } from "clients/v1";
 import { arbitrumSdk, arbitrumSdkConfig } from "clients/v1/testUtil";
 
-describe("Markets", () => {
+// Skipped in CI (FEDEV-4029): hits the live gmxinfra API and is flaky (FetchError: Premature close).
+describe.skip("Markets", () => {
   describe("getMarkets", () => {
     it("should be able to get markets data", { timeout: 90_000 }, async () => {
       const marketsData = await arbitrumSdk.markets.getMarkets();

--- a/sdk/src/clients/v1/modules/orders/helpers.spec.ts
+++ b/sdk/src/clients/v1/modules/orders/helpers.spec.ts
@@ -8,7 +8,8 @@ import * as swapPath from "utils/swap/swapPath";
 import { TokenData, TokensData } from "utils/tokens/types";
 import * as tradeAmounts from "utils/trade/increase";
 
-describe("increaseOrderHelper", () => {
+// Skipped in CI (FEDEV-4029): beforeAll hits the live gmxinfra API and is flaky (FetchError: Premature close).
+describe.skip("increaseOrderHelper", () => {
   let marketsInfoData: MarketsInfoData;
   let tokensData: TokensData;
   let mockParams: any;

--- a/sdk/src/clients/v1/modules/orders/orders.spec.ts
+++ b/sdk/src/clients/v1/modules/orders/orders.spec.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { arbitrumSdk } from "clients/v1/testUtil";
 
-describe("Positions", () => {
+// Skipped in CI (FEDEV-4029): hits the live gmxinfra API and is flaky (FetchError: Premature close).
+describe.skip("Positions", () => {
   describe("read", () => {
     it("should be able to get orders", { timeout: 90_000 }, async () => {
       const { marketsInfoData, tokensData } = (await arbitrumSdk.markets.getMarketsInfo()) ?? {};

--- a/sdk/src/clients/v1/modules/positions/positions.spec.ts
+++ b/sdk/src/clients/v1/modules/positions/positions.spec.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { arbitrumSdk } from "clients/v1/testUtil";
 
-describe("Positions", () => {
+// Skipped in CI (FEDEV-4029): hits the live gmxinfra API and is flaky (FetchError: Premature close).
+describe.skip("Positions", () => {
   describe("getPositions", () => {
     it("should be able to get positions data", { timeout: 90_000 }, async () => {
       const { marketsInfoData, tokensData } = (await arbitrumSdk.markets.getMarketsInfo()) ?? {};

--- a/sdk/src/clients/v1/modules/tokens/tokens.spec.ts
+++ b/sdk/src/clients/v1/modules/tokens/tokens.spec.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import { GmxSdk } from "clients/v1";
 import { arbitrumSdk, arbitrumSdkConfig } from "clients/v1/testUtil";
 
-describe("Tokens", () => {
+// Skipped in CI (FEDEV-4029): hits the live gmxinfra API and is flaky (FetchError: Premature close).
+describe.skip("Tokens", () => {
   it("should be able to fetch tokens", { timeout: 90_000 }, async () => {
     const response = await arbitrumSdk.oracle.getTokens();
     expect(response).toBeDefined();

--- a/sdk/src/clients/v1/modules/trades/trades.spec.ts
+++ b/sdk/src/clients/v1/modules/trades/trades.spec.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { arbitrumSdk } from "clients/v1/testUtil";
 
-describe("Trades", () => {
+// Skipped in CI (FEDEV-4029): hits the live gmxinfra API and is flaky (FetchError: Premature close).
+describe.skip("Trades", () => {
   it("should be able to get positions", { timeout: 90_000 }, async () => {
     const { marketsInfoData, tokensData } = await arbitrumSdk.markets.getMarketsInfo();
 


### PR DESCRIPTION
Skips the six SDK multicall integration specs that fetch the live gmxinfra APIs and intermittently fail CI with `FetchError: Invalid response body ... Premature close`. These are network-flakiness failures, not code regressions, and they turn the `Run SDK multicall tests` step red on release CI.

Each suite is skipped with `describe.skip` and a comment referencing the follow-up task:

- `sdk/src/clients/v1/modules/markets/markets.spec.ts`
- `sdk/src/clients/v1/modules/positions/positions.spec.ts`
- `sdk/src/clients/v1/modules/tokens/tokens.spec.ts`
- `sdk/src/clients/v1/modules/orders/orders.spec.ts`
- `sdk/src/clients/v1/modules/trades/trades.spec.ts`
- `sdk/src/clients/v1/modules/orders/helpers.spec.ts` (fails in `beforeAll`, which fetches markets info)

Failing run: https://github.com/gmx-io/gmx-interface/actions/runs/28591137155/job/84774713593?pr=2607

After the change `yarn test:multicall` passes locally (15 tests skipped, 0 failures, no live fetches).

Follow-up task to stabilize these tests and un-skip them: https://linear.app/gmx-io/issue/FEDEV-4029/stabilize-flaky-sdk-multicall-tests-live-network-fetcherror-in-ci
