### PR TITLE
Reduce metrics sent to Datadog from the UI fedev-3993

### DIFF
--- a/sdk/src/utils/http/http.ts
+++ b/sdk/src/utils/http/http.ts
@@ -30,6 +30,15 @@ export class HttpError extends Error {
   }
 }
 
+// Passed to abort() so a timed-out request rejects with a distinguishable error instead of a
+// generic AbortError, which error reporting treats as a user-initiated abort and drops
+export class HttpTimeoutError extends Error {
+  constructor(timeoutMs: number, url: string) {
+    super(`HTTP timeout after ${timeoutMs}ms: ${url}`);
+    this.name = "HttpTimeoutError";
+  }
+}
+
 function throwHttpError(statusCode: number, statusText: string, errorBody?: Record<string, any>): never {
   let errorMessage = `HTTP ${statusCode}: ${statusText}`;
 
@@ -58,7 +67,7 @@ export class HttpClient implements IHttp {
     const url = buildUrl(this.url, path, query);
 
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timeoutId = setTimeout(() => controller.abort(new HttpTimeoutError(this.timeoutMs, url)), this.timeoutMs);
 
     try {
       const response = await fetch(url, {
@@ -98,7 +107,7 @@ export class HttpClient implements IHttp {
     const url = buildUrl(this.url, path);
 
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timeoutId = setTimeout(() => controller.abort(new HttpTimeoutError(this.timeoutMs, url)), this.timeoutMs);
 
     try {
       const response = await fetch(url, {

--- a/src/domain/synthetics/express/useSponsoredCallParamsRequest.ts
+++ b/src/domain/synthetics/express/useSponsoredCallParamsRequest.ts
@@ -13,6 +13,12 @@ export type SponsoredCallBalanceData = {
   isSponsoredCallAllowed: boolean;
 };
 
+function getIsTransportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return /failed to fetch|networkerror|load failed|network request failed/i.test(message);
+}
+
 export function useIsSponsoredCallBalanceAvailable(chainId: number): SponsoredCallBalanceData {
   const { data: isSponsoredCallAllowed } = useSWR<boolean>([chainId, "isSponsoredCallAllowed"], {
     refreshInterval: FREQUENT_UPDATE_INTERVAL,
@@ -30,7 +36,10 @@ export function useIsSponsoredCallBalanceAvailable(chainId: number): SponsoredCa
 
         return gasTankBalance.balance > MIN_GELATO_USD_BALANCE;
       } catch (error) {
-        metrics.pushError(error, "expressOrders.useIsSponsoredCallBalanceAvailable");
+        // Frequent poll: a transport failure is a client connection blip that floods Datadog at fleet scale
+        if (!getIsTransportError(error)) {
+          metrics.pushError(error, "expressOrders.useIsSponsoredCallBalanceAvailable");
+        }
         return false;
       }
     },

--- a/src/lib/abortSignalHelpers.ts
+++ b/src/lib/abortSignalHelpers.ts
@@ -1,7 +1,8 @@
 export function createTimeoutSignal(timeout: number): AbortSignal {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
-    controller.abort();
+    // abort(reason) so consumers can tell a timeout from a user-initiated abort (plain AbortError)
+    controller.abort(new DOMException(`Timed out after ${timeout}ms`, "TimeoutError"));
   }, timeout);
 
   controller.signal.addEventListener("abort", () => {

--- a/src/lib/metrics/Metrics.spec.ts
+++ b/src/lib/metrics/Metrics.spec.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { metrics, MetricEventParams } from "./Metrics";
+
+function makeCoalescedParams(errorMessage: string): MetricEventParams {
+  return {
+    event: "multicall.error",
+    isError: true,
+    data: { errorMessage, rpcProvider: "alchemy", requestType: "initial", isInMainThread: true },
+  };
+}
+
+function getQueuedEventPayloads() {
+  return metrics.queue.flatMap((item) => (item.type === "event" ? [item.payload] : []));
+}
+
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+}
+
+describe("Metrics coalescing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    metrics.queue = [];
+    for (const bucket of metrics.coalescedBuckets.values()) {
+      window.clearTimeout(bucket.timeoutId);
+    }
+    metrics.coalescedBuckets.clear();
+    setVisibilityState("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends non-coalesced events immediately", () => {
+    metrics.pushEvent<MetricEventParams>({ event: "some.event", data: {} });
+    metrics.pushEvent<MetricEventParams>({ event: "some.event", data: {} });
+
+    expect(getQueuedEventPayloads()).toHaveLength(2);
+  });
+
+  it("sends the first coalesced event immediately and folds identical repeats into one summary", () => {
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+
+    expect(getQueuedEventPayloads()).toHaveLength(1);
+
+    vi.advanceTimersByTime(60_000);
+
+    const payloads = getQueuedEventPayloads();
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1].event).toBe("multicall.error");
+    expect(payloads[1].isError).toBe(true);
+    expect(payloads[1].customFields.repeatCount).toBe(2);
+  });
+
+  it("does not fold events that differ in a key field", () => {
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("other"));
+
+    expect(getQueuedEventPayloads()).toHaveLength(2);
+  });
+
+  it("flushes a bucket with no repeats silently", () => {
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(getQueuedEventPayloads()).toHaveLength(1);
+    expect(metrics.coalescedBuckets.size).toBe(0);
+  });
+
+  it("timestamps firstSuppressedAt at the first suppressed repeat, not the sent event", () => {
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+    vi.advanceTimersByTime(10_000);
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+
+    vi.advanceTimersByTime(50_000);
+
+    const payloads = getQueuedEventPayloads();
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1].customFields.firstSuppressedAt).toBe(payloads[1].customFields.lastSuppressedAt);
+  });
+
+  it("holds even the first event in a hidden tab and delivers it on the visibility flush", () => {
+    setVisibilityState("hidden");
+    metrics.pushEvent<MetricEventParams>(makeCoalescedParams("boom"));
+
+    expect(getQueuedEventPayloads()).toHaveLength(0);
+
+    setVisibilityState("visible");
+    metrics.handleVisibilityChange();
+
+    const payloads = getQueuedEventPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].customFields.repeatCount).toBe(1);
+  });
+});
+
+describe("Metrics ignored errors", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    metrics.queue = [];
+    for (const bucket of metrics.coalescedBuckets.values()) {
+      window.clearTimeout(bucket.timeoutId);
+    }
+    metrics.coalescedBuckets.clear();
+    setVisibilityState("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("drops AbortError and known browser-noise errors", () => {
+    const abortError = new Error("signal is aborted without reason");
+    abortError.name = "AbortError";
+
+    metrics.pushError(abortError, "test");
+    metrics.pushError(new Error("The user aborted a request."), "test");
+    metrics.pushError(new Error("The operation was aborted."), "test");
+    metrics.pushError(new Error("can't access dead object"), "test");
+
+    expect(getQueuedEventPayloads()).toHaveLength(0);
+  });
+
+  it("still reports real errors", () => {
+    metrics.pushError(new Error("real failure"), "test");
+
+    expect(getQueuedEventPayloads()).toHaveLength(1);
+  });
+});

