### PR TITLE
Remove test event

### DIFF
--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -4,7 +4,6 @@ import { ReactNode } from "react";
 import { Link } from "react-router-dom";
 
 import { ARBITRUM, AVALANCHE, BOTANIX, MEGAETH } from "config/chains";
-import { isDevelopment } from "config/env";
 
 import ExternalLink from "components/ExternalLink/ExternalLink";
 import TokenIcon from "components/TokenIcon/TokenIcon";
@@ -46,19 +45,7 @@ export type EventData = {
   requiresOpenPosition?: string;
 };
 
-const testEvent: EventData = {
-  id: "test-event-flag",
-  type: "update",
-  flagId: "testEventFlagId",
-  endDate: "31 Dec 2026, 0:00",
-  title: "Test announcement",
-  description: (
-    <>Test announcement gated by the testEventFlagId KLI flag; its start date comes from the flag's createdAt.</>
-  ),
-};
-
 export const appEventsData: EventData[] = [
-  ...(isDevelopment() ? [testEvent] : []),
   {
     id: "release-117-highlights",
     type: "update",


### PR DESCRIPTION
## Summary

- Remove the development-only test announcement and its unused environment import.

## Testing

- `yarn test:ci`
- `yarn test:ct`
- `cd sdk && yarn test:ci`
- `yarn tscheck:ci`
- `yarn lint:ci`
- `yarn exec prettier --check src/config/events.tsx`
