### PR TITLE
Open footer social links in a new tab FEDEV-4007

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -73,7 +73,7 @@ export default function Footer({ showRedirectModal, redirectPopupTimestamp, isMo
                 );
               }}
             >
-              <Button variant="ghost" href={platform.link} newTab>
+              <Button variant="ghost" to={platform.link} newTab>
                 <div className="size-16">{platform.icon}</div>
               </Button>
             </TrackingLink>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -73,7 +73,7 @@ export default function Footer({ showRedirectModal, redirectPopupTimestamp, isMo
                 );
               }}
             >
-              <Button variant="ghost" to={platform.link} newTab>
+              <Button variant="ghost" to={platform.link} newTab aria-label={platform.name}>
                 <div className="size-16">{platform.icon}</div>
               </Button>
             </TrackingLink>

--- a/src/components/TrackingLink/TrackingLink.tsx
+++ b/src/components/TrackingLink/TrackingLink.tsx
@@ -1,39 +1,50 @@
 import React from "react";
 
-type InternalLink = { to: string | { pathname: string }; onClick?: (e: React.MouseEvent) => void };
+type TrackingLinkChild = {
+  to?: string | { pathname: string };
+  href?: string;
+  newTab?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+};
 
-interface TrackingLinkProps<TChildren extends InternalLink | HTMLAnchorElement> {
+interface TrackingLinkProps<TChildren extends TrackingLinkChild> {
   onClick?: (e: React.MouseEvent<HTMLAnchorElement | HTMLDivElement, MouseEvent>) => Promise<void> | void;
   children: React.ReactElement<TChildren>;
 }
 
-export function TrackingLink<TChildren extends InternalLink | HTMLAnchorElement>({
-  onClick,
-  children,
-}: TrackingLinkProps<TChildren>) {
+export function TrackingLink<TChildren extends TrackingLinkChild>({ onClick, children }: TrackingLinkProps<TChildren>) {
   if (!children) {
     return null;
   }
 
   const handleClick = async (e: React.MouseEvent<HTMLAnchorElement | HTMLDivElement, MouseEvent>) => {
-    if (onClick) {
-      e.preventDefault();
-
-      try {
-        await onClick(e);
-      } catch (error) {
-        // ignore
-      }
-
-      // Navigate after the onClick completes
-      if ("href" in children.props) {
-        window.location.href = children.props.href;
-      } else if ("to" in children.props) {
-        const to = children.props.to;
-        window.location.href = typeof to === "string" ? to : to.pathname || "/";
-      }
-    } else if ("onClick" in children.props) {
+    if (!onClick) {
       children.props.onClick?.(e);
+      return;
+    }
+
+    const opensInNewTab = Boolean(children.props.newTab);
+
+    if (!opensInNewTab) {
+      e.preventDefault();
+    }
+
+    try {
+      await onClick(e);
+    } catch (error) {
+      // ignore
+    }
+
+    if (opensInNewTab) {
+      return;
+    }
+
+    // Navigate after the onClick completes
+    if (children.props.href) {
+      window.location.href = children.props.href;
+    } else if (children.props.to) {
+      const to = children.props.to;
+      window.location.href = typeof to === "string" ? to : to.pathname || "/";
     }
   };
 


### PR DESCRIPTION
## Problem

Footer social icons (X, Substack, Github, Telegram, Discord) opened the external site in the **same** browser tab, taking the user away from the GMX app.

Two things combined to cause this:

1. The social `<Button>` was given `href` — but `Button` only renders a real anchor (via `ButtonLink`, which applies `target="_blank" rel="noopener"`) when `to` is set. With `href` plus the `onClick` injected by `TrackingLink`, it rendered a plain `<button>`, so `newTab` was ignored.
2. `TrackingLink` overrode the child's `onClick`, called `e.preventDefault()`, and then navigated with `window.location.href = children.props.href` — always in the same tab.

## Fix

- **`Footer.tsx`**: render the social `Button` with `to` instead of `href`, so it renders a proper external link with `target="_blank" rel="noopener"`.
- **`TrackingLink.tsx`**: for new-tab children, don't `preventDefault`/navigate manually — fire tracking and let the browser open the new tab natively. (Doing `window.open` after an `await` would be popup-blocked; relying on the anchor's native default action isn't.) Same-tab links keep the previous behavior.

Both the desktop footer and the mobile side-nav footer render the same `Footer` component, so both are fixed. Non-social footer links are untouched, and social click tracking still fires for each icon.

https://linear.app/gmx-io/issue/FEDEV-4007/bug-footer-social-icons-open-in-the-same-tab-instead-of-a-new-tab