### PR TITLE
Fix leaderboard PnL accounting FEDEV-4019

### DIFF
--- a/sdk/src/codegen/subsquid.ts
+++ b/sdk/src/codegen/subsquid.ts
@@ -6490,6 +6490,8 @@ export interface PeriodAccountStatObject {
   losses: Scalars["Float"]["output"];
   maxCapital: Scalars["BigInt"]["output"];
   netCapital: Scalars["BigInt"]["output"];
+  /** Positive funding accrued as claimable in the period (claimed or not) */
+  positiveFundingFeesUsd: Scalars["BigInt"]["output"];
   realizedFees: Scalars["BigInt"]["output"];
   realizedPnl: Scalars["BigInt"]["output"];
   realizedPriceImpact: Scalars["BigInt"]["output"];

--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -22,7 +22,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-arbitrum-referrals/master-240506225935-51167d5/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-260605170830-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@6230c4/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@9c4ad1/api/graphql",
   },
 
   [AVALANCHE]: {
@@ -32,7 +32,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-avalanche-referrals/master-240415215829-f6877d6/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-avalanche-stats/master-260605222642-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche@6230c4/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche@9c4ad1/api/graphql",
   },
 
   [AVALANCHE_FUJI]: {
@@ -44,7 +44,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
   },
 
   [ARBITRUM_SEPOLIA]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia@6230c4/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia@9c4ad1/api/graphql",
   },
 
   [BOTANIX]: {
@@ -54,7 +54,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
   },
 
   [MEGAETH]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth@6230c4/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth@9c4ad1/api/graphql",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-megaeth-stats/master-260120151613-540f334/gn",
     referrals:

