### PR TITLE
Add Release 118 in-app announcement FEDEV-4087

### DIFF
--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -47,6 +47,40 @@ export type EventData = {
 
 export const appEventsData: EventData[] = [
   {
+    id: "release-118-highlights",
+    type: "update",
+    isActive: true,
+    startDate: "17 Jul 2026, 14:00",
+    endDate: "24 Jul 2026, 14:00",
+    variant: "info",
+    title: "App Update: Passkey Login, Wallet Funding, and Performance Sharing",
+    summary: (
+      <>
+        Sign in with a passkey, fund your wallet with a card, share your performance, and skip swap fees on TP/SL
+        closes.
+      </>
+    ),
+    description: (
+      <span className="flex flex-col gap-12">
+        <span>
+          Create a GMX wallet with just a passkey. Face ID, Touch ID, Windows Hello, or Android biometrics get you
+          trading, with no email or seed phrase required. Funding is built into the Receive flow: buy crypto with a
+          card, Apple Pay, or Google Pay, or transfer from another wallet, exchange, or chain.
+        </span>
+        <span>
+          Share your results: the Account Dashboard now generates a performance card with your PnL, win rate, and
+          cumulative PnL curve, carrying your referral code.
+        </span>
+        <span>
+          TP/SL and TWAP close orders can now return profit and collateral separately, skipping the internal swap and
+          its fee. The app also warns you if a resting increase order would be liquidatable at its trigger price.
+        </span>
+        <span>Your TradingView chart drawings and tool settings now survive refreshes.</span>
+        <span>The Support menu now shows how many replies came in while you were away.</span>
+      </span>
+    ),
+  },
+  {
     id: "release-117-highlights",
     type: "update",
     isActive: true,

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -50,7 +50,7 @@ export const appEventsData: EventData[] = [
     id: "release-118-highlights",
     type: "update",
     isActive: true,
-    startDate: "17 Jul 2026, 14:00",
+    startDate: "16 Jul 2026, 12:00",
     endDate: "24 Jul 2026, 14:00",
     variant: "info",
     title: "App Update: Passkey Login, Wallet Funding, and Performance Sharing",


### PR DESCRIPTION
## Summary

- Add the Release 118 in-app highlights announcement with the requested title, summary, and full description.
- Show the toast across all chains from July 17 to July 24, while keeping the announcement available on the Announcements page.
- Linear: https://linear.app/gmx-io/issue/FEDEV-4087/in-app-announcement-release-118-highlights
