### PR TITLE
Fix false USDC balance warning FEDEV-4033

### DIFF
--- a/src/domain/tokens/useMaxAvailableAmount.spec.ts
+++ b/src/domain/tokens/useMaxAvailableAmount.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { ARBITRUM } from "sdk/configs/chainIds";
+import { getTokenBySymbol } from "sdk/configs/tokens";
+import type { TokenData } from "sdk/utils/tokens/types";
+
+import { getMaxAvailableTokenAmount, shouldShowGasPaymentTokenWarning } from "./useMaxAvailableAmount";
+
+const USDC = getTokenBySymbol(ARBITRUM, "USDC");
+const USDC_UNIT = 10n ** 6n;
+const USDC_DATA = {
+  ...USDC,
+  prices: {
+    minPrice: 10n ** 30n,
+    maxPrice: 10n ** 30n,
+  },
+} satisfies TokenData;
+
+describe("gas payment token warning threshold", () => {
+  const balance = 27_797_480_000n;
+  const gasPaymentTokenAmount = USDC_UNIT;
+  const maxDetails = getMaxAvailableTokenAmount({
+    chainId: ARBITRUM,
+    fromTokenAddress: USDC.address,
+    fromTokenBalance: balance,
+    gasPaymentToken: USDC_DATA,
+    gasPaymentTokenBalance: balance,
+    gasPaymentTokenAmount,
+    useMinimalBuffer: true,
+  });
+
+  it("keeps the minimal-buffer Max while retaining the safe warning threshold", () => {
+    expect(maxDetails).toEqual({
+      maxAvailableAmount: 27_796_080_000n,
+      safeMaxAvailableAmount: 27_776_480_000n,
+      bufferType: "minimal",
+    });
+  });
+
+  it("does not warn for a small swap with a large balance", () => {
+    expect(
+      shouldShowGasPaymentTokenWarning({
+        fromTokenAmount: 3n * USDC_UNIT,
+        fromTokenBalance: balance,
+        maxAvailableAmount: maxDetails.maxAvailableAmount,
+        safeMaxAvailableAmount: maxDetails.safeMaxAvailableAmount,
+      })
+    ).toBe(false);
+  });
+
+  it("warns when a near-Max swap consumes the safe gas reserve", () => {
+    expect(
+      shouldShowGasPaymentTokenWarning({
+        fromTokenAmount: 27_796n * USDC_UNIT,
+        fromTokenBalance: balance,
+        maxAvailableAmount: maxDetails.maxAvailableAmount,
+        safeMaxAvailableAmount: maxDetails.safeMaxAvailableAmount,
+      })
+    ).toBe(true);
+  });
+
+  it("still warns when a low balance can only support the minimal buffer", () => {
+    const lowBalance = 1_500_000n;
+    const lowBalanceMaxDetails = getMaxAvailableTokenAmount({
+      chainId: ARBITRUM,
+      fromTokenAddress: USDC.address,
+      fromTokenBalance: lowBalance,
+      gasPaymentToken: USDC_DATA,
+      gasPaymentTokenBalance: lowBalance,
+      gasPaymentTokenAmount,
+    });
+
+    expect(lowBalanceMaxDetails.bufferType).toBe("minimal");
+    expect(
+      shouldShowGasPaymentTokenWarning({
+        fromTokenAmount: 50_000n,
+        fromTokenBalance: lowBalance,
+        maxAvailableAmount: lowBalanceMaxDetails.maxAvailableAmount,
+        safeMaxAvailableAmount: lowBalanceMaxDetails.safeMaxAvailableAmount,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/domain/tokens/useMaxAvailableAmount.ts
+++ b/src/domain/tokens/useMaxAvailableAmount.ts
@@ -40,11 +40,13 @@ export function getMaxAvailableTokenAmount({
   useMinimalBuffer?: boolean;
 }): {
   maxAvailableAmount: bigint;
+  safeMaxAvailableAmount: bigint;
   bufferType?: "safe" | "minimal";
 } {
   if (fromTokenBalance === undefined || (!ignoreGasPaymentToken && gasPaymentToken === undefined)) {
     return {
       maxAvailableAmount: 0n,
+      safeMaxAvailableAmount: 0n,
       bufferType: undefined,
     };
   }
@@ -52,6 +54,7 @@ export function getMaxAvailableTokenAmount({
   if (ignoreGasPaymentToken || (gasPaymentToken !== undefined && fromTokenAddress !== gasPaymentToken.address)) {
     return {
       maxAvailableAmount: fromTokenBalance,
+      safeMaxAvailableAmount: fromTokenBalance,
       bufferType: "safe",
     };
   }
@@ -59,6 +62,7 @@ export function getMaxAvailableTokenAmount({
   if (gasPaymentToken === undefined || gasPaymentTokenBalance === undefined) {
     return {
       maxAvailableAmount: 0n,
+      safeMaxAvailableAmount: 0n,
       bufferType: undefined,
     };
   }
@@ -66,33 +70,37 @@ export function getMaxAvailableTokenAmount({
   const effectiveGasPaymentTokenAmount =
     gasPaymentTokenAmount > 0n ? gasPaymentTokenAmount : fallbackGasPaymentTokenAmount;
 
-  if (!useMinimalBuffer) {
-    const { min: minResidualUsd, max: maxResidualUsd } = getResidualGasUsd(chainId);
+  const { min: minResidualUsd, max: maxResidualUsd } = getResidualGasUsd(chainId);
 
-    const minResidualAmount = convertToTokenAmount(
-      minResidualUsd,
-      gasPaymentToken.decimals,
-      gasPaymentToken.prices.minPrice
-    )!;
+  const minResidualAmount = convertToTokenAmount(
+    minResidualUsd,
+    gasPaymentToken.decimals,
+    gasPaymentToken.prices.minPrice
+  )!;
 
-    const maxResidualAmount = convertToTokenAmount(
-      maxResidualUsd,
-      gasPaymentToken.decimals,
-      gasPaymentToken.prices.maxPrice
-    )!;
+  const maxResidualAmount = convertToTokenAmount(
+    maxResidualUsd,
+    gasPaymentToken.decimals,
+    gasPaymentToken.prices.maxPrice
+  )!;
 
-    let safeBuffer = bigMath.clamp(
-      effectiveGasPaymentTokenAmount * RESIDUAL_GAS_AMOUNT_MULTIPLIER,
-      minResidualAmount,
-      maxResidualAmount
-    );
+  const safeBuffer = bigMath.clamp(
+    effectiveGasPaymentTokenAmount * RESIDUAL_GAS_AMOUNT_MULTIPLIER,
+    minResidualAmount,
+    maxResidualAmount
+  );
 
-    if (safeBuffer + effectiveGasPaymentTokenAmount <= gasPaymentTokenBalance) {
-      return {
-        maxAvailableAmount: gasPaymentTokenBalance - safeBuffer - effectiveGasPaymentTokenAmount,
-        bufferType: "safe",
-      };
-    }
+  const hasSafeBuffer = safeBuffer + effectiveGasPaymentTokenAmount <= gasPaymentTokenBalance;
+  const safeMaxAvailableAmount = hasSafeBuffer
+    ? gasPaymentTokenBalance - safeBuffer - effectiveGasPaymentTokenAmount
+    : 0n;
+
+  if (!useMinimalBuffer && hasSafeBuffer) {
+    return {
+      maxAvailableAmount: safeMaxAvailableAmount,
+      safeMaxAvailableAmount,
+      bufferType: "safe",
+    };
   }
 
   if (effectiveGasPaymentTokenAmount > 0n) {
@@ -100,12 +108,32 @@ export function getMaxAvailableTokenAmount({
     if (gasPaymentTokenBalance >= minimalBuffer) {
       return {
         maxAvailableAmount: gasPaymentTokenBalance - minimalBuffer,
+        safeMaxAvailableAmount,
         bufferType: "minimal",
       };
     }
   }
 
-  return { maxAvailableAmount: 0n, bufferType: undefined };
+  return { maxAvailableAmount: 0n, safeMaxAvailableAmount, bufferType: undefined };
+}
+
+export function shouldShowGasPaymentTokenWarning({
+  fromTokenAmount,
+  fromTokenBalance,
+  maxAvailableAmount,
+  safeMaxAvailableAmount,
+}: {
+  fromTokenAmount: bigint;
+  fromTokenBalance: bigint;
+  maxAvailableAmount: bigint;
+  safeMaxAvailableAmount: bigint;
+}): boolean {
+  return (
+    maxAvailableAmount > 0n &&
+    fromTokenAmount > 0n &&
+    fromTokenAmount <= fromTokenBalance &&
+    fromTokenAmount > safeMaxAvailableAmount
+  );
 }
 
 export function useMaxAvailableAmount({
@@ -159,7 +187,7 @@ export function useMaxAvailableAmount({
   const { chainId } = useChainId();
   const isMetamaskMobile = useIsMetamaskMobile();
 
-  const { maxAvailableAmount, bufferType } = getMaxAvailableTokenAmount({
+  const { maxAvailableAmount, safeMaxAvailableAmount } = getMaxAvailableTokenAmount({
     chainId,
     fromTokenAddress: fromToken?.address,
     fromTokenBalance,
@@ -207,20 +235,19 @@ export function useMaxAvailableAmount({
     gasPaymentToken !== undefined &&
     gasPaymentTokenAmount !== undefined &&
     gasPaymentToken.address === fromToken.address &&
-    maxAvailableAmount > 0n &&
     fromTokenAmount !== undefined &&
-    fromTokenAmount > 0n
+    shouldShowGasPaymentTokenWarning({
+      fromTokenAmount,
+      fromTokenBalance,
+      maxAvailableAmount,
+      safeMaxAvailableAmount,
+    })
   ) {
-    const isDifferentEnough = fromTokenAmount > maxAvailableAmount;
-    const aboveBalance = fromTokenAmount > fromTokenBalance;
-
-    if (!aboveBalance && (bufferType === "minimal" || isDifferentEnough)) {
-      gasPaymentTokenWarningContent = getLowGasPaymentTokenBalanceWarning({
-        chainId,
-        isGmxAccount,
-        symbol: gasPaymentToken.symbol,
-      });
-    }
+    gasPaymentTokenWarningContent = getLowGasPaymentTokenBalanceWarning({
+      chainId,
+      isGmxAccount,
+      symbol: gasPaymentToken.symbol,
+    });
   }
 
   const formattedMaxAvailableAmount = formatAmountFree(


### PR DESCRIPTION
## Summary

- Keep the minimal-buffer Max available for gas-token-to-gas-token swaps while retaining the safe-reserve Max as the low-balance warning threshold.
- Prevent small USDC → WETH swaps from showing a false low-USDC warning without suppressing near-Max or genuinely low-balance warnings.
- Linear: https://linear.app/gmx-io/issue/FEDEV-4033/bug-swap-shows-false-low-usdc-balance-warning-despite-large-usdc