--- a/src/context/SyntheticsStateContext/selectors/__tests__/leaderboardSelectors.spec.ts
+++ b/src/context/SyntheticsStateContext/selectors/__tests__/leaderboardSelectors.spec.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import { LeaderboardAccount, LeaderboardPositionBase } from "domain/synthetics/leaderboard";
+import { DeepPartial } from "lib/types";
+
+import { SyntheticsState } from "../../SyntheticsStateContextProvider";
+import {
+  selectLeaderboardAccountsRanks,
+  selectLeaderboardRankedAccounts,
+  selectLeaderboardRankedAccountsByPnl,
+  selectLeaderboardRankedAccountsByPnlPercentage,
+} from "../leaderboardSelectors";
+
+function createAccount(overrides: Partial<LeaderboardAccount> = {}): LeaderboardAccount {
+  return {
+    account: "0x0000000000000000000000000000000000000001",
+    averageLeverage: 0n,
+    averageSize: 0n,
+    closedCount: 1,
+    cumsumCollateral: 0n,
+    cumsumSize: 0n,
+    hasRank: true,
+    losses: 0,
+    maxCapital: 10_000n,
+    netCapital: 0n,
+    pnlPercentage: 0n,
+    realizedFees: 1_000n,
+    realizedPnl: 10_000n,
+    realizedPriceImpact: -200n,
+    realizedSwapFees: 500n,
+    realizedSwapImpact: -300n,
+    positiveFundingFeesUsd: 400n,
+    startUnrealizedFees: 50n,
+    startUnrealizedPnl: 200n,
+    startUnrealizedPriceImpact: 0n,
+    sumMaxSize: 0n,
+    totalCount: 0,
+    totalFees: 0n,
+    totalPnl: 0n,
+    totalQualifyingPnl: 0n,
+    unrealizedFees: 0n,
+    unrealizedPnl: 0n,
+    volume: 0n,
+    wins: 1,
+    ...overrides,
+  };
+}
+
+function createPosition(overrides: Partial<LeaderboardPositionBase> = {}): LeaderboardPositionBase {
+  return {
+    key: "position-key",
+    account: "0x0000000000000000000000000000000000000001",
+    collateralAmount: 0n,
+    collateralToken: "0x0000000000000000000000000000000000000002",
+    entryPrice: 0n,
+    isLong: true,
+    isSnapshot: false,
+    market: "0x0000000000000000000000000000000000000003",
+    maxSize: 0n,
+    realizedFees: 0n,
+    realizedPnl: 0n,
+    realizedPriceImpact: 0n,
+    sizeInTokens: 0n,
+    sizeInUsd: 0n,
+    snapshotTimestamp: 0,
+    unrealizedFees: 0n,
+    unrealizedPnl: 0n,
+    unrealizedPriceImpact: 0n,
+    ...overrides,
+  };
+}
+
+function createState(accounts: LeaderboardAccount[], positions: LeaderboardPositionBase[] = []): SyntheticsState {
+  const state: DeepPartial<SyntheticsState> = {
+    leaderboard: {
+      accounts,
+      positions,
+      leaderboardDataType: "accounts",
+      leaderboardPageKey: "leaderboard",
+    },
+  };
+
+  return state as SyntheticsState;
+}
+
+describe("leaderboardSelectors", () => {
+  it("includes realized swap fees, swap impact, and positive funding in account PnL and PnL percentage", () => {
+    const [account] = selectLeaderboardRankedAccounts(createState([createAccount()]))!;
+
+    expect(account.totalQualifyingPnl).toBe(8_250n);
+    expect(account.pnlPercentage).toBe(8_250n);
+  });
+
+  it("uses Squid position PnL for live positions to match Account Performance", () => {
+    const longAccount = createAccount({
+      account: "0x0000000000000000000000000000000000000001",
+      realizedFees: 0n,
+      realizedPnl: 0n,
+      realizedPriceImpact: 0n,
+      realizedSwapFees: 0n,
+      realizedSwapImpact: 0n,
+      positiveFundingFeesUsd: 0n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+    const shortAccount = createAccount({
+      ...longAccount,
+      account: "0x0000000000000000000000000000000000000002",
+    });
+    const positions = [
+      createPosition({
+        account: longAccount.account,
+        isLong: true,
+        unrealizedPnl: 123n,
+      }),
+      createPosition({
+        key: "short-position-key",
+        account: shortAccount.account,
+        isLong: false,
+        unrealizedPnl: -456n,
+      }),
+    ];
+
+    const accounts = selectLeaderboardRankedAccounts(createState([longAccount, shortAccount], positions))!;
+
+    expect(accounts.find((account) => account.account === longAccount.account)?.unrealizedPnl).toBe(123n);
+    expect(accounts.find((account) => account.account === shortAccount.account)?.unrealizedPnl).toBe(-456n);
+  });
+
+  it("reproduces the reported account performance PnL", () => {
+    const reportedAccount = createAccount({
+      account: "0x8B262bD986f98Cf5F1e5dC13329Ab44e01364AD5",
+      maxCapital: 971639106271148873083323948823830n,
+      realizedPnl: 181616261023240050511226098557319059n,
+      realizedFees: 76234346270514491573918899491895957n,
+      realizedSwapFees: 563005008666748828343063631827190n,
+      realizedPriceImpact: -19827344546320417876682895216332189n,
+      realizedSwapImpact: -1771696578537105146428031407200800n,
+      positiveFundingFeesUsd: 1057038746736718298403207028128434n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+
+    const [account] = selectLeaderboardRankedAccounts(createState([reportedAccount]))!;
+
+    expect(account.totalQualifyingPnl).toBe(84276907365938005384256415838191357n);
+    expect(account.pnlPercentage).toBe(867368n);
+  });
+
+  it("uses realized swap fees and negative swap impact for sorting and ranks", () => {
+    const firstBeforeSwapAdjustments = createAccount({
+      account: "0x0000000000000000000000000000000000000001",
+      maxCapital: 1_000n,
+      realizedFees: 0n,
+      realizedPnl: 1_000n,
+      realizedPriceImpact: 0n,
+      realizedSwapFees: 300n,
+      realizedSwapImpact: -300n,
+      positiveFundingFeesUsd: 0n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+    const firstAfterSwapAdjustments = createAccount({
+      account: "0x0000000000000000000000000000000000000002",
+      maxCapital: 1_000n,
+      realizedFees: 0n,
+      realizedPnl: 500n,
+      realizedPriceImpact: 0n,
+      realizedSwapFees: 0n,
+      realizedSwapImpact: 0n,
+      positiveFundingFeesUsd: 0n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+    const state = createState([firstBeforeSwapAdjustments, firstAfterSwapAdjustments]);
+
+    expect(selectLeaderboardRankedAccountsByPnl(state)?.map((account) => account.account)).toEqual([
+      firstAfterSwapAdjustments.account,
+      firstBeforeSwapAdjustments.account,
+    ]);
+    expect(selectLeaderboardRankedAccountsByPnlPercentage(state)?.map((account) => account.account)).toEqual([
+      firstAfterSwapAdjustments.account,
+      firstBeforeSwapAdjustments.account,
+    ]);
+    expect(selectLeaderboardAccountsRanks(state).pnl.get(firstAfterSwapAdjustments.account)).toBe(1);
+    expect(selectLeaderboardAccountsRanks(state).pnlPercentage.get(firstAfterSwapAdjustments.account)).toBe(1);
+  });
+
+  it("uses positive swap impact and funding for PnL and percentage ranks", () => {
+    const firstByPnl = createAccount({
+      account: "0x0000000000000000000000000000000000000001",
+      maxCapital: 1_000n,
+      realizedFees: 0n,
+      realizedPnl: 100n,
+      realizedPriceImpact: 0n,
+      realizedSwapFees: 0n,
+      realizedSwapImpact: 200n,
+      positiveFundingFeesUsd: 200n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+    const firstByPnlPercentage = createAccount({
+      account: "0x0000000000000000000000000000000000000002",
+      maxCapital: 100n,
+      realizedFees: 0n,
+      realizedPnl: 400n,
+      realizedPriceImpact: 0n,
+      realizedSwapFees: 0n,
+      realizedSwapImpact: 0n,
+      positiveFundingFeesUsd: 0n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+    const state = createState([firstByPnlPercentage, firstByPnl]);
+
+    expect(selectLeaderboardRankedAccountsByPnl(state)?.map((account) => account.account)).toEqual([
+      firstByPnl.account,
+      firstByPnlPercentage.account,
+    ]);
+    expect(selectLeaderboardRankedAccountsByPnlPercentage(state)?.map((account) => account.account)).toEqual([
+      firstByPnlPercentage.account,
+      firstByPnl.account,
+    ]);
+    expect(selectLeaderboardAccountsRanks(state).pnl.get(firstByPnl.account)).toBe(1);
+    expect(selectLeaderboardAccountsRanks(state).pnlPercentage.get(firstByPnlPercentage.account)).toBe(1);
+  });
+
+  it("uses consistent ranks when account PnL percentages are equal", () => {
+    const higherPnl = createAccount({
+      account: "0x0000000000000000000000000000000000000001",
+      maxCapital: 200n,
+      realizedFees: 0n,
+      realizedPnl: 200n,
+      realizedPriceImpact: 0n,
+      realizedSwapFees: 0n,
+      realizedSwapImpact: 0n,
+      positiveFundingFeesUsd: 0n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+    const lowerPnl = createAccount({
+      account: "0x0000000000000000000000000000000000000002",
+      maxCapital: 100n,
+      realizedFees: 0n,
+      realizedPnl: 100n,
+      realizedPriceImpact: 0n,
+      realizedSwapFees: 0n,
+      realizedSwapImpact: 0n,
+      positiveFundingFeesUsd: 0n,
+      startUnrealizedFees: 0n,
+      startUnrealizedPnl: 0n,
+    });
+    const state = createState([lowerPnl, higherPnl]);
+
+    expect(selectLeaderboardRankedAccountsByPnl(state)?.map((account) => account.account)).toEqual([
+      higherPnl.account,
+      lowerPnl.account,
+    ]);
+    expect(selectLeaderboardRankedAccountsByPnlPercentage(state)?.map((account) => account.account)).toEqual([
+      lowerPnl.account,
+      higherPnl.account,
+    ]);
+    expect(selectLeaderboardAccountsRanks(state).pnl.get(higherPnl.account)).toBe(1);
+    expect(selectLeaderboardAccountsRanks(state).pnlPercentage.get(lowerPnl.account)).toBe(1);
+    expect(selectLeaderboardAccountsRanks(state).pnlPercentage.get(higherPnl.account)).toBe(2);
+  });
+});

--- a/src/context/SyntheticsStateContext/selectors/leaderboardSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/leaderboardSelectors.ts
@@ -9,6 +9,10 @@ import { selectAccount, selectMarketsInfoData, selectTokensData, selectUserRefer
 
 const BASIS_POINTS_DIVISOR = 10000n;
 
+function compareBigIntDescending(a: bigint, b: bigint) {
+  return a > b ? -1 : a < b ? 1 : 0;
+}
+
 const selectLeaderboardAccountBases = (s: SyntheticsState) => s.leaderboard.accounts;
 
 const selectLeaderboardPositionBases = (s: SyntheticsState) => s.leaderboard.positions;
@@ -60,6 +64,9 @@ export const selectLeaderboardCurrentAccount = createSelector(function selectLea
     netCapital: 0n,
     realizedFees: 0n,
     realizedPriceImpact: 0n,
+    realizedSwapFees: 0n,
+    realizedSwapImpact: 0n,
+    positiveFundingFeesUsd: 0n,
     pnlPercentage: 0n,
     realizedPnl: 0n,
     startUnrealizedFees: 0n,
@@ -103,7 +110,6 @@ const selectLeaderboardAccounts = createSelector(function selectLeaderboardAccou
 
   const baseAccounts = q(selectLeaderboardAccountBases);
   const positionBasesByAccount = q(selectPositionBasesByAccount);
-  const marketsInfoData = q(selectMarketsInfoData);
 
   if (!baseAccounts) return undefined;
 
@@ -122,17 +128,21 @@ const selectLeaderboardAccounts = createSelector(function selectLeaderboardAccou
     };
 
     for (const p of positionBasesByAccount[base.account] || []) {
-      const market = (marketsInfoData || {})[p.market];
-      const unrealizedPnl = getPositionPnl(p, market);
       account.totalCount++;
       account.sumMaxSize = account.sumMaxSize + p.maxSize;
       account.unrealizedFees = account.unrealizedFees + p.unrealizedFees;
-      account.unrealizedPnl = account.unrealizedPnl + unrealizedPnl;
+      account.unrealizedPnl = account.unrealizedPnl + p.unrealizedPnl;
     }
 
     account.totalFees = account.totalFees + account.unrealizedFees - account.startUnrealizedFees;
     account.totalPnl = account.totalPnl + account.unrealizedPnl - account.startUnrealizedPnl;
-    account.totalQualifyingPnl = account.totalPnl - account.totalFees + account.realizedPriceImpact;
+    account.totalQualifyingPnl =
+      account.totalPnl -
+      account.totalFees -
+      account.realizedSwapFees +
+      account.realizedPriceImpact +
+      account.realizedSwapImpact +
+      account.positiveFundingFeesUsd;
 
     if (account.maxCapital > 0n) {
       account.pnlPercentage = (account.totalQualifyingPnl * BASIS_POINTS_DIVISOR) / account.maxCapital;
@@ -159,14 +169,14 @@ export const selectLeaderboardRankedAccounts = createSelector(function selectLea
 export const selectLeaderboardRankedAccountsByPnl = createSelector(function selectLeaderboardRankedAccountsByPnl(q) {
   const accounts = q(selectLeaderboardRankedAccounts);
   if (!accounts) return undefined;
-  return [...accounts].sort((a, b) => (b.totalQualifyingPnl - a.totalQualifyingPnl > 0n ? 1 : -1));
+  return [...accounts].sort((a, b) => compareBigIntDescending(a.totalQualifyingPnl, b.totalQualifyingPnl));
 });
 
 export const selectLeaderboardRankedAccountsByPnlPercentage = createSelector(
   function selectLeaderboardRankedAccountsByPnlPercentage(q) {
     const accounts = q(selectLeaderboardRankedAccounts);
     if (!accounts) return undefined;
-    return [...accounts].sort((a, b) => (b.pnlPercentage - a.pnlPercentage > 0n ? 1 : -1));
+    return [...accounts].sort((a, b) => compareBigIntDescending(a.pnlPercentage, b.pnlPercentage));
   }
 );
 
@@ -175,16 +185,14 @@ export const selectLeaderboardAccountsRanks = createSelector(function selectLead
   const ranks = { pnl: new Map<string, number>(), pnlPercentage: new Map<string, number>() };
   if (!accounts) return ranks;
 
-  const accountsCopy = [...accounts];
-
-  accountsCopy
-    .sort((a, b) => (b.totalQualifyingPnl - a.totalQualifyingPnl > 0n ? 1 : -1))
+  [...accounts]
+    .sort((a, b) => compareBigIntDescending(a.totalQualifyingPnl, b.totalQualifyingPnl))
     .forEach((account, index) => {
       ranks.pnl.set(account.account, index + 1);
     });
 
-  accountsCopy
-    .sort((a, b) => (b.pnlPercentage - a.pnlPercentage > 0n ? 1 : -1))
+  [...accounts]
+    .sort((a, b) => compareBigIntDescending(a.pnlPercentage, b.pnlPercentage))
     .forEach((account, index) => {
       ranks.pnlPercentage.set(account.account, index + 1);
     });
@@ -219,7 +227,7 @@ export const selectLeaderboardPositions = createSelector(function selectLeaderbo
 
       if (!marketInfo) return undefined;
 
-      const unrealizedPnl = getPositionPnl(position, market);
+      const unrealizedPnl = position.unrealizedPnl;
 
       const pnl = position.realizedPnl + unrealizedPnl;
       const closingFeeUsd = getCloseFee(marketInfo, position.sizeInUsd, false, userReferralInfo);
@@ -260,26 +268,6 @@ export const selectLeaderboardPositions = createSelector(function selectLeaderbo
 
   return positions;
 });
-
-function getPositionPnl(position: LeaderboardPositionBase, market: MarketInfo) {
-  if (position.isSnapshot) {
-    return position.unrealizedPnl;
-  }
-
-  if (!market) {
-    return 0n;
-  }
-
-  let pnl =
-    (position.sizeInTokens * market.indexToken.prices.minPrice) / 10n ** BigInt(market.indexToken.decimals) -
-    position.sizeInUsd;
-
-  if (!position.isLong) {
-    pnl = pnl * -1n;
-  }
-
-  return pnl;
-}
 
 function getEntryPrice(sizeInUsd: bigint, sizeInTokens: bigint, decimals: number) {
   if (sizeInTokens <= 0n) {

--- a/src/domain/synthetics/leaderboard/index.ts
+++ b/src/domain/synthetics/leaderboard/index.ts
@@ -25,6 +25,9 @@ type LeaderboardAccountsJson = {
     realizedPnl: string;
     realizedPriceImpact: string;
     realizedFees: string;
+    realizedSwapFees: string;
+    realizedSwapImpact: string;
+    positiveFundingFeesUsd: string;
 
     startUnrealizedPnl: string;
     startUnrealizedPriceImpact: string;
@@ -49,6 +52,9 @@ type LeaderboardAccountsJson = {
     realizedPnl: string;
     realizedPriceImpact: string;
     realizedFees: string;
+    realizedSwapFees: string;
+    realizedSwapImpact: string;
+    positiveFundingFeesUsd: string;
 
     startUnrealizedPnl: string;
     startUnrealizedPriceImpact: string;
@@ -76,6 +82,9 @@ type LeaderboardAccountBase = {
   realizedPriceImpact: bigint;
   realizedFees: bigint;
   realizedPnl: bigint;
+  realizedSwapFees: bigint;
+  realizedSwapImpact: bigint;
+  positiveFundingFeesUsd: bigint;
 
   startUnrealizedPnl: bigint;
   startUnrealizedPriceImpact: bigint;
@@ -156,6 +165,9 @@ const fetchAccounts = async (
           netCapital
           realizedFees
           realizedPnl
+          realizedSwapFees
+          realizedSwapImpact
+          positiveFundingFeesUsd
           volume
           wins
           startUnrealizedPnl
@@ -174,6 +186,9 @@ const fetchAccounts = async (
           netCapital
           realizedFees
           realizedPnl
+          realizedSwapFees
+          realizedSwapImpact
+          positiveFundingFeesUsd
           volume
           wins
           startUnrealizedPnl
@@ -209,6 +224,9 @@ const fetchAccounts = async (
       realizedPnl: BigInt(p.realizedPnl),
       realizedPriceImpact: BigInt(p.realizedPriceImpact),
       realizedFees: BigInt(p.realizedFees),
+      realizedSwapFees: BigInt(p.realizedSwapFees),
+      realizedSwapImpact: BigInt(p.realizedSwapImpact),
+      positiveFundingFeesUsd: BigInt(p.positiveFundingFeesUsd),
 
       startUnrealizedPnl: BigInt(p.startUnrealizedPnl),
       startUnrealizedPriceImpact: BigInt(p.startUnrealizedPriceImpact),

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4446,6 +4446,7 @@ msgstr "Benutzer kopieren"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "Realisierter Swap-Einfluss"
 
@@ -5167,6 +5168,7 @@ msgstr "Letzte 180 Tage"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "Positive Finanzierungsgebühren"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "Realisierte Swap-Gebühren"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4446,6 +4446,7 @@ msgstr "Copy users"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "Realized swap impact"
 
@@ -5167,6 +5168,7 @@ msgstr "Last 180d"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "Positive funding fees"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "Realized swap fees"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4446,6 +4446,7 @@ msgstr "Copiar usuarios"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "Impacto de intercambio realizado"
 
@@ -5167,6 +5168,7 @@ msgstr "Últimos 180d"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "Comisiones de financiación positivas"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "Comisiones de intercambio realizadas"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4446,6 +4446,7 @@ msgstr "Copier les utilisateurs"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "Impact de swap réalisé"
 
@@ -5167,6 +5168,7 @@ msgstr "Derniers 180j"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "Frais de financement positifs"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "Frais de swap réalisés"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4446,6 +4446,7 @@ msgstr "ユーザーをコピー"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "実現スワップインパクト"
 
@@ -5167,6 +5168,7 @@ msgstr "過去180日"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "正のファンディング手数料"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "実現スワップ手数料"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4446,6 +4446,7 @@ msgstr "사용자 복사"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "실현된 스왑 영향"
 
@@ -5167,6 +5168,7 @@ msgstr "최근 180일"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "양의 펀딩 수수료"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "실현 스왑 수수료"
 

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4446,6 +4446,7 @@ msgstr ""
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr ""
 
@@ -5167,6 +5168,7 @@ msgstr ""
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr ""
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr ""
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr ""
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4446,6 +4446,7 @@ msgstr "Копировать пользователей"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "Реализованное влияние свопа"
 
@@ -5167,6 +5168,7 @@ msgstr "Последние 180д"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "Положительные комиссии за финансирование"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "Реализованные комиссии за своп"
 

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4446,6 +4446,7 @@ msgstr "複製使用者"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "已實現兌換影響"
 
@@ -5167,6 +5168,7 @@ msgstr "近 180 天"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "正向資金費用"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "已實現兌換費用"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4446,6 +4446,7 @@ msgstr "复制用户"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap impact"
 msgstr "已实现兑换影响"
 
@@ -5167,6 +5168,7 @@ msgstr "过去 180 天"
 
 #: src/components/Claims/ClaimableCardUI.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Positive funding fees"
 msgstr "正向资金费率"
 
@@ -11254,6 +11256,7 @@ msgid "PNG"
 msgstr "PNG"
 
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
+#: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "Realized swap fees"
 msgstr "已实现兑换费用"
 

--- a/src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
+++ b/src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -25,7 +25,7 @@ import { TableScrollFadeContainer } from "components/TableScrollFade/TableScroll
 import { TooltipPosition } from "components/Tooltip/Tooltip";
 import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
 
-import { formatDelta, getSignedValueClassName } from "./shared";
+import { compareLeaderboardValues, formatDelta, getLeaderboardRealizedPnl, getSignedValueClassName } from "./shared";
 
 function getCellClassname(rank: number | null, competition: CompetitionType | undefined, pinned: boolean) {
   if (pinned) return cx("LeaderboardRankCell-Pinned relative");
@@ -94,20 +94,24 @@ export function LeaderboardAccountsTable({
         key = "totalQualifyingPnl";
       }
 
-      let directionMultiplier = direction === "asc" ? -1 : 1;
+      let sortDirection: "asc" | "desc" = direction === "asc" ? "asc" : "desc";
 
       if (key === "wins" && direction === "asc") {
         key = "losses";
-        directionMultiplier = 1;
+        sortDirection = "desc";
       }
 
-      if (typeof a[key] === "bigint" && typeof b[key] === "bigint") {
-        return directionMultiplier * ((a[key] as bigint) > (b[key] as bigint) ? -1 : 1);
-      } else if (typeof a[key] === "number" && typeof b[key] === "number") {
-        return directionMultiplier * (a[key] > b[key] ? -1 : 1);
-      } else {
-        return 1;
+      const aValue = a[key];
+      const bValue = b[key];
+
+      if (
+        (typeof aValue === "bigint" && typeof bValue === "bigint") ||
+        (typeof aValue === "number" && typeof bValue === "number")
+      ) {
+        return compareLeaderboardValues(aValue, bValue, sortDirection);
       }
+
+      return 0;
     });
   }, [data, direction, orderBy]);
 
@@ -464,10 +468,8 @@ const LeaderboardPnlTooltipContent = memo(({ account }: { account: LeaderboardAc
   const shouldShowStartValues = isCompetition || type !== "all";
 
   const realizedFees = useMemo(() => account.realizedFees * -1n, [account.realizedFees]);
-  const realizedPnl = useMemo(
-    () => (isPnlAfterFees ? account.realizedPnl + realizedFees + account.realizedPriceImpact : account.realizedPnl),
-    [account.realizedPnl, account.realizedPriceImpact, isPnlAfterFees, realizedFees]
-  );
+  const realizedSwapFees = useMemo(() => account.realizedSwapFees * -1n, [account.realizedSwapFees]);
+  const realizedPnl = useMemo(() => getLeaderboardRealizedPnl(account, isPnlAfterFees), [account, isPnlAfterFees]);
 
   const unrealizedFees = useMemo(() => account.unrealizedFees * -1n, [account.unrealizedFees]);
   const unrealizedPnl = useMemo(
@@ -525,6 +527,24 @@ const LeaderboardPnlTooltipContent = memo(({ account }: { account: LeaderboardAc
             }
           />
           <StatsTooltipRow
+            label={t`Realized swap fees`}
+            showDollar={false}
+            value={
+              <span className={cx("numbers", getSignedValueClassName(realizedSwapFees))}>
+                {formatDelta(realizedSwapFees, { signed: true, prefix: "$" })}
+              </span>
+            }
+          />
+          <StatsTooltipRow
+            label={t`Positive funding fees`}
+            showDollar={false}
+            value={
+              <span className={cx("numbers", getSignedValueClassName(account.positiveFundingFeesUsd))}>
+                {formatDelta(account.positiveFundingFeesUsd, { signed: true, prefix: "$" })}
+              </span>
+            }
+          />
+          <StatsTooltipRow
             label={t`Unrealized fees`}
             showDollar={false}
             value={
@@ -551,6 +571,15 @@ const LeaderboardPnlTooltipContent = memo(({ account }: { account: LeaderboardAc
             value={
               <span className={cx("numbers", getSignedValueClassName(account.realizedPriceImpact))}>
                 {formatDelta(account.realizedPriceImpact, { signed: true, prefix: "$" })}
+              </span>
+            }
+          />
+          <StatsTooltipRow
+            label={t`Realized swap impact`}
+            showDollar={false}
+            value={
+              <span className={cx("numbers", getSignedValueClassName(account.realizedSwapImpact))}>
+                {formatDelta(account.realizedSwapImpact, { signed: true, prefix: "$" })}
               </span>
             }
           />

--- a/src/pages/LeaderboardPage/components/shared.spec.ts
+++ b/src/pages/LeaderboardPage/components/shared.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { compareLeaderboardValues, getLeaderboardRealizedPnl } from "./shared";
+
+describe("getLeaderboardRealizedPnl", () => {
+  const account = {
+    realizedPnl: 1_000n,
+    realizedFees: 100n,
+    realizedSwapFees: 20n,
+    realizedPriceImpact: -30n,
+    realizedSwapImpact: 40n,
+    positiveFundingFeesUsd: 10n,
+  };
+
+  it("returns gross realized PnL when fees and price impact are excluded", () => {
+    expect(getLeaderboardRealizedPnl(account, false)).toBe(1_000n);
+  });
+
+  it("includes all realized fees, impacts, and positive funding in net PnL", () => {
+    expect(getLeaderboardRealizedPnl(account, true)).toBe(900n);
+  });
+});
+
+describe("compareLeaderboardValues", () => {
+  it.each(["asc", "desc"] as const)("returns zero for equal bigint and number values in %s order", (direction) => {
+    expect(compareLeaderboardValues(1n, 1n, direction)).toBe(0);
+    expect(compareLeaderboardValues(1, 1, direction)).toBe(0);
+  });
+
+  it("sorts bigint and number values in the requested direction", () => {
+    expect(compareLeaderboardValues(2n, 1n, "desc")).toBe(-1);
+    expect(compareLeaderboardValues(2n, 1n, "asc")).toBe(1);
+    expect(compareLeaderboardValues(2, 1, "desc")).toBe(-1);
+    expect(compareLeaderboardValues(2, 1, "asc")).toBe(1);
+  });
+});

--- a/src/pages/LeaderboardPage/components/shared.ts
+++ b/src/pages/LeaderboardPage/components/shared.ts
@@ -1,3 +1,4 @@
+import type { LeaderboardAccount } from "domain/synthetics/leaderboard";
 import { formatAmount, USD_DECIMALS } from "lib/numbers";
 import { bigMath } from "sdk/utils/bigmath";
 
@@ -25,4 +26,41 @@ export function formatDelta(
 
 export function getSignedValueClassName(num: bigint) {
   return num === 0n ? "" : num < 0 ? "negative" : "positive";
+}
+
+type LeaderboardRealizedPnlAccount = Pick<
+  LeaderboardAccount,
+  | "realizedPnl"
+  | "realizedFees"
+  | "realizedSwapFees"
+  | "realizedPriceImpact"
+  | "realizedSwapImpact"
+  | "positiveFundingFeesUsd"
+>;
+
+export function getLeaderboardRealizedPnl(account: LeaderboardRealizedPnlAccount, isPnlAfterFees: boolean | undefined) {
+  if (!isPnlAfterFees) return account.realizedPnl;
+
+  return (
+    account.realizedPnl -
+    account.realizedFees -
+    account.realizedSwapFees +
+    account.realizedPriceImpact +
+    account.realizedSwapImpact +
+    account.positiveFundingFeesUsd
+  );
+}
+
+export function compareLeaderboardValues(a: bigint | number, b: bigint | number, direction: "asc" | "desc"): number {
+  let comparison = 0;
+
+  if (typeof a === "bigint" && typeof b === "bigint") {
+    comparison = a > b ? -1 : a < b ? 1 : 0;
+  } else if (typeof a === "number" && typeof b === "number") {
+    comparison = a > b ? -1 : a < b ? 1 : 0;
+  }
+
+  if (comparison === 0) return 0;
+
+  return direction === "asc" ? comparison * -1 : comparison;
 }


### PR DESCRIPTION
## Summary

- Include realized swap fees, realized swap impact, and positive funding fees in leaderboard PnL, percentage, sorting, ranks, and tooltip details.
- Use Squid's canonical unrealized position PnL so Leaderboard and Account Performance share the same calculation basis
- Linear: https://linear.app/gmx-io/issue/FEDEV-4019/bug-leaderboard-pnl-omits-realized-swap-fees-and-swap-impact