--- a/src/lib/metrics/Metrics.ts
+++ b/src/lib/metrics/Metrics.ts
@@ -12,7 +12,7 @@ import { sleep } from "lib/sleep";
 import { getRawSessionId } from "lib/userAnalytics/sessionId";
 import { getAppVersion } from "lib/version";
 import { getWalletNames, WalletNames } from "lib/wallets/getWalletNames";
-import { ErrorLike, parseError } from "sdk/utils/errors";
+import { ErrorData, ErrorLike, parseError } from "sdk/utils/errors";
 
 import { _debugMetrics } from "./_debug";
 import {
@@ -39,9 +39,32 @@ const BATCH_INTERVAL_MS = 3000;
 const BANNED_CUSTOM_FIELDS = ["metricId"];
 const BAD_REQUEST_ERROR = "BadRequest";
 
+const COALESCE_WINDOW_MS = 60_000;
+
+// Infra events that flood Datadog in identical storms (broken RPC, flapping endpoints).
+// Values are the data fields defining a "distinct" occurrence — only identical repeats are folded.
+const COALESCED_EVENTS: { [event: string]: string[] } = {
+  "multicall.timeout": ["metricType", "rpcProvider", "requestType", "isInMainThread"],
+  "multicall.error": ["errorMessage", "rpcProvider", "requestType", "isInMainThread"],
+  "worker.multicall.error": ["errorMessage"],
+  "rpcTracker.endpoint.updated": ["chainId", "primary", "secondary"],
+  error: ["errorName", "errorMessage", "errorSource"],
+};
+
+// Non-actionable browser noise: user-initiated fetch aborts (navigation/refresh) and Firefox "dead object" artifacts
+const IGNORED_ERROR_PATTERNS = [/user aborted a request/i, /operation was aborted/i, /can't access dead object/i];
+
 type CachedMetricData = { _metricDataCreated: number; metricId: string };
 type CachedMetricsData = { [key: string]: CachedMetricData };
 type Timers = { [key: string]: number };
+
+type CoalescedBucket = {
+  suppressedCount: number;
+  firstSuppressedAt: number;
+  lastSuppressedAt: number;
+  lastParams: MetricEventParams;
+  timeoutId: number;
+};
 
 class Metrics {
   fetcher?: OracleFetcher;
@@ -101,8 +124,92 @@ class Metrics {
     return this.fetcher.fetchPostBatchReport({ items });
   };
 
+  coalescedBuckets: Map<string, CoalescedBucket> = new Map();
+
   // Require Generic type to be specified
   pushEvent = <T extends MetricEventParams = never>(params: T) => {
+    if (this._coalesceEvent(params)) {
+      return;
+    }
+
+    this._pushEventImmediate(params);
+  };
+
+  _coalesceEvent = (params: MetricEventParams): boolean => {
+    const keyFields = COALESCED_EVENTS[params.event];
+
+    if (!keyFields) {
+      return false;
+    }
+
+    const data = (params.data ?? {}) as Record<string, unknown>;
+    const key = [params.event, ...keyFields.map((field) => String(data[field]))].join("|");
+    const bucket = this.coalescedBuckets.get(key);
+    const now = Date.now();
+
+    if (bucket) {
+      bucket.suppressedCount += 1;
+      // The bucket is created for an event that was sent, so the first *suppressed* one is timestamped here
+      if (bucket.suppressedCount === 1) {
+        bucket.firstSuppressedAt = now;
+      }
+      bucket.lastSuppressedAt = now;
+      bucket.lastParams = params;
+      return true;
+    }
+
+    const newBucket: CoalescedBucket = {
+      suppressedCount: 0,
+      firstSuppressedAt: now,
+      lastSuppressedAt: now,
+      lastParams: params,
+      timeoutId: window.setTimeout(() => this._flushCoalescedBucket(key), COALESCE_WINDOW_MS),
+    };
+
+    this.coalescedBuckets.set(key, newBucket);
+
+    // Hidden tabs are the main storm source (background polling of a broken RPC) — hold even
+    // the first occurrence; the visibilitychange flush will deliver it
+    if (document.visibilityState === "hidden") {
+      newBucket.suppressedCount = 1;
+      return true;
+    }
+
+    return false;
+  };
+
+  _flushCoalescedBucket = (key: string) => {
+    const bucket = this.coalescedBuckets.get(key);
+
+    if (!bucket) {
+      return;
+    }
+
+    window.clearTimeout(bucket.timeoutId);
+    this.coalescedBuckets.delete(key);
+
+    if (bucket.suppressedCount === 0) {
+      return;
+    }
+
+    this._pushEventImmediate({
+      ...bucket.lastParams,
+      data: {
+        ...((bucket.lastParams.data ?? {}) as object),
+        repeatCount: bucket.suppressedCount,
+        firstSuppressedAt: bucket.firstSuppressedAt,
+        lastSuppressedAt: bucket.lastSuppressedAt,
+      },
+    });
+  };
+
+  flushAllCoalesced = () => {
+    for (const key of Array.from(this.coalescedBuckets.keys())) {
+      this._flushCoalescedBucket(key);
+    }
+  };
+
+  _pushEventImmediate = (params: MetricEventParams) => {
     const { time, isError, data, event } = params;
 
     const payload: EventPayload = {
@@ -177,6 +284,10 @@ class Metrics {
       return;
     }
 
+    if (this._isIgnoredError(errorData)) {
+      return;
+    }
+
     const event: ErrorEvent = {
       event: "error",
       isError: true,
@@ -189,6 +300,16 @@ class Metrics {
     _debugMetrics?.logError(event);
 
     this.pushEvent(event);
+  };
+
+  _isIgnoredError = (errorData: ErrorData) => {
+    if (errorData.errorName === "AbortError") {
+      return true;
+    }
+
+    return IGNORED_ERROR_PATTERNS.some(
+      (pattern) => errorData.errorMessage !== undefined && pattern.test(errorData.errorMessage)
+    );
   };
 
   _processQueue = async (retryNumber = 0): Promise<void> => {
@@ -264,6 +385,8 @@ class Metrics {
     window.addEventListener(METRIC_TIMING_DISPATCH_NAME, this.handleWindowTiming);
     window.addEventListener("error", this.handleError);
     window.addEventListener("unhandledrejection", this.handleUnhandledRejection);
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    window.addEventListener("pagehide", this.handlePageHide);
     this.subscribeToLongTasks();
   };
 
@@ -273,6 +396,9 @@ class Metrics {
     window.removeEventListener(METRIC_TIMING_DISPATCH_NAME, this.handleWindowTiming);
     window.removeEventListener("error", this.handleError);
     window.removeEventListener("unhandledrejection", this.handleUnhandledRejection);
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    window.removeEventListener("pagehide", this.handlePageHide);
+    this.flushAllCoalesced();
     this.performanceObserver?.disconnect();
   };
 
@@ -338,6 +464,16 @@ class Metrics {
     if (error) {
       this.pushError(error, "unhandledRejection");
     }
+  };
+
+  handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      this.flushAllCoalesced();
+    }
+  };
+
+  handlePageHide = () => {
+    this.flushAllCoalesced();
   };
 
   // Require Generic type to be specified

--- a/src/lib/metrics/types.ts
+++ b/src/lib/metrics/types.ts
@@ -21,6 +21,8 @@ export type GlobalMetricData = {
   platform?: string;
   isInited?: boolean;
   srcChainId?: SourceChainId;
+  // Lets support match a user's report to their event timeline in Datadog
+  account?: string;
 };
 
 export enum OrderStage {
@@ -566,7 +568,7 @@ export type MulticallBatchedTiming = {
   data: {
     chainId: number;
     priority: string;
-    callsCount: number;
+    callsCountBucket: string;
   };
 };
 
@@ -611,7 +613,7 @@ export type MulticallBatchedCallCounter = {
   data: {
     chainId: number;
     priority: string;
-    callsCount: number;
+    callsCountBucket: string;
   };
 };
 
@@ -620,7 +622,7 @@ export type MulticallBatchedErrorCounter = {
   data: {
     chainId: number;
     priority: string;
-    callsCount: number;
+    callsCountBucket: string;
   };
 };
 

--- a/src/lib/metrics/useConfigureMetrics.ts
+++ b/src/lib/metrics/useConfigureMetrics.ts
@@ -18,7 +18,7 @@ import { metrics } from "./Metrics";
 export function useConfigureMetrics() {
   const { chainId, srcChainId } = useChainId();
   const fetcher = useOracleKeeperFetcher(chainId);
-  const { active } = useWallet();
+  const { active, account } = useWallet();
   const [showDebugValues] = useLocalStorageSerializeKey(SHOW_DEBUG_VALUES_KEY, false);
   const isMobileMetamask = useIsMetamaskMobile();
   const isWindowVisible = useIsWindowVisible();
@@ -60,9 +60,11 @@ export function useConfigureMetrics() {
       platform: bowser?.platform.type,
       isInited: Boolean(bowser),
       srcChainId,
+      account,
     });
   }, [
     active,
+    account,
     isMobileMetamask,
     isWindowVisible,
     isLargeAccount,

--- a/src/lib/multicall/Multicall.ts
+++ b/src/lib/multicall/Multicall.ts
@@ -342,21 +342,26 @@ export class Multicall {
             // eslint-disable-next-line no-console
             console.groupEnd();
 
-            emitMetricEvent<MulticallErrorEvent>({
-              event: "multicall.error",
-              isError: true,
-              data: {
+            // The timeout branch above has already reported this failure (multicall.timeout event + timeout counter)
+            const isTimeoutError = _viemError.message === "multicall timeout";
+
+            if (!isTimeoutError) {
+              emitMetricEvent<MulticallErrorEvent>({
+                event: "multicall.error",
+                isError: true,
+                data: {
+                  requestType: isFallback ? "retry" : "initial",
+                  rpcProvider: rpcProviderName,
+                  isInMainThread: !isWebWorker,
+                  errorMessage: _viemError.message,
+                },
+              });
+
+              sendCounterEvent("error", {
                 requestType: isFallback ? "retry" : "initial",
                 rpcProvider: rpcProviderName,
-                isInMainThread: !isWebWorker,
-                errorMessage: _viemError.message,
-              },
-            });
-
-            sendCounterEvent("error", {
-              requestType: "initial",
-              rpcProvider: rpcProviderName,
-            });
+              });
+            }
 
             sendDebugEvent(isFallback ? "fallback-failed" : "primary-failed", { providerUrl });
 

--- a/src/lib/multicall/executeMulticall.ts
+++ b/src/lib/multicall/executeMulticall.ts
@@ -77,6 +77,16 @@ function executeChainsMulticalls() {
   return Promise.allSettled(tasks);
 }
 
+// Exact counts as metric tags create a unique server-side metric key per value — report the magnitude class instead
+function getCallsCountBucket(callsCount: number): string {
+  if (callsCount <= 10) return "1-10";
+  if (callsCount <= 50) return "11-50";
+  if (callsCount <= 100) return "51-100";
+  if (callsCount <= 200) return "101-200";
+  if (callsCount <= 500) return "201-500";
+  return "500+";
+}
+
 async function executeChainMulticall(
   chainId: AnyChainId,
   calls: MulticallFetcherConfig[number],
@@ -97,7 +107,7 @@ async function executeChainMulticall(
     data: {
       chainId,
       priority,
-      callsCount: totalCallsCount,
+      callsCountBucket: getCallsCountBucket(totalCallsCount),
     },
   });
 
@@ -132,7 +142,7 @@ async function executeChainMulticall(
         data: {
           chainId,
           priority,
-          callsCount: callCount,
+          callsCountBucket: getCallsCountBucket(callCount),
         },
       });
     } else {
@@ -141,7 +151,7 @@ async function executeChainMulticall(
         data: {
           chainId,
           priority,
-          callsCount: callCount,
+          callsCountBucket: getCallsCountBucket(callCount),
         },
       });
     }


### PR DESCRIPTION
## Datadog log volume optimization

Identical infra-event storms (broken RPC × every open tab × fleet) dominate our Datadog log volume. This PR cuts the noise without losing signal.

### Changes

- **Coalesce storm events** (`multicall.timeout`, `multicall.error`, `worker.multicall.error`, `rpcTracker.endpoint.updated`, `error`): first occurrence is sent as-is, identical repeats within a 60s window are folded into one summary event with `repeatCount` / `firstSuppressedAt` / `lastSuppressedAt`. Hidden tabs (the main storm source) hold even the first event until the tab becomes visible or unloads.
- **Drop non-actionable errors**: `AbortError`, "user aborted a request", "operation was aborted", Firefox "dead object", and transport blips in the Gelato gas-tank poll.
- **Stop double-reporting RPC timeouts**: a timeout already reports itself (`multicall.timeout` + timeout counter), it is no longer also reported as `multicall.error` + error counter.
- **Bucket `callsCount`** → `callsCountBucket` ("1-10" … "500+") in `multicall.batched.*` to cap server-side metric-key cardinality.
- **Distinguishable timeout aborts**: SDK `HttpClient` and `createTimeoutSignal` now abort with `HttpTimeoutError` / `TimeoutError` instead of a plain `AbortError`, so the new abort filter can't swallow real backend timeouts.
- **Add `account`** (connected wallet) to global metric fields — lets support match a user's report to their event timeline.
- Fix: `multicall.request.error` counter now sends `requestType: "retry"` for fallback requests (was hardcoded `"initial"`).
- Tests: `Metrics.spec.ts` covering coalescing and the ignored-error filter.

### ⚠️ Breaking for Datadog dashboards / monitors

- `callsCount` field is **gone** → use `callsCountBucket` (string). Facets/filters on `callsCount` will be empty.
- `multicall.request.error` counter: timeouts are no longer counted (use `multicall.request.timeout`); `requestType:"retry"` appears for the first time.
- `multicall.error` event count drops — RPC timeouts are no longer duplicated into it.
- Coalesced events: true frequency = `count + sum(repeatCount)`, not `count`. Summaries arrive up to 60s late (from hidden tabs — only when the tab returns to visibility).
- `error` event baseline drops — aborts/browser noise and Gelato transport blips are filtered out.
- Timeout errors renamed: `AbortError` ("The user aborted a request") → `HttpTimeoutError` / `TimeoutError`. Saved searches on the old messages won't match.