### PR TITLE
Use order-snapshotted uiFeeFactor in existing-order fee estimations (FEDEV-3968)

### DIFF
--- a/sdk/src/clients/v1/modules/orders/utils.spec.ts
+++ b/sdk/src/clients/v1/modules/orders/utils.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGetOrdersResponse } from "./utils";
+
+const ACCOUNT = "0x1000000000000000000000000000000000000001";
+const MARKET = "0x2000000000000000000000000000000000000002";
+const TOKEN = "0x3000000000000000000000000000000000000003";
+const ORDER_KEY = "0x4000000000000000000000000000000000000000000000000000000000000004";
+
+function makeRawOrder(uiFeeFactor: bigint) {
+  return {
+    orderKey: ORDER_KEY,
+    order: {
+      addresses: {
+        account: ACCOUNT,
+        receiver: ACCOUNT,
+        cancellationReceiver: ACCOUNT,
+        callbackContract: ACCOUNT,
+        uiFeeReceiver: ACCOUNT,
+        market: MARKET,
+        initialCollateralToken: TOKEN,
+        swapPath: [],
+      },
+      numbers: {
+        orderType: 2n,
+        decreasePositionSwapType: 0n,
+        sizeDeltaUsd: 1000n,
+        initialCollateralDeltaAmount: 100n,
+        triggerPrice: 0n,
+        acceptablePrice: 0n,
+        executionFee: 1n,
+        callbackGasLimit: 0n,
+        minOutputAmount: 0n,
+        uiFeeFactor,
+        updatedAtTime: 1n,
+        validFromTime: 0n,
+        srcChainId: 0n,
+      },
+      flags: { isLong: true, shouldUnwrapNativeToken: false, isFrozen: false, autoCancel: false },
+      _dataList: [],
+    },
+  };
+}
+
+function makeResponse(uiFeeFactors: bigint[]) {
+  return {
+    data: {
+      dataStore: {
+        count: { returnValues: [BigInt(uiFeeFactors.length)] },
+        keys: { returnValues: uiFeeFactors.map(() => ORDER_KEY) },
+      },
+      reader: {
+        orders: { returnValues: uiFeeFactors.map(makeRawOrder) },
+      },
+    },
+  } as any;
+}
+
+describe("parseGetOrdersResponse", () => {
+  it("extracts the uiFeeFactor snapshot from order numbers", () => {
+    const { orders } = parseGetOrdersResponse(makeResponse([5_000_000_000_000_000_000_000_000n]));
+
+    expect(orders[0].uiFeeFactor).toBe(5_000_000_000_000_000_000_000_000n);
+  });
+
+  it("keeps a zero snapshot as 0n for pre-upgrade orders", () => {
+    const { orders } = parseGetOrdersResponse(makeResponse([0n]));
+
+    expect(orders[0].uiFeeFactor).toBe(0n);
+    expect(orders[0].sizeDeltaUsd).toBe(1000n);
+  });
+});

