### PR TITLE
Enable passkey login for embedded wallet onboarding FEDEV-3954

### DIFF
--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -37,7 +37,6 @@ export default function WalletProvider({ children }: { children: React.ReactNode
         showWalletLoginFirst: true,
       },
       loginMethods: [...PRIVY_LOGIN_METHODS],
-      globalDisablePasskeys: true,
       defaultChain,
       supportedChains: [...supportedChains],
       externalWallets: {

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -38,7 +38,7 @@ export const PRIVY_WALLET_LIST = [
   "wallet_connect",
 ] as const;
 
-export const PRIVY_LOGIN_METHODS = ["wallet", "email", "google", "twitter", "discord"] as const;
+export const PRIVY_LOGIN_METHODS = ["wallet", "email", "google", "twitter", "discord", "passkey"] as const;
 
 const PRIVY_WALLET_REQUEST_TIMEOUT_MS = SECONDS_IN_DAY * 1000;
 


### PR DESCRIPTION
Enables passkey as a login method for Privy embedded wallet onboarding (Phase 4 of the embedded-wallet rollout):

- Add `passkey` to `PRIVY_LOGIN_METHODS`
- Remove the `globalDisablePasskeys` kill-switch from the Privy provider config (added when passkey was deferred out of Phase 1)

The Privy modal handles the passkey UX end to end: WebAuthn support detection (the option auto-hides on unsupported browsers/devices), captcha, the signup-vs-login chooser, and automatic embedded EOA creation through the existing `createOnLogin: "users-without-wallets"` config. Face ID / Touch ID / Android biometrics / Windows Hello appear natively in the OS passkey sheet, and analytics keeps them grouped under the existing `passkey` embedded wallet login method.

Requires the Privy dashboard to have the Passkey login method and passkeys-for-signup enabled (dev and prod apps). Flipping them on prod ahead of this release is safe because the currently deployed code still sets `globalDisablePasskeys: true`.

https://linear.app/gmx-io/issue/FEDEV-3954/phase-4-passkey-first-embedded-wallet-onboarding-with-face-id-touch-id