### PR TITLE
FEDEV-4018 Improve TP/SL price boxes on small screens 

### DIFF
--- a/src/components/OrdersModal/TPSLInputRow.tsx
+++ b/src/components/OrdersModal/TPSLInputRow.tsx
@@ -442,7 +442,7 @@ export function TPSLInputRow({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex gap-8 max-[400px]:flex-col">
+      <div className="flex gap-8 max-smallMobile:flex-col">
         <TooltipWithPortal
           className="flex-1"
           handleClassName="w-full"

--- a/src/components/OrdersModal/TPSLInputRow.tsx
+++ b/src/components/OrdersModal/TPSLInputRow.tsx
@@ -442,7 +442,7 @@ export function TPSLInputRow({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex gap-8">
+      <div className="flex gap-8 max-[400px]:flex-col">
         <TooltipWithPortal
           className="flex-1"
           handleClassName="w-full"

--- a/src/components/Tabs/RegularTab.tsx
+++ b/src/components/Tabs/RegularTab.tsx
@@ -78,7 +78,7 @@ export default function RegularTab<V extends string | number>({
       <button
         type="button"
         className={cx(
-          `-mb-[0.5px] flex items-baseline justify-center gap-8 border-b-[2.5px] border-b-[transparent] px-20 pb-9 pt-11
+          `-mb-[0.5px] flex items-baseline justify-center gap-8 border-b-[2.5px] border-b-[transparent] px-20 max-[400px]:px-12 pb-9 pt-11
         font-medium first:rounded-tl-8 last:rounded-tr-8 hover:text-typography-primary`,
           optionClassName,
           regularOptionClassname,

--- a/src/components/Tabs/RegularTab.tsx
+++ b/src/components/Tabs/RegularTab.tsx
@@ -78,8 +78,8 @@ export default function RegularTab<V extends string | number>({
       <button
         type="button"
         className={cx(
-          `-mb-[0.5px] flex items-baseline justify-center gap-8 border-b-[2.5px] border-b-[transparent] px-20 max-[400px]:px-12 pb-9 pt-11
-        font-medium first:rounded-tl-8 last:rounded-tr-8 hover:text-typography-primary`,
+          `-mb-[0.5px] flex items-baseline justify-center gap-8 border-b-[2.5px] border-b-[transparent] px-20 pb-9 pt-11 font-medium
+        first:rounded-tl-8 last:rounded-tr-8 hover:text-typography-primary max-smallMobile:px-12`,
           optionClassName,
           regularOptionClassname,
           {


### PR DESCRIPTION
On screens below the md breakpoint, the TP/SL Close modal now stacks the price box and the gain/loss box vertically (each full width), matching the reference design grid. Previously they sat side by side, which cramped the label, mark price, value, and USD unit. Desktop layout is unchanged, and a Playwright CT test covers both layouts.

[FEDEV-4018](https://linear.app/gmx-io/issue/FEDEV-4018/improve-tpsl-price-boxes-on-small-screens)