### PR TITLE
Prevent PnL chart animation from restarting after zoom-out FEDEV-4097

### DIFF
--- a/src/pages/AccountDashboard/DailyAndCumulativePnLChart.tsx
+++ b/src/pages/AccountDashboard/DailyAndCumulativePnLChart.tsx
@@ -112,6 +112,7 @@ export function DailyAndCumulativePnLChart({
   resetKey: string;
 }) {
   const [zoomWindow, setZoomWindow] = useState<PnlZoomWindow | undefined>();
+  const [isBarAnimationActive, setIsBarAnimationActive] = useState(true);
   const showDebugValues = useShowDebugValues();
   const chartInteractionRef = useRef<HTMLDivElement>(null);
   const lastTouchTapRef = useRef(0);
@@ -125,6 +126,7 @@ export function DailyAndCumulativePnLChart({
   const zoomWindowRef = useRef<PnlZoomWindow | undefined>(undefined);
   const applyZoomWindow = useCallback((nextWindow: PnlZoomWindow | undefined) => {
     zoomWindowRef.current = nextWindow;
+    setIsBarAnimationActive(false);
     setZoomWindow(nextWindow);
   }, []);
 
@@ -188,12 +190,13 @@ export function DailyAndCumulativePnLChart({
 
   const isZoomed = Boolean(normalizedZoomWindow);
   const canZoom = groupedPnlData.length > 2;
-  const isBarAnimationActive = !isZoomed;
 
   useEffect(() => {
-    applyZoomWindow(undefined);
+    zoomWindowRef.current = undefined;
+    setZoomWindow(undefined);
+    setIsBarAnimationActive(true);
     wheelZoomAccumulatorRef.current = { value: 0 };
-  }, [applyZoomWindow, resetKey]);
+  }, [resetKey]);
 
   useEffect(() => {
     const element = chartInteractionRef.current;


### PR DESCRIPTION
## Summary

- keep the PnL bar entrance animation disabled after the first zoom interaction, including when zooming back to the full range
- re-enable the initial animation only when the chart reset key changes
- track the fix in [FEDEV-4097](https://linear.app/gmx-io/issue/FEDEV-4097/prevent-pnl-chart-animation-from-restarting-after-zoom-out)
