### PR TITLE
Reduce multicall metrics log volume FEDEV-3993

### DIFF
--- a/src/lib/FallbackTracker/__tests__/withFallback.spec.ts
+++ b/src/lib/FallbackTracker/__tests__/withFallback.spec.ts
@@ -14,7 +14,18 @@ describe("withFallback", () => {
 
       expect(result).toBe("success");
       expect(fn).toHaveBeenCalledTimes(1);
-      expect(fn).toHaveBeenCalledWith(testEndpoints.primary);
+      expect(fn).toHaveBeenCalledWith(testEndpoints.primary, { isLastAttempt: false });
+    });
+
+    it("should pass isLastAttempt=true when called with a single endpoint", async () => {
+      const fn = vi.fn().mockResolvedValue("success");
+      const result = await withFallback({
+        fn,
+        endpoints: [testEndpoints.primary],
+      });
+
+      expect(result).toBe("success");
+      expect(fn).toHaveBeenCalledWith(testEndpoints.primary, { isLastAttempt: true });
     });
   });
 
@@ -32,9 +43,9 @@ describe("withFallback", () => {
 
       expect(result).toBe("success");
       expect(fn).toHaveBeenCalledTimes(3);
-      expect(fn).toHaveBeenNthCalledWith(1, testEndpoints.primary);
-      expect(fn).toHaveBeenNthCalledWith(2, testEndpoints.secondary);
-      expect(fn).toHaveBeenNthCalledWith(3, testEndpoints.fallback);
+      expect(fn).toHaveBeenNthCalledWith(1, testEndpoints.primary, { isLastAttempt: false });
+      expect(fn).toHaveBeenNthCalledWith(2, testEndpoints.secondary, { isLastAttempt: false });
+      expect(fn).toHaveBeenNthCalledWith(3, testEndpoints.fallback, { isLastAttempt: true });
     });
 
     it("should call onFallback callback with correct context", async () => {
@@ -154,8 +165,8 @@ describe("withFallback", () => {
       expect(result).toBe("success");
       expect(shouldFallback).toHaveBeenCalledWith(expect.any(Error));
       expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(1, testEndpoints.primary);
-      expect(fn).toHaveBeenNthCalledWith(2, testEndpoints.secondary);
+      expect(fn).toHaveBeenNthCalledWith(1, testEndpoints.primary, { isLastAttempt: false });
+      expect(fn).toHaveBeenNthCalledWith(2, testEndpoints.secondary, { isLastAttempt: true });
     });
   });
 