--- a/sdk/src/clients/v1/modules/orders/utils.ts
+++ b/sdk/src/clients/v1/modules/orders/utils.ts
@@ -239,6 +239,7 @@ export function parseGetOrdersResponse(res: MulticallResult<ReturnType<typeof bu
         executionFee: BigInt(order.numbers.executionFee),
         callbackGasLimit: BigInt(order.numbers.callbackGasLimit),
         minOutputAmount: BigInt(order.numbers.minOutputAmount),
+        uiFeeFactor: BigInt(order.numbers.uiFeeFactor),
         updatedAtTime: BigInt(order.numbers.updatedAtTime),
         isLong: order.flags.isLong as boolean,
         shouldUnwrapNativeToken: order.flags.shouldUnwrapNativeToken as boolean,

--- a/sdk/src/utils/orders/types.ts
+++ b/sdk/src/utils/orders/types.ts
@@ -71,6 +71,8 @@ export type Order = {
   autoCancel: boolean;
   data: string[];
   uiFeeReceiver: string;
+  // snapshotted at order creation since v2.2c (0n for pre-upgrade orders); undefined when the data source doesn't provide it
+  uiFeeFactor: bigint | undefined;
   validFromTime: bigint;
   title?: string;
 };

--- a/src/context/SyntheticsStateContext/selectors/orderEditorSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/orderEditorSelectors.ts
@@ -136,7 +136,8 @@ const selectOrderEditorSwapFees = createSelector((q) => {
     feeDiscountUsd: 0n,
     swapProfitFeeUsd: 0n,
     swapProfitUsdIn: 0n,
-    uiFeeFactor,
+    // execution charges the factor snapshotted on the order, not the live one
+    uiFeeFactor: order.uiFeeFactor ?? uiFeeFactor,
     externalSwapQuote: undefined,
     type: "increase",
   });
@@ -397,7 +398,7 @@ export const selectOrderEditorDecreaseAmounts = createSelector((q) => {
     userReferralInfo,
     minCollateralUsd,
     minPositionSizeUsd,
-    uiFeeFactor,
+    uiFeeFactor: order.uiFeeFactor ?? uiFeeFactor,
     triggerOrderType: order.orderType as OrderType.LimitDecrease | OrderType.StopLossDecrease | undefined,
     isSetAcceptablePriceImpactEnabled,
   });
@@ -666,7 +667,7 @@ export const selectOrderEditorIncreaseAmounts = createSelector((q) => {
     position: existingPosition,
     findSwapPath,
     userReferralInfo,
-    uiFeeFactor,
+    uiFeeFactor: order.uiFeeFactor ?? uiFeeFactor,
     strategy: "independent",
     marketsInfoData,
     chainId,

--- a/src/domain/synthetics/orders/useOrders.ts
+++ b/src/domain/synthetics/orders/useOrders.ts
@@ -234,6 +234,8 @@ function convertApiOrderToOrder({
   ...rest
 }: ApiOrderInfo): Order {
   return {
+    // overridden by the spread once the API starts serving the snapshot
+    uiFeeFactor: undefined,
     ...rest,
     orderType: rest.orderType as OrderType,
     decreasePositionSwapType: rest.decreasePositionSwapType as DecreasePositionSwapType,
@@ -312,6 +314,7 @@ function parseResponse(res: MulticallResult<ReturnType<typeof buildUseOrdersMult
         executionFee: BigInt(orderData.numbers.executionFee),
         callbackGasLimit: BigInt(orderData.numbers.callbackGasLimit),
         minOutputAmount: BigInt(orderData.numbers.minOutputAmount),
+        uiFeeFactor: BigInt(orderData.numbers.uiFeeFactor),
         updatedAtTime: orderData.numbers.updatedAtTime,
         validFromTime: orderData.numbers.validFromTime,
         isLong: orderData.flags.isLong,

--- a/src/domain/synthetics/orders/utils.tsx
+++ b/src/domain/synthetics/orders/utils.tsx
@@ -421,7 +421,8 @@ function getIsMaxLeverageError({
     amountIn: order.initialCollateralDeltaAmount,
     isLimit: false,
     findSwapPath,
-    uiFeeFactor,
+    // execution charges the factor snapshotted on the order, not the live one
+    uiFeeFactor: order.uiFeeFactor ?? uiFeeFactor,
     marketsInfoData: undefined,
     externalSwapQuoteParams: undefined,
     chainId,


### PR DESCRIPTION
## What

Parse the snapshotted `uiFeeFactor` from Reader order responses, expose it on the `Order` type, and use it instead of the live factor when estimating execution outcomes for existing orders.

Part of FEDEV-3968 (SDK slice). Targets `qwinndev/update-v22c-contracts` — the ABI there already carries the field; this PR makes the client consume it.

## Why

Since v2.2c (gmx-synthetics `ce3cc0ae`) contracts snapshot `uiFeeFactor` at order creation and charge the snapshot at execution. `updateOrder` never re-snapshots it (verified: `OrderHandler.updateOrder` mutates only size/prices/minOutput/validFrom/autoCancel/executionFee, and `ce3cc0ae` touched no update path). Estimating an existing order with the live factor can diverge from what execution will actually charge.

## Changes

- `sdk/src/utils/orders/types.ts` — `uiFeeFactor: bigint | undefined` on `Order` (0n = snapshotted as zero, incl. pre-upgrade orders; undefined = data source doesn't provide it).
- `sdk/src/clients/v1/modules/orders/utils.ts`, `src/domain/synthetics/orders/useOrders.ts` — extract the field from `order.numbers` in both Reader parsers (the decoded tuple already carries it via the updated ABI).
- `src/domain/synthetics/orders/useOrders.ts` — API-fallback orders get an explicit `uiFeeFactor: undefined` placed before the spread, so the field flows automatically once gmx-api starts serving it.
- `src/domain/synthetics/orders/utils.tsx` — `getIsMaxLeverageError` simulates the collateral swap with `order.uiFeeFactor ?? live`.
- `src/context/SyntheticsStateContext/selectors/orderEditorSelectors.ts` — OrderEditor previews (swap fees / increase / decrease amounts) prefer the order's snapshot; nullish coalescing keeps a legitimate `0n` snapshot (no falsy-zero loss).
- `sdk/src/clients/v1/modules/orders/utils.spec.ts` — offline unit spec for the parser: value round-trip and `0n` preservation.

New-order previews (TradeBox, TP/SL sidecar, LP deposits) intentionally keep the live factor — the contract snapshots the current value at creation, so live is the correct estimate there.

## Checks

`yarn build-sdk`, `yarn tscheck:ci`, `yarn lint:ci`, `yarn test:ci`, targeted `vitest run sdk/.../orders/utils.spec.ts` — all green.

## Out of scope (rest of FEDEV-3968)

- gmx-api serving the snapshot on `/orders` (then the API-fallback path picks it up automatically).
- Withdrawal/Shift/GlvDeposit/GlvWithdrawal struct consumers — no SDK read path decodes those structs today.
- Squid slice: gmx-io/gmx-squid#181 (merged data live on the v2.2c testnet slot).
- SDK docs in gmx-docs.
