### PR TITLE
Use block-time minCollateralFactorForLiquidation for historical liquidation UI FEDEV-4003

### DIFF
--- a/sdk/scripts/subsquid-codegen.ts
+++ b/sdk/scripts/subsquid-codegen.ts
@@ -1,7 +1,7 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
+  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum@6230c4/api/graphql",
   overwrite: true,
   debug: true,
   generates: {

--- a/sdk/src/clients/v1/modules/trades/trades.ts
+++ b/sdk/src/clients/v1/modules/trades/trades.ts
@@ -266,6 +266,7 @@ export async function fetchTradeActions({
             fundingFeeAmount
             swapFeeUsd
             liquidationFeeAmount
+            minCollateralFactorForLiquidation
             pnlUsd
             basePnlUsd
 

--- a/sdk/src/codegen/subsquid.ts
+++ b/sdk/src/codegen/subsquid.ts
@@ -10655,6 +10655,7 @@ export interface TradeAction {
   isLong?: Maybe<Scalars["Boolean"]["output"]>;
   liquidationFeeAmount?: Maybe<Scalars["BigInt"]["output"]>;
   marketAddress?: Maybe<Scalars["String"]["output"]>;
+  minCollateralFactorForLiquidation?: Maybe<Scalars["BigInt"]["output"]>;
   minOutputAmount?: Maybe<Scalars["BigInt"]["output"]>;
   numberOfParts?: Maybe<Scalars["Int"]["output"]>;
   orderKey: Scalars["String"]["output"];
@@ -10816,6 +10817,12 @@ export enum TradeActionOrderByInput {
   marketAddress_DESC = "marketAddress_DESC",
   marketAddress_DESC_NULLS_FIRST = "marketAddress_DESC_NULLS_FIRST",
   marketAddress_DESC_NULLS_LAST = "marketAddress_DESC_NULLS_LAST",
+  minCollateralFactorForLiquidation_ASC = "minCollateralFactorForLiquidation_ASC",
+  minCollateralFactorForLiquidation_ASC_NULLS_FIRST = "minCollateralFactorForLiquidation_ASC_NULLS_FIRST",
+  minCollateralFactorForLiquidation_ASC_NULLS_LAST = "minCollateralFactorForLiquidation_ASC_NULLS_LAST",
+  minCollateralFactorForLiquidation_DESC = "minCollateralFactorForLiquidation_DESC",
+  minCollateralFactorForLiquidation_DESC_NULLS_FIRST = "minCollateralFactorForLiquidation_DESC_NULLS_FIRST",
+  minCollateralFactorForLiquidation_DESC_NULLS_LAST = "minCollateralFactorForLiquidation_DESC_NULLS_LAST",
   minOutputAmount_ASC = "minOutputAmount_ASC",
   minOutputAmount_ASC_NULLS_FIRST = "minOutputAmount_ASC_NULLS_FIRST",
   minOutputAmount_ASC_NULLS_LAST = "minOutputAmount_ASC_NULLS_LAST",
@@ -11194,6 +11201,15 @@ export interface TradeActionWhereInput {
   marketAddress_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
   marketAddress_not_startsWith?: InputMaybe<Scalars["String"]["input"]>;
   marketAddress_startsWith?: InputMaybe<Scalars["String"]["input"]>;
+  minCollateralFactorForLiquidation_eq?: InputMaybe<Scalars["BigInt"]["input"]>;
+  minCollateralFactorForLiquidation_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
+  minCollateralFactorForLiquidation_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
+  minCollateralFactorForLiquidation_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  minCollateralFactorForLiquidation_isNull?: InputMaybe<Scalars["Boolean"]["input"]>;
+  minCollateralFactorForLiquidation_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
+  minCollateralFactorForLiquidation_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
+  minCollateralFactorForLiquidation_not_eq?: InputMaybe<Scalars["BigInt"]["input"]>;
+  minCollateralFactorForLiquidation_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
   minOutputAmount_eq?: InputMaybe<Scalars["BigInt"]["input"]>;
   minOutputAmount_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
   minOutputAmount_gte?: InputMaybe<Scalars["BigInt"]["input"]>;

--- a/sdk/src/utils/tradeHistory/types.ts
+++ b/sdk/src/utils/tradeHistory/types.ts
@@ -52,6 +52,7 @@ export type PositionTradeAction = {
   shouldUnwrapNativeToken: boolean;
   totalImpactUsd?: bigint;
   liquidationFeeAmount?: bigint;
+  minCollateralFactorForLiquidation?: bigint;
   twapParams:
     | {
         twapGroupId: string;

--- a/sdk/src/utils/tradeHistory/utils.ts
+++ b/sdk/src/utils/tradeHistory/utils.ts
@@ -151,6 +151,9 @@ export function createRawTradeActionTransformer(
         fundingFeeAmount: rawAction.fundingFeeAmount ? BigInt(rawAction.fundingFeeAmount) : undefined,
         swapFeeUsd: rawAction.swapFeeUsd ? BigInt(rawAction.swapFeeUsd) : undefined,
         liquidationFeeAmount: rawAction.liquidationFeeAmount ? BigInt(rawAction.liquidationFeeAmount) : undefined,
+        minCollateralFactorForLiquidation: rawAction.minCollateralFactorForLiquidation
+          ? BigInt(rawAction.minCollateralFactorForLiquidation)
+          : undefined,
 
         reason: rawAction.reason ?? undefined,
         reasonBytes: rawAction.reasonBytes ?? undefined,

--- a/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
@@ -414,7 +414,7 @@ describe("TradeHistoryRow helpers", () => {
         "priceComment": [
           "Mark price for the liquidation",
           "",
-          "Liquidated as max leverage of 0.0x was exceeded when accounting for fees.",
+          "Liquidated as the max allowed leverage was exceeded when accounting for fees.",
           "",
           {
             "key": "Initial margin",
@@ -449,10 +449,7 @@ describe("TradeHistoryRow helpers", () => {
             },
           },
           "",
-          {
-            "key": "Minimum required margin",
-            "value": "< $ 0.01",
-          },
+          undefined,
           {
             "key": "Margin at liquidation",
             "value": "$ 83.95",
@@ -775,24 +772,31 @@ describe("TradeHistoryRow helpers", () => {
     expect(details.priceComment).toContainEqual({ key: "Minimum required margin", value: expectedMinMargin });
   });
 
-  it("formatPositionMessage falls back to current market config when block-time factor is missing", () => {
-    const currentFactor = PRECISION / 100n;
-    const fallbackLiquidation = {
-      ...liquidated,
-      marketInfo: {
-        ...liquidated.marketInfo,
-        minCollateralFactorForLiquidation: currentFactor,
-      },
-      minCollateralFactorForLiquidation: undefined,
-    };
+  it("formatPositionMessage hides factor-derived rows when the block-time factor is unresolved", () => {
+    for (const unresolved of [undefined, 0n]) {
+      const oldLiquidation = {
+        ...liquidated,
+        marketInfo: {
+          ...liquidated.marketInfo,
+          minCollateralFactorForLiquidation: PRECISION / 100n,
+        },
+        minCollateralFactorForLiquidation: unresolved,
+      };
 
-    const details = formatPositionMessage(fallbackLiquidation, minCollateralUsd);
+      const details = formatPositionMessage(oldLiquidation, minCollateralUsd);
+      const rowKeys = (details.priceComment ?? [])
+        .filter((line) => typeof line === "object" && line !== null && "key" in line)
+        .map((line) => (line as { key: string }).key);
 
-    const expectedMinMargin = formatUsd(applyFactor(fallbackLiquidation.sizeDeltaUsd, currentFactor));
-    expect(details.priceComment).toContainEqual({ key: "Minimum required margin", value: expectedMinMargin });
-    expect(details.priceComment).toContainEqual(
-      "Liquidated as max leverage of 100.0x was exceeded when accounting for fees."
-    );
+      expect(details.priceComment).toContainEqual(
+        "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+      );
+      expect(details.priceComment).not.toContainEqual(
+        "Liquidated as max leverage of 0.0x was exceeded when accounting for fees."
+      );
+      expect(rowKeys).not.toContain("Minimum required margin");
+      expect(rowKeys).toContain("Margin at liquidation");
+    }
   });
 
   it("formatPositionMessage includes indexed trader discounts in the fee breakdown", () => {

--- a/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
@@ -751,7 +751,6 @@ describe("TradeHistoryRow helpers", () => {
   });
 
   it("formatPositionMessage uses block-time minCollateralFactorForLiquidation for liquidations", () => {
-    // Current/on-hours market config (0.5% -> 200x) differs from the block-time/off-hours factor (1% -> 100x).
     const currentFactor = PRECISION / 200n;
     const blockTimeFactor = PRECISION / 100n;
 
@@ -766,12 +765,10 @@ describe("TradeHistoryRow helpers", () => {
 
     const details = formatPositionMessage(historicalLiquidation, minCollateralUsd);
 
-    // Max leverage context reflects the block-time factor (100x), not the current config (200x).
     expect(details.priceComment).toContainEqual(
       "Liquidated as max leverage of 100.0x was exceeded when accounting for fees."
     );
 
-    // Minimum required margin is computed from the block-time factor, not the current market config.
     const expectedMinMargin = formatUsd(applyFactor(historicalLiquidation.sizeDeltaUsd, blockTimeFactor));
     const currentConfigMinMargin = formatUsd(applyFactor(historicalLiquidation.sizeDeltaUsd, currentFactor));
     expect(expectedMinMargin).not.toBe(currentConfigMinMargin);
@@ -779,7 +776,6 @@ describe("TradeHistoryRow helpers", () => {
   });
 
   it("formatPositionMessage falls back to current market config when block-time factor is missing", () => {
-    // Old data without an indexed block-time factor keeps using the current market config.
     const currentFactor = PRECISION / 100n;
     const fallbackLiquidation = {
       ...liquidated,

--- a/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { OrderType } from "domain/synthetics/orders";
 import { TradeActionType } from "domain/synthetics/tradeHistory";
-import { MaxUint256 } from "lib/numbers";
+import { MaxUint256, PRECISION, applyFactor, formatUsd } from "lib/numbers";
 
 import {
   cancelOrderIncreaseLong,
@@ -748,6 +748,55 @@ describe("TradeHistoryRow helpers", () => {
       sizeDeltaUsd: MaxUint256,
     };
     expect(formatPositionMessage(fullCloseStopLoss, minCollateralUsd).size).toBe("Full position close");
+  });
+
+  it("formatPositionMessage uses block-time minCollateralFactorForLiquidation for liquidations", () => {
+    // Current/on-hours market config (0.5% -> 200x) differs from the block-time/off-hours factor (1% -> 100x).
+    const currentFactor = PRECISION / 200n;
+    const blockTimeFactor = PRECISION / 100n;
+
+    const historicalLiquidation = {
+      ...liquidated,
+      marketInfo: {
+        ...liquidated.marketInfo,
+        minCollateralFactorForLiquidation: currentFactor,
+      },
+      minCollateralFactorForLiquidation: blockTimeFactor,
+    };
+
+    const details = formatPositionMessage(historicalLiquidation, minCollateralUsd);
+
+    // Max leverage context reflects the block-time factor (100x), not the current config (200x).
+    expect(details.priceComment).toContainEqual(
+      "Liquidated as max leverage of 100.0x was exceeded when accounting for fees."
+    );
+
+    // Minimum required margin is computed from the block-time factor, not the current market config.
+    const expectedMinMargin = formatUsd(applyFactor(historicalLiquidation.sizeDeltaUsd, blockTimeFactor));
+    const currentConfigMinMargin = formatUsd(applyFactor(historicalLiquidation.sizeDeltaUsd, currentFactor));
+    expect(expectedMinMargin).not.toBe(currentConfigMinMargin);
+    expect(details.priceComment).toContainEqual({ key: "Minimum required margin", value: expectedMinMargin });
+  });
+
+  it("formatPositionMessage falls back to current market config when block-time factor is missing", () => {
+    // Old data without an indexed block-time factor keeps using the current market config.
+    const currentFactor = PRECISION / 100n;
+    const fallbackLiquidation = {
+      ...liquidated,
+      marketInfo: {
+        ...liquidated.marketInfo,
+        minCollateralFactorForLiquidation: currentFactor,
+      },
+      minCollateralFactorForLiquidation: undefined,
+    };
+
+    const details = formatPositionMessage(fallbackLiquidation, minCollateralUsd);
+
+    const expectedMinMargin = formatUsd(applyFactor(fallbackLiquidation.sizeDeltaUsd, currentFactor));
+    expect(details.priceComment).toContainEqual({ key: "Minimum required margin", value: expectedMinMargin });
+    expect(details.priceComment).toContainEqual(
+      "Liquidated as max leverage of 100.0x was exceeded when accounting for fees."
+    );
   });
 
   it("formatPositionMessage includes indexed trader discounts in the fee breakdown", () => {

--- a/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -538,10 +538,13 @@ export const formatPositionMessage = (
     //#endregion StopLossDecrease
     //#region Liquidation
   } else if (ot === OrderType.Liquidation && ev === TradeActionType.OrderExecuted) {
-    const maxLeverage =
-      tradeAction.marketInfo.minCollateralFactorForLiquidation === 0n
-        ? 0n
-        : PRECISION / tradeAction.marketInfo.minCollateralFactorForLiquidation;
+    // Use the block-time minCollateralFactorForLiquidation captured on the trade action so historical
+    // liquidation context is not reconstructed with the current (possibly changed) market config.
+    // Falls back to the current market config only when the historical value is unavailable (old data).
+    const minCollateralFactorForLiquidation =
+      tradeAction.minCollateralFactorForLiquidation ?? tradeAction.marketInfo.minCollateralFactorForLiquidation;
+
+    const maxLeverage = minCollateralFactorForLiquidation === 0n ? 0n : PRECISION / minCollateralFactorForLiquidation;
     const formattedMaxLeverage = Number(maxLeverage).toFixed(1) + "x";
 
     const initialCollateralUsd = convertToUsd(
@@ -589,7 +592,7 @@ export const formatPositionMessage = (
     );
     const formattedPositionFee = formatUsd(positionFeeUsd === undefined ? undefined : -positionFeeUsd);
 
-    let liquidationCollateralUsd = applyFactor(sizeDeltaUsd, tradeAction.marketInfo.minCollateralFactorForLiquidation);
+    let liquidationCollateralUsd = applyFactor(sizeDeltaUsd, minCollateralFactorForLiquidation);
     if (liquidationCollateralUsd < minCollateralUsd) {
       liquidationCollateralUsd = minCollateralUsd;
     }

--- a/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -538,9 +538,6 @@ export const formatPositionMessage = (
     //#endregion StopLossDecrease
     //#region Liquidation
   } else if (ot === OrderType.Liquidation && ev === TradeActionType.OrderExecuted) {
-    // Use the block-time minCollateralFactorForLiquidation captured on the trade action so historical
-    // liquidation context is not reconstructed with the current (possibly changed) market config.
-    // Falls back to the current market config only when the historical value is unavailable (old data).
     const minCollateralFactorForLiquidation =
       tradeAction.minCollateralFactorForLiquidation ?? tradeAction.marketInfo.minCollateralFactorForLiquidation;
 

--- a/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -539,10 +539,14 @@ export const formatPositionMessage = (
     //#region Liquidation
   } else if (ot === OrderType.Liquidation && ev === TradeActionType.OrderExecuted) {
     const minCollateralFactorForLiquidation =
-      tradeAction.minCollateralFactorForLiquidation ?? tradeAction.marketInfo.minCollateralFactorForLiquidation;
+      tradeAction.minCollateralFactorForLiquidation !== undefined && tradeAction.minCollateralFactorForLiquidation > 0n
+        ? tradeAction.minCollateralFactorForLiquidation
+        : undefined;
 
-    const maxLeverage = minCollateralFactorForLiquidation === 0n ? 0n : PRECISION / minCollateralFactorForLiquidation;
-    const formattedMaxLeverage = Number(maxLeverage).toFixed(1) + "x";
+    const formattedMaxLeverage =
+      minCollateralFactorForLiquidation === undefined
+        ? undefined
+        : Number(PRECISION / minCollateralFactorForLiquidation).toFixed(1) + "x";
 
     const initialCollateralUsd = convertToUsd(
       tradeAction.initialCollateralDeltaAmount,
@@ -589,8 +593,11 @@ export const formatPositionMessage = (
     );
     const formattedPositionFee = formatUsd(positionFeeUsd === undefined ? undefined : -positionFeeUsd);
 
-    let liquidationCollateralUsd = applyFactor(sizeDeltaUsd, minCollateralFactorForLiquidation);
-    if (liquidationCollateralUsd < minCollateralUsd) {
+    let liquidationCollateralUsd =
+      minCollateralFactorForLiquidation === undefined
+        ? undefined
+        : applyFactor(sizeDeltaUsd, minCollateralFactorForLiquidation);
+    if (liquidationCollateralUsd !== undefined && liquidationCollateralUsd < minCollateralUsd) {
       liquidationCollateralUsd = minCollateralUsd;
     }
 
@@ -600,7 +607,8 @@ export const formatPositionMessage = (
         : initialCollateralUsd + tradeAction.basePnlUsd! - borrowingFeeUsd! - fundingFeeUsd! - positionFeeUsd!;
 
     const formattedLeftoverCollateral = formatUsd(leftoverCollateralUsd!);
-    const formattedMinCollateral = formatUsd(liquidationCollateralUsd)!;
+    const formattedMinCollateral =
+      liquidationCollateralUsd === undefined ? undefined : formatUsd(liquidationCollateralUsd);
 
     const liquidationFeeUsd =
       convertToUsd(
@@ -643,7 +651,9 @@ export const formatPositionMessage = (
       priceComment: lines(
         t`Mark price for the liquidation`,
         "",
-        t`Liquidated as max leverage of ${formattedMaxLeverage} was exceeded when accounting for fees.`,
+        formattedMaxLeverage === undefined
+          ? t`Liquidated as the max allowed leverage was exceeded when accounting for fees.`
+          : t`Liquidated as max leverage of ${formattedMaxLeverage} was exceeded when accounting for fees.`,
         "",
         infoRow(t`Initial margin`, formattedInitialCollateral!),
         infoRow(t`PnL`, {
@@ -663,7 +673,7 @@ export const formatPositionMessage = (
           state: "error",
         }),
         "",
-        infoRow(t`Minimum required margin`, formattedMinCollateral),
+        formattedMinCollateral === undefined ? undefined : infoRow(t`Minimum required margin`, formattedMinCollateral),
         infoRow(t`Margin at liquidation`, formattedLeftoverCollateral),
         "",
         ...priceImpactLines,

--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -22,7 +22,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-arbitrum-referrals/master-240506225935-51167d5/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-260605170830-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@6230c4/api/graphql",
   },
 
   [AVALANCHE]: {
@@ -32,7 +32,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-avalanche-referrals/master-240415215829-f6877d6/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-avalanche-stats/master-260605222642-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche:prod/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche@6230c4/api/graphql",
   },
 
   [AVALANCHE_FUJI]: {
@@ -44,17 +44,17 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
   },
 
   [ARBITRUM_SEPOLIA]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia:prod/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia@6230c4/api/graphql",
   },
 
   [BOTANIX]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-botanix:prod/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-botanix@6230c4/api/graphql",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-botanix-stats/botanix-250617091016-f7b3bb5/gn",
   },
 
   [MEGAETH]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth:prod/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth@6230c4/api/graphql",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-megaeth-stats/master-260120151613-540f334/gn",
     referrals:

--- a/src/domain/synthetics/tradeHistory/useTradeHistory.ts
+++ b/src/domain/synthetics/tradeHistory/useTradeHistory.ts
@@ -346,6 +346,7 @@ export async function fetchRawTradeActions({
             fundingFeeAmount
             swapFeeUsd
             liquidationFeeAmount
+            minCollateralFactorForLiquidation
             pnlUsd
             basePnlUsd
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -465,6 +465,10 @@ msgstr "GMX Account Guthaben"
 msgid "Search in perpetuals markets"
 msgstr "In Perpetual-Märkten suchen"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "Liquidiert, da der maximal zulässige Hebel unter Berücksichtigung der Gebühren überschritten wurde."
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "Verkauf von {gmOrGlvLabel} fehlgeschlagen"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -465,6 +465,10 @@ msgstr "GMX Account balance"
 msgid "Search in perpetuals markets"
 msgstr "Search in perpetuals markets"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "Sell {gmOrGlvLabel} failed"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -465,6 +465,10 @@ msgstr "Saldo de GMX Account"
 msgid "Search in perpetuals markets"
 msgstr "Buscar en mercados perpetuos"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "Liquidado porque se superó el apalancamiento máximo permitido al considerar las comisiones."
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "Error al vender {gmOrGlvLabel}"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -465,6 +465,10 @@ msgstr "Solde du GMX Account"
 msgid "Search in perpetuals markets"
 msgstr "Rechercher dans les marchés perpétuels"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "Liquidé car l’effet de levier maximum autorisé a été dépassé après prise en compte des frais."
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "Échec de la vente de {gmOrGlvLabel}"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -465,6 +465,10 @@ msgstr "GMX Account残高"
 msgid "Search in perpetuals markets"
 msgstr "無期限市場を検索"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "手数料を考慮した結果、最大許容レバレッジを超えたため清算されました。"
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "{gmOrGlvLabel}の売却に失敗しました"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -465,6 +465,10 @@ msgstr "GMX Account 잔액"
 msgid "Search in perpetuals markets"
 msgstr "무기한 시장 검색"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "수수료를 고려했을 때 최대 허용 레버리지를 초과하여 청산되었습니다."
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "{gmOrGlvLabel} 판매 실패"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -465,6 +465,10 @@ msgstr ""
 msgid "Search in perpetuals markets"
 msgstr "[!! Search in perpetuals markets !!]"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -465,6 +465,10 @@ msgstr "Баланс GMX Account"
 msgid "Search in perpetuals markets"
 msgstr "Поиск на рынках бессрочных контрактов"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "Ликвидировано, так как максимальное допустимое кредитное плечо было превышено с учётом комиссий."
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "Не удалось продать {gmOrGlvLabel}"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -465,6 +465,10 @@ msgstr "GMX Account 餘額"
 msgid "Search in perpetuals markets"
 msgstr "搜尋永續合約市場"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "計入費用後，超過最大允許槓桿，已被清算。"
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "出售 {gmOrGlvLabel} 失敗"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -465,6 +465,10 @@ msgstr "GMX Account 余额"
 msgid "Search in perpetuals markets"
 msgstr "搜索永续合约市场"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+msgid "Liquidated as the max allowed leverage was exceeded when accounting for fees."
+msgstr "在计入费用后超出最大允许杠杆，仓位已被清算。"
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed"
 msgstr "出售 {gmOrGlvLabel} 失败"


### PR DESCRIPTION
## Summary

Historical liquidation rows/tooltips in Trade History reconstructed **Minimum required margin** and the max-leverage context from `tradeAction.marketInfo.minCollateralFactorForLiquidation` — the *current* market config. For markets that switch risk parameters (e.g. RWA/commodity markets toggling off-hours vs on-hours), this renders a misleading historical value.

This change reads the **block-time** `minCollateralFactorForLiquidation` now indexed on `TradeAction` (Subsquid slot `6230c4`) and uses it for the liquidation tooltip, so a past liquidation is explained with the config that applied at its block. It falls back to the current market config only when the historical value is unavailable (old data).

Example (WTIOIL/USD): renders the historical off-hours `1%` factor → `$9,526.02` minimum required margin instead of the later on-hours `0.5%` → `$4,763.01`.

## Changes

- **Subsquid**: point all chains except Fuji at slot `6230c4` (which indexes `TradeAction.minCollateralFactorForLiquidation`); bump the codegen source URL.
- **SDK**: add `minCollateralFactorForLiquidation` to the generated `TradeAction` type, both trade-history GraphQL queries, the raw→domain transformer, and `PositionTradeAction`.
- **UI**: `formatPositionMessage` liquidation branch uses the event-time factor (with fallback) for max leverage and minimum required margin.
- **Tests**: regression coverage for a liquidation whose factor changes after the execution block, plus the missing-value fallback.

Linear: https://linear.app/gmx-io/issue/FEDEV-4003/bug-use-block-time-market-config-for-historical-interface-calculations
