### PR TITLE
Skip failing SDK positions test

### DIFF
--- a/sdk/src/clients/v1/modules/positions/positions.spec.ts
+++ b/sdk/src/clients/v1/modules/positions/positions.spec.ts
@@ -4,7 +4,7 @@ import { arbitrumSdk } from "clients/v1/testUtil";
 
 describe("Positions", () => {
   describe("getPositions", () => {
-    it("should be able to get positions data", { timeout: 90_000 }, async () => {
+    it.skip("should be able to get positions data", { timeout: 90_000 }, async () => {
       const { marketsInfoData, tokensData } = (await arbitrumSdk.markets.getMarketsInfo()) ?? {};
 
       if (!tokensData || !marketsInfoData) {


### PR DESCRIPTION
## Summary

- Skip the SDK positions data test that triggers an unhandled Vitest serialization error in CI.

## Testing

- Not run per request.