@@ -238,8 +249,8 @@ describe("withFallback", () => {
       expect(result).toBe("result");
       expect(shouldFallback).toHaveBeenCalledWith(undefined, "result");
       expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(1, testEndpoints.primary);
-      expect(fn).toHaveBeenNthCalledWith(2, testEndpoints.secondary);
+      expect(fn).toHaveBeenNthCalledWith(1, testEndpoints.primary, { isLastAttempt: false });
+      expect(fn).toHaveBeenNthCalledWith(2, testEndpoints.secondary, { isLastAttempt: true });
     });
 
     it("should not fallback on last endpoint even if shouldFallback returns true", async () => {

--- a/src/lib/FallbackTracker/withFallback.ts
+++ b/src/lib/FallbackTracker/withFallback.ts
@@ -1,5 +1,5 @@
 type WithFallbackOptions<TReturn, TEndpoint> = {
-  fn: (endpoint: TEndpoint) => Promise<TReturn>;
+  fn: (endpoint: TEndpoint, ctx: WithFallbackAttemptContext) => Promise<TReturn>;
   shouldFallback?: (error?: Error, result?: TReturn) => boolean;
   endpoints: TEndpoint[];
   onFallback?: (ctx: WithFallbackContext<TEndpoint>) => void;
@@ -8,6 +8,10 @@ type WithFallbackOptions<TReturn, TEndpoint> = {
 type WithFallbackContext<TEndpoint> = {
   endpoint: TEndpoint;
   fallbacks: TEndpoint[];
+};
+
+export type WithFallbackAttemptContext = {
+  isLastAttempt: boolean;
 };
 
 export async function withFallback<TReturn, TEndpoint>({
@@ -25,7 +29,7 @@ export async function withFallback<TReturn, TEndpoint>({
     const remainingFallbacks = isLast ? [] : endpoints.slice(i + 1);
 
     try {
-      const result = await fn(endpoint);
+      const result = await fn(endpoint, { isLastAttempt: isLast });
 
       const needFallback = typeof shouldFallback === "function" ? shouldFallback(undefined, result) : false;
 

--- a/src/lib/metrics/Metrics.ts
+++ b/src/lib/metrics/Metrics.ts
@@ -226,7 +226,7 @@ class Metrics {
       this.isGlobalPropsFilled = true;
     }
 
-    this.queue = this.queue.slice(MAX_BATCH_LENGTH - 1);
+    this.queue = this.queue.slice(MAX_BATCH_LENGTH);
 
     _debugMetrics?.logSendBatchItems(items);
 

--- a/src/lib/multicall/Multicall.ts
+++ b/src/lib/multicall/Multicall.ts
@@ -218,7 +218,7 @@ export class Multicall {
 
     return withFallback({
       endpoints: [providerUrl, ...providerUrls.fallbacks],
-      fn: async (providerUrl: string) => {
+      fn: async (providerUrl: string, { isLastAttempt }) => {
         const isFallback = providerUrl !== providerUrls.primary;
 
         const rpcProviderName = getProviderNameFromUrl(providerUrl);
@@ -288,17 +288,19 @@ export class Multicall {
               rpcProvider: rpcProviderName,
             });
 
-            emitMetricEvent<MulticallTimeoutEvent>({
-              event: "multicall.timeout",
-              isError: true,
-              data: {
-                metricType: "rpcTimeout",
-                isInMainThread: !isWebWorker,
-                requestType: isFallback ? "retry" : "initial",
-                rpcProvider: rpcProviderName,
-                errorMessage: "multicall timeout",
-              },
-            });
+            if (isLastAttempt) {
+              emitMetricEvent<MulticallTimeoutEvent>({
+                event: "multicall.timeout",
+                isError: true,
+                data: {
+                  metricType: "rpcTimeout",
+                  isInMainThread: !isWebWorker,
+                  requestType: isFallback ? "retry" : "initial",
+                  rpcProvider: rpcProviderName,
+                  errorMessage: "multicall timeout",
+                },
+              });
+            }
 
             return Promise.reject(new Error("multicall timeout"));
           }),
@@ -342,21 +344,27 @@ export class Multicall {
             // eslint-disable-next-line no-console
             console.groupEnd();
 
-            emitMetricEvent<MulticallErrorEvent>({
-              event: "multicall.error",
-              isError: true,
-              data: {
+            const isTimeoutError = _viemError.message === "multicall timeout";
+
+            if (!isTimeoutError) {
+              if (isLastAttempt) {
+                emitMetricEvent<MulticallErrorEvent>({
+                  event: "multicall.error",
+                  isError: true,
+                  data: {
+                    requestType: isFallback ? "retry" : "initial",
+                    rpcProvider: rpcProviderName,
+                    isInMainThread: !isWebWorker,
+                    errorMessage: _viemError.message,
+                  },
+                });
+              }
+
+              sendCounterEvent("error", {
                 requestType: isFallback ? "retry" : "initial",
                 rpcProvider: rpcProviderName,
-                isInMainThread: !isWebWorker,
-                errorMessage: _viemError.message,
-              },
-            });
-
-            sendCounterEvent("error", {
-              requestType: "initial",
-              rpcProvider: rpcProviderName,
-            });
+              });
+            }
 
             sendDebugEvent(isFallback ? "fallback-failed" : "primary-failed", { providerUrl });
 


### PR DESCRIPTION
Emit multicall.error / multicall.timeout (rpcTimeout) events only when the last RPC endpoint attempt fails, i.e. they now mean "all endpoints exhausted" instead of "one attempt failed". Per-attempt failures are still tracked by the multicall.request.timeout / multicall.request.error counters, so dashboards built on these events will drop by design.

- withFallback: pass { isLastAttempt } attempt context to fn
- multicall.request.error counter: no longer incremented on timeouts (multicall.request.timeout counts those) and reports the actual requestType (initial/retry) instead of always "initial"
- worker.multicall.error and the workerTimeout multicall.timeout escape in executeMulticallWorker are intentionally unchanged
- Metrics: fix off-by-one in _processQueue batch slicing that re-sent the last item of every full 100-item batch