### PR TITLE
Unblock smart wallet users for Express and One-Click FEDEV-3682

### DIFF
--- a/src/components/GmxAccountModal/DepositView.tsx
+++ b/src/components/GmxAccountModal/DepositView.tsx
@@ -72,7 +72,7 @@ import { EMPTY_ARRAY, EMPTY_OBJECT, getByKey } from "lib/objects";
 import { TxnCallback, TxnEventName, WalletTxnCtx } from "lib/transactions";
 import { getPageOutdatedError, useHasOutdatedUi } from "lib/useHasOutdatedUi";
 import { useThrottledAsync } from "lib/useThrottledAsync";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 import { getPublicClientWithRpc } from "lib/wallets/walletConfig";
 import { abis } from "sdk/abis";
 import { convertTokenAddress, getToken } from "sdk/configs/tokens";
@@ -578,8 +578,8 @@ export const DepositView = () => {
 
   const subaccountState = useSubaccountContext();
 
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
-  const isExpressTradingDisabled = isNonEoaAccountOnAnyChain;
+  const { isExpressAccountSupported } = useExpressAccountSupport();
+  const isExpressTradingDisabled = !isExpressAccountSupported;
   const hasOutdatedUi = useHasOutdatedUi();
   const multipleWalletExtensionsChainError = useMultipleWalletExtensionsChainError();
 

--- a/src/components/GmxAccountModal/MainView.tsx
+++ b/src/components/GmxAccountModal/MainView.tsx
@@ -121,8 +121,8 @@ function WalletBlock({ account }: { account: string }) {
   const embeddedWallet = getEmbeddedConnectedWallet(wallets);
   const canExport = Boolean(embeddedWallet && account && isAddressEqual(embeddedWallet.address, account));
 
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
-  const canSend = !isNonEoaAccountOnAnyChain;
+  const { isNonSigningAccountOnAnyChain } = useNonSigningAccount();
+  const canSend = !isNonSigningAccountOnAnyChain;
 
   const accountUrl = !account || !chainId ? "" : `${getExplorerUrl(chainId)}address/${account}`;
 

--- a/src/components/NetworkDropdown/NetworkDropdown.tsx
+++ b/src/components/NetworkDropdown/NetworkDropdown.tsx
@@ -74,7 +74,7 @@ export default function NetworkDropdown({
 }
 
 function NetworkMenuItems({ networkOptions, chainId }: { networkOptions: NetworkOption[]; chainId: number }) {
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
+  const { isNonSigningAccountOnAnyChain } = useNonSigningAccount();
 
   const [disabledNetworks, enabledNetworks] = partition(
     networkOptions,
@@ -82,7 +82,7 @@ function NetworkMenuItems({ networkOptions, chainId }: { networkOptions: Network
       // True is passed to filter both dev and prod contracts chains
       !isContractsChain(network.value, true) &&
       isSourceChainForAnySettlementChain(network.value) &&
-      isNonEoaAccountOnAnyChain
+      isNonSigningAccountOnAnyChain
   );
 
   const walletAndGmxAccountNetworks = enabledNetworks.filter(

--- a/src/components/OneClickPromoBanner/OneClickPromoBanner.tsx
+++ b/src/components/OneClickPromoBanner/OneClickPromoBanner.tsx
@@ -6,7 +6,7 @@ import { getOneClickTradingPromoHiddenKey } from "config/localStorage";
 import { useSettings } from "context/SettingsContext/SettingsContextProvider";
 import { useIsOutOfGasPaymentBalance } from "domain/synthetics/express/useIsOutOfGasPaymentBalance";
 import { useChainId } from "lib/chains";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 
 import { ColorfulBanner } from "components/ColorfulBanner/ColorfulBanner";
 
@@ -20,15 +20,15 @@ export function OneClickPromoBanner({ openSettings, isShort }: { openSettings: (
     false
   );
 
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
+  const { isExpressAccountSupported } = useExpressAccountSupport();
   const isOutOfGasPaymentBalance = useIsOutOfGasPaymentBalance();
 
-  const shouldShow = !isOneClickPromoHidden && !expressOrdersEnabled && !isNonEoaAccountOnAnyChain;
+  const shouldShow = !isOneClickPromoHidden && !expressOrdersEnabled && isExpressAccountSupported;
 
   const onClickEnable = useCallback(() => {
     openSettings();
 
-    if (isOutOfGasPaymentBalance) {
+    if (isOutOfGasPaymentBalance || !isExpressAccountSupported) {
       return;
     }
 
@@ -36,7 +36,13 @@ export function OneClickPromoBanner({ openSettings, isShort }: { openSettings: (
       setExpressOrdersEnabled(true);
       setIsOneClickPromoHidden(true);
     }, 500);
-  }, [isOutOfGasPaymentBalance, openSettings, setExpressOrdersEnabled, setIsOneClickPromoHidden]);
+  }, [
+    isExpressAccountSupported,
+    isOutOfGasPaymentBalance,
+    openSettings,
+    setExpressOrdersEnabled,
+    setIsOneClickPromoHidden,
+  ]);
 
   if (!shouldShow) {
     return null;

--- a/src/components/OrderEditor/OrderEditor.tsx
+++ b/src/components/OrderEditor/OrderEditor.tsx
@@ -431,7 +431,7 @@ export function OrderEditor(p: Props) {
     additionalExecutionFee?.feeTokenAmount,
   ]);
 
-  const { expressParams, expressParamsPromise, isMultichainSubmitDisabled } = useExpressOrdersParams({
+  const { expressParams, expressParamsPromise, isMultichainSubmitDisabled, shouldUseExpress } = useExpressOrdersParams({
     orderParams: batchParams,
     label: "Order Editor",
     isGmxAccount: srcChainId !== undefined,
@@ -558,6 +558,7 @@ export function OrderEditor(p: Props) {
       signer,
       batchParams,
       expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
+      requireExpress: shouldUseExpress,
       simulationParams: undefined,
       callback: makeOrderTxnCallback({
         actionName: "Update Order",
@@ -597,6 +598,7 @@ export function OrderEditor(p: Props) {
     chainId,
     makeOrderTxnCallback,
     srcChainId,
+    shouldUseExpress,
     expressParams?.subaccount,
     p,
     market,

--- a/src/components/OrderList/OrderList.tsx
+++ b/src/components/OrderList/OrderList.tsx
@@ -190,6 +190,7 @@ export function OrderList({
       signer,
       batchParams,
       expressParams,
+      requireExpress: true,
       simulationParams: undefined,
       callback: makeOrderTxnCallback({
         actionName: "Cancel Order",

--- a/src/components/OrdersModal/AddTPSLModal.tsx
+++ b/src/components/OrdersModal/AddTPSLModal.tsx
@@ -768,7 +768,7 @@ export function AddTPSLModal({
     return getBatchTotalExecutionFee({ batchParams, chainId, tokensData });
   }, [batchParams, chainId, tokensData]);
 
-  const { expressParamsPromise, isMultichainSubmitDisabled } = useExpressOrdersParams({
+  const { expressParamsPromise, isMultichainSubmitDisabled, shouldUseExpress } = useExpressOrdersParams({
     orderParams: batchParams,
     label: "Add TP/SL",
     isGmxAccount: srcChainId !== undefined,
@@ -837,6 +837,7 @@ export function AddTPSLModal({
         signer,
         batchParams,
         expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
+        requireExpress: shouldUseExpress,
         simulationParams: shouldDisableValidationForTesting
           ? undefined
           : {
@@ -867,6 +868,7 @@ export function AddTPSLModal({
     shouldDisableValidationForTesting,
     blockTimestampData,
     makeOrderTxnCallback,
+    shouldUseExpress,
     position.collateralToken.symbol,
     srcChainId,
     setIsVisible,

--- a/src/components/OrdersModal/OrdersModal.tsx
+++ b/src/components/OrdersModal/OrdersModal.tsx
@@ -15,6 +15,7 @@ import {
   selectSubaccountForChainAction,
   selectUserReferralInfo,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
+import { selectExpressOrdersEnabled } from "context/SyntheticsStateContext/selectors/settingsSelectors";
 import { makeSelectMarketPriceDecimals } from "context/SyntheticsStateContext/selectors/statsSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { estimateBatchExpressParams } from "domain/synthetics/express/expressOrderUtils";
@@ -97,6 +98,7 @@ export function OrdersModal({
   const [editingOrderState, setEditingOrderState] = useEditingOrderState();
   const { makeOrderTxnCallback } = useOrderTxnCallbacks();
   const globalExpressParams = useSelector(selectExpressGlobalParams);
+  const expressOrdersEnabled = useSelector(selectExpressOrdersEnabled);
   const subaccount = useSelector(selectSubaccountForChainAction);
 
   const effectivePositionKey = position?.key ?? positionKeyProp;
@@ -212,6 +214,7 @@ export function OrdersModal({
         signer,
         batchParams,
         expressParams,
+        requireExpress: expressOrdersEnabled || srcChainId !== undefined,
         simulationParams: undefined,
         callback: makeOrderTxnCallback({
           actionName: "Cancel Order",
@@ -230,6 +233,7 @@ export function OrdersModal({
     displayedOrders,
     setCancellingOrdersKeys,
     globalExpressParams,
+    expressOrdersEnabled,
     chainId,
     srcChainId,
     subaccount,

--- a/src/components/PositionEditor/PositionEditor.tsx
+++ b/src/components/PositionEditor/PositionEditor.tsx
@@ -25,16 +25,19 @@ import {
 import { makeSelectMarketPriceDecimals } from "context/SyntheticsStateContext/selectors/statsSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { toastEnableExpress } from "domain/multichain/toastEnableExpress";
+import { getExpressAccountUnavailableMessage } from "domain/synthetics/express/getExpressAccountUnavailableMessage";
 import { formatLiquidationPrice, getIsPositionInfoLoaded } from "domain/synthetics/positions";
 import { getBalanceByBalanceType, TokenBalanceType } from "domain/synthetics/tokens";
 import { getMaxWithdrawAmount, getTradeFlagsForCollateralEdit } from "domain/synthetics/trade";
 import { usePriceImpactWarningState } from "domain/synthetics/trade/usePriceImpactWarningState";
 import { useMaxAvailableAmount } from "domain/tokens/useMaxAvailableAmount";
 import { useChainId } from "lib/chains";
+import { helperToast } from "lib/helperToast";
 import { useLocalizedMap } from "lib/i18n";
 import { formatAmountFree, formatBalanceAmount, formatTokenAmountWithUsd, formatUsd } from "lib/numbers";
 import { getByKey } from "lib/objects";
 import { usePrevious } from "lib/usePrevious";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 import {
   convertTokenAddress,
   getTokenVisualMultiplier,
@@ -71,6 +74,7 @@ import "./PositionEditor.scss";
 export function PositionEditor() {
   const { chainId, srcChainId } = useChainId();
   const { expressOrdersEnabled, setExpressOrdersEnabled, setIsSettingsVisible } = useSettings();
+  const { isExpressAccountSupported, unavailableReason: expressAccountUnavailableReason } = useExpressAccountSupport();
   const [, setEditingPositionKey] = usePositionEditorPositionState();
   const tokensData = useTokensData();
   const nativeToken = getByKey(tokensData, NATIVE_TOKEN_ADDRESS);
@@ -93,6 +97,11 @@ export function PositionEditor() {
 
   const handleSetCollateralAddress = useCallback(
     (tokenAddress: string, isGmxAccount?: boolean) => {
+      if (isGmxAccount && !isExpressAccountSupported) {
+        helperToast.error(getExpressAccountUnavailableMessage(expressAccountUnavailableReason));
+        return;
+      }
+
       if (isGmxAccount && !expressOrdersEnabled) {
         setExpressOrdersEnabled(true);
         toastEnableExpress(() => setIsSettingsVisible(true));
@@ -105,6 +114,8 @@ export function PositionEditor() {
     },
     [
       expressOrdersEnabled,
+      expressAccountUnavailableReason,
+      isExpressAccountSupported,
       setSelectedCollateralAddress,
       setExpressOrdersEnabled,
       setIsSettingsVisible,

--- a/src/components/PositionEditor/usePositionEditorButtonState.tsx
+++ b/src/components/PositionEditor/usePositionEditorButtonState.tsx
@@ -254,6 +254,7 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
     fastExpressParams,
     asyncExpressParams,
     expressParamsPromise,
+    shouldUseExpress,
   } = useExpressOrdersParams({
     label: "Position Editor",
     orderParams: batchParams,
@@ -530,6 +531,7 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
       provider,
       batchParams,
       expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
+      requireExpress: shouldUseExpress,
       isGmxAccount: isCollateralTokenFromGmxAccount,
       simulationParams: shouldDisableValidationForTesting
         ? undefined

--- a/src/components/PositionSeller/PositionSeller.tsx
+++ b/src/components/PositionSeller/PositionSeller.tsx
@@ -461,6 +461,7 @@ export function PositionSeller() {
     expressParamsPromise,
     fastExpressParams,
     asyncExpressParams,
+    shouldUseExpress,
   } = useExpressOrdersParams({
     label: "Position Seller",
     orderParams: batchParams,
@@ -679,6 +680,7 @@ export function PositionSeller() {
       batchParams,
       isGmxAccount,
       expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
+      requireExpress: shouldUseExpress,
       simulationParams: shouldDisableValidationForTesting
         ? undefined
         : {

--- a/src/components/SettingsModal/TradingSettings.tsx
+++ b/src/components/SettingsModal/TradingSettings.tsx
@@ -80,11 +80,13 @@ export function TradingSettings({
   const isWalletGasPaymentBalanceInsufficient = isOutOfGasPaymentBalance && srcChainId === undefined;
   const isExpressTradingDisabled =
     isWalletGasPaymentBalanceInsufficient || !isExpressAccountSupported || isExpressAccountSupportLoading;
-  const expressTradingDisabledTooltip = expressAccountUnavailableReason
-    ? getExpressAccountUnavailableMessage(expressAccountUnavailableReason)
-    : isWalletGasPaymentBalanceInsufficient
-      ? t`Insufficient gas balance. Deposit more ${gasPaymentTokensText}.`
-      : undefined;
+  const expressTradingDisabledTooltip = isExpressAccountSupportLoading
+    ? t`Checking wallet signing support...`
+    : expressAccountUnavailableReason
+      ? getExpressAccountUnavailableMessage(expressAccountUnavailableReason)
+      : isWalletGasPaymentBalanceInsufficient
+        ? t`Insufficient gas balance. Deposit more ${gasPaymentTokensText}.`
+        : undefined;
   const { tokensData } = useTokensDataRequest(chainId, srcChainId);
   const gasPaymentTokens = getGasPaymentTokens(chainId);
 

--- a/src/components/SettingsModal/TradingSettings.tsx
+++ b/src/components/SettingsModal/TradingSettings.tsx
@@ -13,6 +13,7 @@ import { useSettings } from "context/SettingsContext/SettingsContextProvider";
 import { useSubaccountContext } from "context/SubaccountContext/SubaccountContextProvider";
 import { SettlementChainWarningContainer } from "domain/multichain/SettlementChainWarningContainer";
 import { useEmptyGmxAccounts } from "domain/multichain/useEmptyGmxAccounts";
+import { getExpressAccountUnavailableMessage } from "domain/synthetics/express/getExpressAccountUnavailableMessage";
 import { useIsOutOfGasPaymentBalance } from "domain/synthetics/express/useIsOutOfGasPaymentBalance";
 import { getIsSubaccountActive } from "domain/synthetics/subaccount";
 import { getBalanceByBalanceType } from "domain/synthetics/tokens";
@@ -21,7 +22,7 @@ import { TokenBalanceType } from "domain/tokens";
 import { useChainId } from "lib/chains";
 import { useGasPaymentTokensText } from "lib/gas/useGasPaymentTokensText";
 import { EMPTY_ARRAY, getByKey } from "lib/objects";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 import { getGasPaymentTokens } from "sdk/configs/express";
 import { getNativeToken } from "sdk/configs/tokens";
 
@@ -67,10 +68,20 @@ export function TradingSettings({
   const subaccountState = useSubaccountContext();
   const isOutOfGasPaymentBalance = useIsOutOfGasPaymentBalance();
   const [settlementChainId, setSettlementChainId] = useGmxAccountSettlementChainId();
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
+  const {
+    isExpressAccountSupported,
+    unavailableReason: expressAccountUnavailableReason,
+    isLoading: isExpressAccountSupportLoading,
+  } = useExpressAccountSupport();
   const { emptyGmxAccounts } = useEmptyGmxAccounts([AVALANCHE]);
   const isAvalancheEmpty = emptyGmxAccounts?.[AVALANCHE] === true;
-  const isExpressTradingDisabled = (isOutOfGasPaymentBalance && srcChainId === undefined) || isNonEoaAccountOnAnyChain;
+  const isExpressTradingDisabled =
+    (isOutOfGasPaymentBalance && srcChainId === undefined) ||
+    !isExpressAccountSupported ||
+    isExpressAccountSupportLoading;
+  const expressAccountUnavailableMessage = expressAccountUnavailableReason
+    ? getExpressAccountUnavailableMessage(expressAccountUnavailableReason)
+    : undefined;
   const nativeTokenSymbol = getNativeToken(chainId).symbol;
   const { gasPaymentTokensText } = useGasPaymentTokensText(chainId);
   const { tokensData } = useTokensDataRequest(chainId, srcChainId);
@@ -149,11 +160,7 @@ export function TradingSettings({
               }
               icon={<ExpressIcon className="size-28" />}
               disabled={isExpressTradingDisabled}
-              disabledTooltip={
-                isNonEoaAccountOnAnyChain ? (
-                  <Trans>Smart wallets are not supported on Express Trading or One-Click Trading</Trans>
-                ) : undefined
-              }
+              disabledTooltip={expressAccountUnavailableMessage}
               chip={
                 <Chip color="gray">
                   <Trans>Optimal</Trans>
@@ -168,11 +175,7 @@ export function TradingSettings({
               description={<Trans>Seamless trading with Express reliability</Trans>}
               icon={<OneClickIcon className="size-28" />}
               disabled={isExpressTradingDisabled}
-              disabledTooltip={
-                isNonEoaAccountOnAnyChain ? (
-                  <Trans>Smart wallets are not supported on Express Trading or One-Click Trading</Trans>
-                ) : undefined
-              }
+              disabledTooltip={expressAccountUnavailableMessage}
               info={
                 <Trans>
                   GMX executes transactions without individual signing. Trades use GMX-sponsored premium RPCs for
@@ -191,7 +194,7 @@ export function TradingSettings({
               onClick={() => handleTradingModeChange(TradingMode.Express1CT)}
             />
 
-            {isOutOfGasPaymentBalance && !isNonEoaAccountOnAnyChain && (
+            {isOutOfGasPaymentBalance && isExpressAccountSupported && (
               <ExpressTradingOutOfGasBanner onClose={onClose} />
             )}
 

--- a/src/components/SettingsModal/TradingSettings.tsx
+++ b/src/components/SettingsModal/TradingSettings.tsx
@@ -75,15 +75,16 @@ export function TradingSettings({
   } = useExpressAccountSupport();
   const { emptyGmxAccounts } = useEmptyGmxAccounts([AVALANCHE]);
   const isAvalancheEmpty = emptyGmxAccounts?.[AVALANCHE] === true;
-  const isExpressTradingDisabled =
-    (isOutOfGasPaymentBalance && srcChainId === undefined) ||
-    !isExpressAccountSupported ||
-    isExpressAccountSupportLoading;
-  const expressAccountUnavailableMessage = expressAccountUnavailableReason
-    ? getExpressAccountUnavailableMessage(expressAccountUnavailableReason)
-    : undefined;
   const nativeTokenSymbol = getNativeToken(chainId).symbol;
   const { gasPaymentTokensText } = useGasPaymentTokensText(chainId);
+  const isWalletGasPaymentBalanceInsufficient = isOutOfGasPaymentBalance && srcChainId === undefined;
+  const isExpressTradingDisabled =
+    isWalletGasPaymentBalanceInsufficient || !isExpressAccountSupported || isExpressAccountSupportLoading;
+  const expressTradingDisabledTooltip = expressAccountUnavailableReason
+    ? getExpressAccountUnavailableMessage(expressAccountUnavailableReason)
+    : isWalletGasPaymentBalanceInsufficient
+      ? t`Insufficient gas balance. Deposit more ${gasPaymentTokensText}.`
+      : undefined;
   const { tokensData } = useTokensDataRequest(chainId, srcChainId);
   const gasPaymentTokens = getGasPaymentTokens(chainId);
 
@@ -160,7 +161,7 @@ export function TradingSettings({
               }
               icon={<ExpressIcon className="size-28" />}
               disabled={isExpressTradingDisabled}
-              disabledTooltip={expressAccountUnavailableMessage}
+              disabledTooltip={expressTradingDisabledTooltip}
               chip={
                 <Chip color="gray">
                   <Trans>Optimal</Trans>
@@ -175,7 +176,7 @@ export function TradingSettings({
               description={<Trans>Seamless trading with Express reliability</Trans>}
               icon={<OneClickIcon className="size-28" />}
               disabled={isExpressTradingDisabled}
-              disabledTooltip={expressAccountUnavailableMessage}
+              disabledTooltip={expressTradingDisabledTooltip}
               info={
                 <Trans>
                   GMX executes transactions without individual signing. Trades use GMX-sponsored premium RPCs for

--- a/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
+++ b/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -155,7 +155,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
     allowedSlippage,
   ]);
 
-  const { expressParams, expressParamsPromise, isMultichainSubmitDisabled } = useExpressOrdersParams({
+  const { expressParams, expressParamsPromise, isMultichainSubmitDisabled, shouldUseExpress } = useExpressOrdersParams({
     orderParams: batchParams,
     label: "Settle Funding Fee",
     isGmxAccount: srcChainId !== undefined,
@@ -280,6 +280,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
         signer,
         batchParams,
         expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
+        requireExpress: shouldUseExpress,
         simulationParams: undefined,
         callback: makeOrderTxnCallback({
           metricId: undefined,
@@ -307,6 +308,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
     makeOrderTxnCallback,
     provider,
     signer,
+    shouldUseExpress,
     srcChainId,
     tokensData,
     tokensToApprove,

--- a/src/components/TVChartContainer/DynamicLines.tsx
+++ b/src/components/TVChartContainer/DynamicLines.tsx
@@ -104,6 +104,7 @@ export function DynamicLines({
         signer,
         batchParams,
         expressParams,
+        requireExpress: true,
         simulationParams: undefined,
         callback: makeOrderTxnCallback({
           actionName: "Cancel Order",

--- a/src/components/TradeBox/TradeBox.tsx
+++ b/src/components/TradeBox/TradeBox.tsx
@@ -62,6 +62,7 @@ import { useSelector } from "context/SyntheticsStateContext/utils";
 import { toastEnableExpress } from "domain/multichain/toastEnableExpress";
 import { useGmxAccountShowDepositButton } from "domain/multichain/useGmxAccountShowDepositButton";
 import { getPrimaryOrderGasPaymentTokenAmount } from "domain/synthetics/express/expressOrderUtils";
+import { getExpressAccountUnavailableMessage } from "domain/synthetics/express/getExpressAccountUnavailableMessage";
 import { getMarketIndexName, MarketInfo, OFF_HOURS_DOCS_URL } from "domain/synthetics/markets";
 import { formatLeverage, formatLiquidationPrice } from "domain/synthetics/positions";
 import { convertToUsd, getBalanceByBalanceType, TokenBalanceType } from "domain/synthetics/tokens";
@@ -92,7 +93,7 @@ import { EMPTY_ARRAY, getByKey } from "lib/objects";
 import { useCursorInside } from "lib/useCursorInside";
 import { sendTradeBoxInteractionStartedEvent } from "lib/userAnalytics";
 import { useWalletIconUrls } from "lib/wallets/getWalletIconUrls";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 import useWallet from "lib/wallets/useWallet";
 import { getGasPaymentTokens } from "sdk/configs/express";
 import { NATIVE_TOKEN_ADDRESS } from "sdk/configs/tokens";
@@ -660,11 +661,11 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
     },
     [setFocusedInput, setToTokenInputValue]
   );
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
+  const { isExpressAccountSupported, unavailableReason: expressAccountUnavailableReason } = useExpressAccountSupport();
   const handleSelectFromTokenAddress = useCallback(
     (tokenAddress: string, isGmxAccount: boolean) => {
-      if (isGmxAccount && isNonEoaAccountOnAnyChain) {
-        helperToast.error(t`Smart wallets are not supported on Express Trading or One-Click Trading`);
+      if (isGmxAccount && !isExpressAccountSupported) {
+        helperToast.error(getExpressAccountUnavailableMessage(expressAccountUnavailableReason));
         return;
       }
 
@@ -679,7 +680,8 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
     },
     [
       expressOrdersEnabled,
-      isNonEoaAccountOnAnyChain,
+      expressAccountUnavailableReason,
+      isExpressAccountSupported,
       onSelectFromTokenAddress,
       setExpressOrdersEnabled,
       setIsFromTokenGmxAccount,
@@ -764,7 +766,7 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
           placeholder={TRADEBOX_INPUT_PLACEHOLDER}
         >
           {fromTokenAddress &&
-            (!isSettlementChain(chainId) || isNonEoaAccountOnAnyChain ? (
+            (!isSettlementChain(chainId) || !isExpressAccountSupported ? (
               <TokenSelector
                 label={t`Pay`}
                 chainId={chainId}

--- a/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
+++ b/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
@@ -175,6 +175,7 @@ export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactions
     expressParamsPromise,
     isLoading: isExpressLoading,
     isMultichainSubmitDisabled,
+    shouldUseExpress,
   } = useExpressOrdersParams({
     orderParams: batchParams,
     label: "TradeBox",
@@ -367,6 +368,7 @@ export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactions
       batchParams,
       isGmxAccount: isFromTokenGmxAccount,
       expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
+      requireExpress: shouldUseExpress,
       simulationParams: shouldDisableValidationForTesting
         ? undefined
         : {
@@ -415,6 +417,7 @@ export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactions
     setShouldFallbackToInternalSwap,
     setShouldForceExternalSwap,
     shouldDisableValidationForTesting,
+    shouldUseExpress,
     signer,
     slippageInputId,
     tokensData,

--- a/src/components/TradeboxMarginFields/MarginField.tsx
+++ b/src/components/TradeboxMarginFields/MarginField.tsx
@@ -16,7 +16,7 @@ import { convertToUsd } from "domain/synthetics/tokens";
 import { MissedCoinsPlace } from "domain/synthetics/userFeedback";
 import { formatBalanceAmount, formatUsd, parseValue } from "lib/numbers";
 import { useWalletIconUrls } from "lib/wallets/getWalletIconUrls";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 import useWallet from "lib/wallets/useWallet";
 
 import { useMultichainTradeTokensRequest } from "components/GmxAccountModal/hooks";
@@ -53,7 +53,7 @@ export function MarginField({
   const { active, account } = useWallet();
   const { openConnectModal } = useConnectModal();
   const walletIconUrls = useWalletIconUrls();
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
+  const { isExpressAccountSupported } = useExpressAccountSupport();
 
   const { tokenChainDataArray: multichainTokens } = useMultichainTradeTokensRequest(chainId, account);
 
@@ -116,7 +116,7 @@ export function MarginField({
       rightContent={
         <div data-token-selector>
           {fromTokenAddress &&
-            (!isSettlementChain(chainId) || isNonEoaAccountOnAnyChain ? (
+            (!isSettlementChain(chainId) || !isExpressAccountSupported ? (
               <TokenSelector
                 label={t`Pay`}
                 chainId={chainId}

--- a/src/context/SettingsContext/SettingsContextProvider.tsx
+++ b/src/context/SettingsContext/SettingsContextProvider.tsx
@@ -4,6 +4,7 @@ import { ReactNode, createContext, useContext, useEffect, useMemo, useState } fr
 import { ARBITRUM, BOTANIX, getExecutionFeeConfig } from "config/chains";
 import { isDevelopment } from "config/env";
 import { DEFAULT_ACCEPTABLE_PRICE_IMPACT_BUFFER, DEFAULT_SLIPPAGE_AMOUNT } from "config/factors";
+import { getIsExpressSupported } from "config/features";
 import {
   BREAKDOWN_NET_PRICE_IMPACT_ENABLED_KEY,
   BUY_SELL_ICONS_MODE_KEY,
@@ -33,9 +34,9 @@ import {
   getSyntheticsAcceptablePriceImpactBufferKey,
 } from "config/localStorage";
 import { useChainId } from "lib/chains";
-import { useLocalStorageByChainId, useLocalStorageSerializeKey } from "lib/localStorage";
+import { hasStoredLocalStorageValue, useLocalStorageByChainId, useLocalStorageSerializeKey } from "lib/localStorage";
 import { tenderlyLsKeys } from "lib/tenderly";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 import useWallet from "lib/wallets/useWallet";
 import { getDefaultGasPaymentToken } from "sdk/configs/express";
 import { isValidTokenSafe } from "sdk/configs/tokens";
@@ -142,7 +143,11 @@ export function useSettings() {
 export function SettingsContextProvider({ children }: { children: ReactNode }) {
   const { chainId, srcChainId } = useChainId();
   const { account } = useWallet();
-  const { isLoading: isNonEoaLoading } = useNonSigningAccount();
+  const {
+    isExpressAccountSupported,
+    isLoading: isExpressAccountSupportLoading,
+    unavailableReason: expressAccountUnavailableReason,
+  } = useExpressAccountSupport();
 
   const [isSettingsVisible, setIsSettingsVisible] = useState(false);
   const [showDebugValues, setShowDebugValues] = useLocalStorageSerializeKey(SHOW_DEBUG_VALUES_KEY, false);
@@ -216,6 +221,9 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
 
   const expressOrdersEnabledKey = getExpressOrdersEnabledKey(chainId, account);
   const [expressOrdersEnabled, setExpressOrdersEnabled] = useLocalStorageSerializeKey(expressOrdersEnabledKey, false);
+  const effectiveExpressOrdersEnabled = Boolean(
+    expressOrdersEnabled && isExpressAccountSupported && !isExpressAccountSupportLoading
+  );
 
   const [receiveToGmxAccount, setReceiveToGmxAccount] = useLocalStorageSerializeKey<boolean | null>(
     getCollateralCloseDestinationKey(chainId, account),
@@ -323,12 +331,64 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
   ]);
 
   useEffect(
+    function defaultExpressForSupportedWallets() {
+      if (
+        !account ||
+        expressOrdersEnabled ||
+        !isExpressAccountSupported ||
+        isExpressAccountSupportLoading ||
+        !getIsExpressSupported(chainId) ||
+        hasStoredLocalStorageValue(expressOrdersEnabledKey)
+      ) {
+        return;
+      }
+
+      setExpressOrdersEnabled(true);
+    },
+    [
+      chainId,
+      account,
+      expressOrdersEnabled,
+      expressOrdersEnabledKey,
+      isExpressAccountSupported,
+      isExpressAccountSupportLoading,
+      setExpressOrdersEnabled,
+    ]
+  );
+
+  useEffect(
     function fallbackMultichain() {
-      if (srcChainId && !expressOrdersEnabled && !isNonEoaLoading) {
+      if (srcChainId && !expressOrdersEnabled && isExpressAccountSupported && !isExpressAccountSupportLoading) {
         setExpressOrdersEnabled(true);
       }
     },
-    [expressOrdersEnabled, setExpressOrdersEnabled, srcChainId, isNonEoaLoading]
+    [
+      expressOrdersEnabled,
+      isExpressAccountSupportLoading,
+      isExpressAccountSupported,
+      setExpressOrdersEnabled,
+      srcChainId,
+    ]
+  );
+
+  useEffect(
+    function disableExpressForUnsupportedWallets() {
+      if (
+        !isExpressAccountSupportLoading &&
+        !isExpressAccountSupported &&
+        expressAccountUnavailableReason !== "capabilityCheckFailed" &&
+        expressOrdersEnabled
+      ) {
+        setExpressOrdersEnabled(false);
+      }
+    },
+    [
+      expressAccountUnavailableReason,
+      expressOrdersEnabled,
+      isExpressAccountSupportLoading,
+      isExpressAccountSupported,
+      setExpressOrdersEnabled,
+    ]
   );
 
   const contextState: SettingsContextType = useMemo(() => {
@@ -379,7 +439,7 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
       isSettingsVisible,
       setIsSettingsVisible,
 
-      expressOrdersEnabled: expressOrdersEnabled!,
+      expressOrdersEnabled: effectiveExpressOrdersEnabled,
       setExpressOrdersEnabled,
       gasPaymentTokenAddress: gasPaymentTokenAddress!,
       setGasPaymentTokenAddress,
@@ -449,7 +509,7 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
     tenderlyProjectSlug,
     tenderlySimulationEnabled,
     isSettingsVisible,
-    expressOrdersEnabled,
+    effectiveExpressOrdersEnabled,
     setExpressOrdersEnabled,
     gasPaymentTokenAddress,
     setGasPaymentTokenAddress,

--- a/src/context/SettingsContext/SettingsContextProvider.tsx
+++ b/src/context/SettingsContext/SettingsContextProvider.tsx
@@ -97,6 +97,9 @@ export type SettingsContextType = {
   setIsSettingsVisible: (val: boolean) => void;
 
   expressOrdersEnabled: boolean;
+  isExpressOrdersAvailable: boolean;
+  isExpressAccountSupportLoading: boolean;
+  isExpressAccountSupportResolved: boolean;
   setExpressOrdersEnabled: (val: boolean) => void;
 
   gasPaymentTokenAddress: string;
@@ -219,10 +222,12 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
     undefined | { disabledSwapMarkets?: string[]; manualPath?: string[] }
   >([chainId, DEBUG_SWAP_MARKETS_CONFIG_KEY], undefined);
 
-  const expressOrdersEnabledKey = getExpressOrdersEnabledKey(chainId, account);
+  const expressOrdersEnabledKey = useMemo(() => getExpressOrdersEnabledKey(chainId, account), [account, chainId]);
   const [expressOrdersEnabled, setExpressOrdersEnabled] = useLocalStorageSerializeKey(expressOrdersEnabledKey, false);
-  const effectiveExpressOrdersEnabled = Boolean(
-    expressOrdersEnabled && isExpressAccountSupported && !isExpressAccountSupportLoading
+  const isExpressAccountSupportResolved =
+    !isExpressAccountSupportLoading && expressAccountUnavailableReason !== "capabilityCheckFailed";
+  const isExpressOrdersAvailable = Boolean(
+    expressOrdersEnabled && isExpressAccountSupported && isExpressAccountSupportResolved
   );
 
   const [receiveToGmxAccount, setReceiveToGmxAccount] = useLocalStorageSerializeKey<boolean | null>(
@@ -358,13 +363,13 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
 
   useEffect(
     function fallbackMultichain() {
-      if (srcChainId && !expressOrdersEnabled && isExpressAccountSupported && !isExpressAccountSupportLoading) {
+      if (srcChainId && !expressOrdersEnabled && isExpressAccountSupported && isExpressAccountSupportResolved) {
         setExpressOrdersEnabled(true);
       }
     },
     [
       expressOrdersEnabled,
-      isExpressAccountSupportLoading,
+      isExpressAccountSupportResolved,
       isExpressAccountSupported,
       setExpressOrdersEnabled,
       srcChainId,
@@ -439,7 +444,10 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
       isSettingsVisible,
       setIsSettingsVisible,
 
-      expressOrdersEnabled: effectiveExpressOrdersEnabled,
+      expressOrdersEnabled: Boolean(expressOrdersEnabled),
+      isExpressOrdersAvailable,
+      isExpressAccountSupportLoading,
+      isExpressAccountSupportResolved,
       setExpressOrdersEnabled,
       gasPaymentTokenAddress: gasPaymentTokenAddress!,
       setGasPaymentTokenAddress,
@@ -509,7 +517,10 @@ export function SettingsContextProvider({ children }: { children: ReactNode }) {
     tenderlyProjectSlug,
     tenderlySimulationEnabled,
     isSettingsVisible,
-    effectiveExpressOrdersEnabled,
+    expressOrdersEnabled,
+    isExpressOrdersAvailable,
+    isExpressAccountSupportLoading,
+    isExpressAccountSupportResolved,
     setExpressOrdersEnabled,
     gasPaymentTokenAddress,
     setGasPaymentTokenAddress,

--- a/src/context/SyntheticsStateContext/hooks/orderHooks.ts
+++ b/src/context/SyntheticsStateContext/hooks/orderHooks.ts
@@ -19,6 +19,7 @@ import {
   makeSelectOrdersWithErrorsByPositionKey,
   selectOrderErrorsCount,
 } from "../selectors/orderSelectors";
+import { selectExpressOrdersEnabled } from "../selectors/settingsSelectors";
 import { useSelector } from "../utils";
 
 export const useOrderErrors = (orderKey: string) => {
@@ -41,6 +42,7 @@ export function useCancelOrder(order: OrderInfo) {
   const [cancellingOrdersKeys, setCancellingOrdersKeys] = useCancellingOrdersKeysState();
   const { makeOrderTxnCallback } = useOrderTxnCallbacks();
   const globalExpressParams = useSelector(selectExpressGlobalParams);
+  const expressOrdersEnabled = useSelector(selectExpressOrdersEnabled);
   const subaccount = useSelector(selectSubaccountForChainAction);
   const hasOutdatedUi = useHasOutdatedUi();
 
@@ -83,6 +85,7 @@ export function useCancelOrder(order: OrderInfo) {
         signer,
         batchParams,
         expressParams,
+        requireExpress: expressOrdersEnabled || srcChainId !== undefined,
         simulationParams: undefined,
         callback: makeOrderTxnCallback({
           actionName: "Cancel Order",
@@ -96,6 +99,7 @@ export function useCancelOrder(order: OrderInfo) {
     },
     [
       chainId,
+      expressOrdersEnabled,
       globalExpressParams,
       hasOutdatedUi,
       makeOrderTxnCallback,

--- a/src/context/SyntheticsStateContext/selectors/__tests__/externalSwapSelectors.spec.ts
+++ b/src/context/SyntheticsStateContext/selectors/__tests__/externalSwapSelectors.spec.ts
@@ -301,6 +301,7 @@ describe("externalSwapSelectors", () => {
         settings: {
           ...defaultState.settings,
           expressOrdersEnabled: true,
+          isExpressOrdersAvailable: true,
           gasPaymentTokenAddress: tokensData.USDC.address,
         },
         features: {

--- a/src/context/SyntheticsStateContext/selectors/expressSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/expressSelectors.ts
@@ -24,9 +24,9 @@ import {
 import {
   selectDebugSwapMarketsConfig,
   selectExecutionFeeBufferBps,
-  selectExpressOrdersEnabled,
   selectGasPaymentTokenAddress,
   selectGmxAccountGasPaymentTokenAddress,
+  selectIsExpressOrdersAvailable,
 } from "./settingsSelectors";
 import { selectTokenPermits } from "./tokenPermitsSelectors";
 import { selectGasEstimationParams } from "./tradeSelectors";
@@ -50,7 +50,7 @@ export const selectGasPaymentToken = createSelector((q) => {
 });
 
 export const selectIsExpressTransactionAvailable = createSelector((q) => {
-  const isExpressOrdersEnabledSetting = q(selectExpressOrdersEnabled);
+  const isExpressOrdersEnabledSetting = q(selectIsExpressOrdersAvailable);
   const isRelayRouterEnabled = q(selectIsRelayRouterEnabled);
   const isSponsoredCallAvailable = q(selectIsSponsoredCallAvailable);
 

--- a/src/context/SyntheticsStateContext/selectors/settingsSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/settingsSelectors.ts
@@ -9,6 +9,8 @@ export const selectIsPnlInLeverage = (s: SyntheticsState) => s.settings.isPnlInL
 export const selectShowPnlAfterFees = (s: SyntheticsState) => s.settings.showPnlAfterFees;
 export const selectIsLeverageSliderEnabled = (s: SyntheticsState) => s.settings.isLeverageSliderEnabled;
 export const selectExpressOrdersEnabled = (s: SyntheticsState) => s.settings.expressOrdersEnabled;
+export const selectIsExpressOrdersAvailable = (s: SyntheticsState) => s.settings.isExpressOrdersAvailable;
+export const selectIsExpressAccountSupportLoading = (s: SyntheticsState) => s.settings.isExpressAccountSupportLoading;
 export const selectSetExpressOrdersEnabled = (s: SyntheticsState) => s.settings.setExpressOrdersEnabled;
 export const selectGasPaymentTokenAddress = (s: SyntheticsState) => s.settings.gasPaymentTokenAddress;
 export const selectSetGasPaymentTokenAddress = (s: SyntheticsState) => s.settings.setGasPaymentTokenAddress;

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.spec.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.spec.ts
@@ -10,6 +10,8 @@ import { getContract } from "sdk/configs/contracts";
 import { SUBACCOUNT_ORDER_ACTION } from "sdk/configs/dataStore";
 
 import { selectIsOneClickActiveByUser } from ".";
+import { selectIsExpressTransactionAvailable } from "../expressSelectors";
+import { selectExpressOrdersEnabled } from "../settingsSelectors";
 
 const subaccountRouterAddress = getContract(AVALANCHE, "SubaccountGelatoRelayRouter");
 
@@ -75,6 +77,7 @@ function createState(subaccount: Subaccount | undefined): SyntheticsState {
     },
     settings: {
       expressOrdersEnabled: true,
+      isExpressOrdersAvailable: true,
     },
     features: {
       relayRouterEnabled: true,
@@ -120,6 +123,15 @@ describe("tradeboxSelectors", () => {
   });
 
   describe("selectIsOneClickActiveByUser", () => {
+    it("keeps the saved Express preference separate from temporary availability", () => {
+      const state = createState(createSubaccount());
+      state.settings.isExpressOrdersAvailable = false;
+
+      expect(selectExpressOrdersEnabled(state)).toBe(true);
+      expect(selectIsExpressTransactionAvailable(state)).toBe(false);
+      expect(selectIsOneClickActiveByUser(state)).toBe(false);
+    });
+
     it("returns true only for a valid One-Click subaccount", () => {
       expect(selectIsOneClickActiveByUser(createState(createSubaccount()))).toBe(true);
     });

--- a/src/domain/multichain/useGmxAccountShowDepositButton.tsx
+++ b/src/domain/multichain/useGmxAccountShowDepositButton.tsx
@@ -1,5 +1,5 @@
 import { useChainId } from "lib/chains";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 
 import { useAvailableToTradeAssetSettlementChain } from "components/GmxAccountModal/hooks";
 
@@ -8,14 +8,14 @@ import { useEmptyAvalancheGmxAccount } from "./useEmptyGmxAccounts";
 export function useGmxAccountShowDepositButton() {
   const { srcChainId } = useChainId();
   const { gmxAccountUsd, isGmxAccountLoading } = useAvailableToTradeAssetSettlementChain();
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
+  const { isExpressAccountSupported } = useExpressAccountSupport();
   const { isEmptyAvalancheGmxAccountOrNotConnected } = useEmptyAvalancheGmxAccount();
 
   const shouldShowDepositButton =
     !isGmxAccountLoading &&
     gmxAccountUsd === 0n &&
     srcChainId !== undefined &&
-    !isNonEoaAccountOnAnyChain &&
+    isExpressAccountSupported &&
     !isEmptyAvalancheGmxAccountOrNotConnected;
 
   return { shouldShowDepositButton };

--- a/src/domain/supportChat/useSupportChat.ts
+++ b/src/domain/supportChat/useSupportChat.ts
@@ -11,7 +11,7 @@ import { useIsLargeAccountVolumeStats } from "domain/synthetics/accountStats/use
 import { useChainId } from "lib/chains";
 import { formatAmountForMetrics } from "lib/metrics";
 import { tradingErrorTracker } from "lib/tradingErrorTracker";
-import { useNonSigningAccount } from "lib/wallets/useAccountType";
+import { useIsNonEoaAccountOnAnyChain } from "lib/wallets/useAccountType";
 
 import { useAvailableToTradeAssetMultichain } from "components/GmxAccountModal/hooks";
 
@@ -25,7 +25,7 @@ import { getOrCreateSupportChatUserId, themeToIntercomTheme } from "./utils";
 export function useSupportChat() {
   const { shouldShowSupportChat } = useShowSupportChat();
   const { address: account, connector } = useAccount();
-  const { isNonEoaAccountOnAnyChain, isLoading: isNonEoaAccountOnAnyChainLoading } = useNonSigningAccount();
+  const { isNonEoaAccountOnAnyChain, isLoading: isNonEoaAccountOnAnyChainLoading } = useIsNonEoaAccountOnAnyChain();
   const { data: largeAccountVolumeStatsData, isLoading: isLargeAccountVolumeStatsLoading } =
     useIsLargeAccountVolumeStats({ account });
   const { walletPortfolioUsd, isWalletPortfolioUsdLoading } = useWalletPortfolioUsd();

--- a/src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
+++ b/src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
@@ -151,5 +151,5 @@ async function signClaimCollateralPayload({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData });
+  return signTypedData({ signer, domain, types, typedData, verificationChainId: chainId });
 }

--- a/src/domain/synthetics/express/expressOrderUtils.ts
+++ b/src/domain/synthetics/express/expressOrderUtils.ts
@@ -305,6 +305,7 @@ export async function buildAndSignExpressBatchOrderTxn({
       typedData: typedData.message,
       domain: typedData.domain,
       shouldUseSignerMethod: subaccount !== undefined,
+      verificationChainId: chainId,
     };
 
     signature = await signTypedData(signatureParams);
@@ -482,7 +483,7 @@ async function signBridgeOutPayload({
 
   const domain = getGelatoRelayRouterDomain(srcChainId, getContract(chainId, "MultichainTransferRouter"));
 
-  return signTypedData({ signer, domain, types, typedData });
+  return signTypedData({ signer, domain, types, typedData, verificationChainId: chainId });
 }
 
 export async function signSetTraderReferralCode({
@@ -513,7 +514,7 @@ export async function signSetTraderReferralCode({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod });
+  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod, verificationChainId: chainId });
 }
 
 export async function signRegisterCode({
@@ -544,7 +545,7 @@ export async function signRegisterCode({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod });
+  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod, verificationChainId: chainId });
 }
 
 async function validateSignature({

--- a/src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+++ b/src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
@@ -1,0 +1,15 @@
+import { t } from "@lingui/macro";
+
+import type { ExpressAccountUnavailableReason } from "lib/wallets/useAccountType";
+
+export function getExpressAccountUnavailableMessage(reason: ExpressAccountUnavailableReason | undefined): string {
+  switch (reason) {
+    case "unsupportedChain":
+      return t`This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading.`;
+    case "capabilityCheckFailed":
+      return t`Wallet signing support could not be verified. Use Classic Trading and try again later.`;
+    case "unsupportedWallet":
+    default:
+      return t`This wallet cannot sign Express or One-Click orders. Use Classic Trading instead.`;
+  }
+}

--- a/src/domain/synthetics/express/useRelayerFeeHandler.ts
+++ b/src/domain/synthetics/express/useRelayerFeeHandler.ts
@@ -10,6 +10,10 @@ import {
   selectRawSubaccountForMultichainAction,
   selectRawSubaccountForSettlementChainAction,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
+import {
+  selectExpressOrdersEnabled,
+  selectIsExpressAccountSupportLoading,
+} from "context/SyntheticsStateContext/selectors/settingsSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { useChainId } from "lib/chains";
 import { FAST_EXPRESS_PARAMS_TIMEOUT_ERROR } from "lib/errors/customErrors";
@@ -41,6 +45,7 @@ export type ExpressOrdersParamsResult = {
   expressParamsPromise: Promise<ExpressTxnParams | undefined> | undefined;
   isLoading: boolean;
   isMultichainSubmitDisabled: boolean;
+  shouldUseExpress: boolean;
 };
 
 export function useExpressOrdersParams({
@@ -63,6 +68,10 @@ export function useExpressOrdersParams({
     isGmxAccount ? selectRawSubaccountForMultichainAction : selectRawSubaccountForSettlementChainAction
   );
   const isExpressAvailable = useSelector(selectIsExpressTransactionAvailable);
+  const expressOrdersEnabled = useSelector(selectExpressOrdersEnabled);
+  const isExpressAccountSupportLoading = useSelector(selectIsExpressAccountSupportLoading);
+  const hasExpressCompatibleOrder = orderParams && !getBatchIsNativePayment(orderParams);
+  const shouldUseExpress = Boolean((expressOrdersEnabled || isGmxAccount) && hasExpressCompatibleOrder);
 
   const isAvailable = isExpressAvailable && orderParams && !getBatchIsNativePayment(orderParams);
 
@@ -183,9 +192,10 @@ export function useExpressOrdersParams({
         expressEstimateMethod: undefined,
         fastExpressParams: undefined,
         asyncExpressParams: undefined,
-        isLoading: false,
-        isMultichainSubmitDisabled: false,
+        isLoading: shouldUseExpress && isExpressAccountSupportLoading,
+        isMultichainSubmitDisabled: shouldUseExpress && !isExpressAccountSupportLoading && !isExpressAvailable,
         expressParamsPromise: undefined,
+        shouldUseExpress,
       };
     }
 
@@ -208,6 +218,7 @@ export function useExpressOrdersParams({
       isLoading,
       isMultichainSubmitDisabled,
       expressParamsPromise,
+      shouldUseExpress,
     };
   }, [
     isAvailable,
@@ -219,6 +230,9 @@ export function useExpressOrdersParams({
     orderParams,
     fastExpressError,
     isGmxAccount,
+    isExpressAvailable,
+    isExpressAccountSupportLoading,
+    shouldUseExpress,
   ]);
 
   useSwitchGasPaymentTokenIfRequiredFromExpressParams({

--- a/src/domain/synthetics/markets/claimFundingFeesTxn.ts
+++ b/src/domain/synthetics/markets/claimFundingFeesTxn.ts
@@ -138,5 +138,5 @@ async function signClaimFundingFeesPayload({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData });
+  return signTypedData({ signer, domain, types, typedData, verificationChainId: chainId });
 }

--- a/src/domain/synthetics/markets/signCreateDeposit.ts
+++ b/src/domain/synthetics/markets/signCreateDeposit.ts
@@ -67,5 +67,5 @@ export async function signCreateDeposit({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod });
+  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod, verificationChainId: chainId });
 }

--- a/src/domain/synthetics/markets/signCreateGlvDeposit.ts
+++ b/src/domain/synthetics/markets/signCreateGlvDeposit.ts
@@ -68,5 +68,5 @@ export function signCreateGlvDeposit({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod });
+  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod, verificationChainId: chainId });
 }

--- a/src/domain/synthetics/markets/signCreateGlvWithdrawal.ts
+++ b/src/domain/synthetics/markets/signCreateGlvWithdrawal.ts
@@ -68,5 +68,5 @@ export async function signCreateGlvWithdrawal({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod });
+  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod, verificationChainId: chainId });
 }

--- a/src/domain/synthetics/markets/signCreateWithdrawal.ts
+++ b/src/domain/synthetics/markets/signCreateWithdrawal.ts
@@ -67,5 +67,5 @@ export async function signCreateWithdrawal({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod });
+  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod, verificationChainId: chainId });
 }

--- a/src/domain/synthetics/orders/sendBatchOrderTxn.spec.ts
+++ b/src/domain/synthetics/orders/sendBatchOrderTxn.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExpressTxnParams } from "domain/synthetics/express";
+
+import { assertExpressParams } from "./sendBatchOrderTxn";
+
+const EXPRESS_PARAMS = {} as ExpressTxnParams;
+
+describe("assertExpressParams", () => {
+  it("prevents an Express intent from falling through to a wallet transaction", () => {
+    expect(() =>
+      assertExpressParams({
+        expressParams: undefined,
+        isGmxAccount: false,
+        requireExpress: true,
+      })
+    ).toThrow("Express parameters are required for the selected trading mode");
+  });
+
+  it("requires Express parameters for multichain orders", () => {
+    expect(() =>
+      assertExpressParams({
+        expressParams: undefined,
+        isGmxAccount: true,
+        requireExpress: false,
+      })
+    ).toThrow("Multichain orders are only supported with express params");
+  });
+
+  it("allows Classic and resolved Express submissions", () => {
+    expect(() =>
+      assertExpressParams({
+        expressParams: undefined,
+        isGmxAccount: false,
+        requireExpress: false,
+      })
+    ).not.toThrow();
+    expect(() =>
+      assertExpressParams({
+        expressParams: EXPRESS_PARAMS,
+        isGmxAccount: false,
+        requireExpress: true,
+      })
+    ).not.toThrow();
+  });
+});

--- a/src/domain/synthetics/orders/sendBatchOrderTxn.ts
+++ b/src/domain/synthetics/orders/sendBatchOrderTxn.ts
@@ -42,6 +42,24 @@ export type BatchOrderTxnCtx = {
 
 const DEFAULT_RUN_SIMULATION = () => Promise.resolve(undefined);
 
+export function assertExpressParams({
+  expressParams,
+  isGmxAccount,
+  requireExpress,
+}: {
+  expressParams: ExpressTxnParams | undefined;
+  isGmxAccount: boolean;
+  requireExpress: boolean;
+}): void {
+  if (requireExpress && !expressParams) {
+    throw new Error("Express parameters are required for the selected trading mode");
+  }
+
+  if (isGmxAccount && !expressParams) {
+    throw new Error("Multichain orders are only supported with express params");
+  }
+}
+
 export async function sendBatchOrderTxn({
   chainId,
   signer,
@@ -49,6 +67,7 @@ export async function sendBatchOrderTxn({
   provider,
   batchParams,
   expressParams,
+  requireExpress = false,
   simulationParams,
   callback,
 }: {
@@ -58,6 +77,7 @@ export async function sendBatchOrderTxn({
   provider: Provider;
   batchParams: BatchOrderTxnParams;
   expressParams: ExpressTxnParams | undefined;
+  requireExpress?: boolean;
   simulationParams: BatchSimulationParams | undefined;
   callback: TxnCallback<BatchOrderTxnCtx> | undefined;
 }) {
@@ -69,9 +89,7 @@ export async function sendBatchOrderTxn({
   });
 
   try {
-    if (isGmxAccount && !expressParams) {
-      throw new Error("Multichain orders are only supported with express params");
-    }
+    assertExpressParams({ expressParams, isGmxAccount, requireExpress });
 
     if (isGmxAccount && !provider) {
       throw new Error("provider is required for multichain txns");

--- a/src/domain/synthetics/referrals/signClaimAffiliateRewards.ts
+++ b/src/domain/synthetics/referrals/signClaimAffiliateRewards.ts
@@ -44,5 +44,5 @@ export async function signClaimAffiliateRewards({
     relayParams: hashRelayParams(relayParams),
   };
 
-  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod });
+  return signTypedData({ signer, domain, types, typedData, shouldUseSignerMethod, verificationChainId: chainId });
 }

--- a/src/domain/synthetics/subaccount/removeSubaccount.ts
+++ b/src/domain/synthetics/subaccount/removeSubaccount.ts
@@ -141,6 +141,7 @@ async function signRemoveSubaccountPayload({
     types,
     typedData,
     domain,
+    verificationChainId: chainId,
   });
 }
 

--- a/src/domain/synthetics/trade/usePositionEditorState.ts
+++ b/src/domain/synthetics/trade/usePositionEditorState.ts
@@ -16,7 +16,7 @@ export type PositionEditorState = ReturnType<typeof usePositionEditorState>;
 
 export function usePositionEditorState(chainId: ContractsChainId, srcChainId: SourceChainId | undefined) {
   // const expressOrdersEnabled = useSelector(selectExpressOrdersEnabled);
-  const { expressOrdersEnabled } = useSettings();
+  const { expressOrdersEnabled, isExpressAccountSupportResolved } = useSettings();
   const [editingPositionKey, setEditingPositionKey] = useState<string>();
   const [collateralInputValue, setCollateralInputValue] = useState("");
   const [selectedCollateralAddressMap, setSelectedCollateralAddressMap] = useLocalStorageSerializeKey<
@@ -53,15 +53,20 @@ export function usePositionEditorState(chainId: ContractsChainId, srcChainId: So
 
   useEffect(
     function fallbackIsCollateralTokenFromGmxAccount() {
-      if (expressOrdersEnabled) {
+      if (expressOrdersEnabled || !isExpressAccountSupportResolved) {
         return;
       }
 
-      if (isCollateralTokenFromGmxAccount && !expressOrdersEnabled) {
+      if (isCollateralTokenFromGmxAccount) {
         setIsCollateralTokenFromGmxAccount(false);
       }
     },
-    [expressOrdersEnabled, isCollateralTokenFromGmxAccount, setIsCollateralTokenFromGmxAccount]
+    [
+      expressOrdersEnabled,
+      isCollateralTokenFromGmxAccount,
+      isExpressAccountSupportResolved,
+      setIsCollateralTokenFromGmxAccount,
+    ]
   );
 
   return useMemo(

--- a/src/domain/synthetics/trade/useTradeboxState.ts
+++ b/src/domain/synthetics/trade/useTradeboxState.ts
@@ -183,7 +183,8 @@ export function useTradeboxState(
     [chainId, latestEnabled, latestHistory]
   );
 
-  const { savedAllowedSlippage, savedTwapNumberOfParts, expressOrdersEnabled } = useSettings();
+  const { savedAllowedSlippage, savedTwapNumberOfParts, expressOrdersEnabled, isExpressAccountSupportResolved } =
+    useSettings();
   const [syncedChainId, setSyncedChainId] = useState<number | undefined>(undefined);
   const [allowedSlippage, setAllowedSlippage] = useState<number>(savedAllowedSlippage);
 
@@ -714,11 +715,20 @@ export function useTradeboxState(
 
   useEffect(
     function fallbackIsFromTokenGmxAccount() {
-      if (isFromTokenGmxAccount && (!expressOrdersEnabled || isEmptyAvalancheGmxAccount)) {
+      if (
+        isFromTokenGmxAccount &&
+        ((!expressOrdersEnabled && isExpressAccountSupportResolved) || isEmptyAvalancheGmxAccount)
+      ) {
         setIsFromTokenGmxAccount(false);
       }
     },
-    [expressOrdersEnabled, isEmptyAvalancheGmxAccount, isFromTokenGmxAccount, setIsFromTokenGmxAccount]
+    [
+      expressOrdersEnabled,
+      isEmptyAvalancheGmxAccount,
+      isExpressAccountSupportResolved,
+      isFromTokenGmxAccount,
+      setIsFromTokenGmxAccount,
+    ]
   );
 
   return {

--- a/src/domain/tokens/useTokenApproval.spec.ts
+++ b/src/domain/tokens/useTokenApproval.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { getShouldAllowPermit } from "./useTokenApproval";
+
+describe("getShouldAllowPermit", () => {
+  it("allows permit for a loaded EOA flow", () => {
+    expect(
+      getShouldAllowPermit({
+        allowPermit: true,
+        isSmartAccount: false,
+        isAccountTypeUnavailable: false,
+      })
+    ).toBe(true);
+  });
+
+  it("routes smart accounts to approve", () => {
+    expect(
+      getShouldAllowPermit({
+        allowPermit: true,
+        isSmartAccount: true,
+        isAccountTypeUnavailable: false,
+      })
+    ).toBe(false);
+  });
+
+  it("fails closed while the account type is loading", () => {
+    expect(
+      getShouldAllowPermit({
+        allowPermit: true,
+        isSmartAccount: false,
+        isAccountTypeUnavailable: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/domain/tokens/useTokenApproval.ts
+++ b/src/domain/tokens/useTokenApproval.ts
@@ -6,6 +6,7 @@ import { useTokenPermitsContext } from "context/TokenPermitsContext/TokenPermits
 import { getNeedTokenApprove, useTokensAllowanceData } from "domain/synthetics/tokens";
 import { EMPTY_ARRAY } from "lib/objects";
 import type { WalletSigner } from "lib/wallets";
+import { useExpressAccountSupport } from "lib/wallets/useAccountType";
 import type { AnyChainId } from "sdk/configs/chains";
 
 import { wrapChainAction } from "components/GmxAccountModal/wrapChainAction";
@@ -39,6 +40,18 @@ interface UseTokenApprovalReturn {
   handleApprove: (options?: HandleApproveOptions) => void;
 }
 
+export function getShouldAllowPermit({
+  allowPermit,
+  isSmartAccount,
+  isAccountTypeUnavailable,
+}: {
+  allowPermit: boolean;
+  isSmartAccount: boolean;
+  isAccountTypeUnavailable: boolean;
+}): boolean {
+  return allowPermit && !isSmartAccount && !isAccountTypeUnavailable;
+}
+
 export function useTokenApproval({
   chainId,
   spenderAddress,
@@ -50,6 +63,12 @@ export function useTokenApproval({
   const [approvingToken, setApprovingToken] = useState<string | undefined>();
   const { tokenPermits, addTokenPermit, isPermitsDisabled, setIsPermitsDisabled } = useTokenPermitsContext();
   const [, setSettlementChainId] = useGmxAccountSettlementChainId();
+  const { isSmartAccount, isExpressAccountSupported, isLoading: isAccountTypeLoading } = useExpressAccountSupport();
+  const shouldAllowPermit = getShouldAllowPermit({
+    allowPermit,
+    isSmartAccount,
+    isAccountTypeUnavailable: isAccountTypeLoading || !isExpressAccountSupported,
+  });
 
   const mergedTokens = useMemo(() => {
     const map = new Map<string, bigint>();
@@ -78,7 +97,7 @@ export function useTokenApproval({
   const isAllowanceLoading = nothingToCheck ? false : isAllowanceLoadingRaw;
   const isAllowanceLoaded = nothingToCheck ? true : isAllowanceLoadedRaw;
 
-  const permitsOrEmpty = allowPermit && !isPermitsDisabled && tokenPermits ? tokenPermits : EMPTY_ARRAY;
+  const permitsOrEmpty = shouldAllowPermit && !isPermitsDisabled && tokenPermits ? tokenPermits : EMPTY_ARRAY;
 
   const tokensToApprove = useMemo(
     () =>
@@ -106,7 +125,7 @@ export function useTokenApproval({
       const tokenAddress = tokensToApprove[0];
       if (!chainId || isApproving || !tokenAddress || !spenderAddress) return;
 
-      const permitParams = allowPermit ? { addTokenPermit, setIsPermitsDisabled, isPermitsDisabled } : undefined;
+      const permitParams = shouldAllowPermit ? { addTokenPermit, setIsPermitsDisabled, isPermitsDisabled } : undefined;
 
       const doApprove = async (signerToUse: WalletSigner) => {
         setApprovingToken(tokenAddress);
@@ -134,13 +153,13 @@ export function useTokenApproval({
     },
     [
       addTokenPermit,
-      allowPermit,
       approveAmount,
       chainId,
       isApproving,
       isPermitsDisabled,
       setIsPermitsDisabled,
       setSettlementChainId,
+      shouldAllowPermit,
       spenderAddress,
       tokensToApprove,
     ]

--- a/src/lib/chains/useNonEoaAccountChainWarning.ts
+++ b/src/lib/chains/useNonEoaAccountChainWarning.ts
@@ -23,22 +23,22 @@ const toastGetSnapshot = () => toast.isActive(NON_EOA_ACCOUNT_CHAIN_WARNING_TOAS
 
 export function useNonEoaAccountChainWarning() {
   const { srcChainId } = useChainId();
-  const { isNonEoaAccountOnAnyChain } = useNonSigningAccount();
+  const { isNonSigningAccountOnAnyChain } = useNonSigningAccount();
 
   const isActive = useSyncExternalStore(toastSubscribe, toastGetSnapshot);
 
   useEffect(() => {
-    if (srcChainId && isNonEoaAccountOnAnyChain) {
+    if (srcChainId && isNonSigningAccountOnAnyChain) {
       toast.error(getNonEoaAccountChainWarningToastContent(srcChainId), {
         toastId: NON_EOA_ACCOUNT_CHAIN_WARNING_TOAST_ID,
         autoClose: false,
         closeButton: false,
         delay: 2000,
       });
-    } else if (!srcChainId || !isNonEoaAccountOnAnyChain) {
+    } else if (!srcChainId || !isNonSigningAccountOnAnyChain) {
       toast.dismiss(NON_EOA_ACCOUNT_CHAIN_WARNING_TOAST_ID);
     }
-  }, [isActive, isNonEoaAccountOnAnyChain, srcChainId]);
+  }, [isActive, isNonSigningAccountOnAnyChain, srcChainId]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/errors/customErrors.ts
+++ b/src/lib/errors/customErrors.ts
@@ -8,21 +8,6 @@ import { ErrorData, ErrorLike, extendError, parseError } from ".";
 export const INVALID_PERMIT_SIGNATURE_ERROR = "Invalid permit signature";
 export const EXPIRED_PERMIT_DEADLINE_ERROR = "Expired permit deadline";
 export const FAST_EXPRESS_PARAMS_TIMEOUT_ERROR = "fastExpressParams timeout";
-export const NON_SIGNING_ACCOUNT_DETECTED_ERROR = "Non-signing account detected";
-
-export function nonSigningAccountError(chainId: number) {
-  return extendError(new Error(NON_SIGNING_ACCOUNT_DETECTED_ERROR), {
-    data: {
-      chainId,
-    },
-  });
-}
-
-export function getIsNonSigningAccountError(error: ErrorLike) {
-  const parsedError = parseError(error);
-
-  return parsedError?.errorMessage?.includes(NON_SIGNING_ACCOUNT_DETECTED_ERROR);
-}
 
 export function getIsInsufficientExecutionFeeError(
   error: ErrorLike

--- a/src/lib/wallets/index.ts
+++ b/src/lib/wallets/index.ts
@@ -10,6 +10,7 @@ import { getWagmiConfig } from "./walletConfig";
 
 export type WalletSigner = UncheckedJsonRpcSigner & {
   address: string;
+  isSmartAccount?: boolean;
 };
 
 function selectNetworkInApp(chainId: number) {

--- a/src/lib/wallets/privyWagmi.spec.ts
+++ b/src/lib/wallets/privyWagmi.spec.ts
@@ -5,7 +5,7 @@ import type { Config } from "wagmi";
 import {
   disconnectPrivyWalletsFromWagmi,
   getConnectedPrivyWallet,
-  getIsKnownSmartWalletClient,
+  getIsSmartWalletClient,
   getPrivyWagmiConnectorId,
 } from "./privyWagmi";
 
@@ -65,11 +65,24 @@ describe("privyWagmi", () => {
   });
 
   it("distinguishes known smart-wallet clients from regular Coinbase Wallet", () => {
-    expect(getIsKnownSmartWalletClient("safe")).toBe(true);
-    expect(getIsKnownSmartWalletClient("coinbase_smart_wallet")).toBe(true);
-    expect(getIsKnownSmartWalletClient("base_account")).toBe(true);
-    expect(getIsKnownSmartWalletClient("coinbase_wallet")).toBe(false);
-    expect(getIsKnownSmartWalletClient("metamask")).toBe(false);
+    for (const walletClientType of [
+      "safe",
+      "coinbase_smart_wallet",
+      "base_account",
+      "kernel",
+      "light_account",
+      "biconomy",
+      "thirdweb",
+      "nexus",
+      "unknown",
+    ]) {
+      expect(getIsSmartWalletClient(walletClientType)).toBe(true);
+    }
+
+    expect(getIsSmartWalletClient("coinbase_wallet")).toBe(false);
+    expect(getIsSmartWalletClient("metamask")).toBe(false);
+    expect(getIsSmartWalletClient("rainbow")).toBe(false);
+    expect(getIsSmartWalletClient(undefined)).toBe(false);
   });
 
   it("marks all Privy-backed wagmi connectors disconnected", async () => {

--- a/src/lib/wallets/privyWagmi.spec.ts
+++ b/src/lib/wallets/privyWagmi.spec.ts
@@ -2,7 +2,12 @@ import type { ConnectedWallet } from "@privy-io/react-auth";
 import { describe, expect, it, vi } from "vitest";
 import type { Config } from "wagmi";
 
-import { disconnectPrivyWalletsFromWagmi, getPrivyWagmiConnectorId } from "./privyWagmi";
+import {
+  disconnectPrivyWalletsFromWagmi,
+  getConnectedPrivyWallet,
+  getIsKnownSmartWalletClient,
+  getPrivyWagmiConnectorId,
+} from "./privyWagmi";
 
 function createWallet({
   address = "0x0000000000000000000000000000000000000001",
@@ -41,6 +46,30 @@ describe("privyWagmi", () => {
     });
 
     expect(getPrivyWagmiConnectorId(wallet)).toBe("io.phantom");
+  });
+
+  it("finds the active Privy wallet by address and connector", () => {
+    const inactiveWallet = createWallet({ metaId: "io.metamask" });
+    const activeWallet = createWallet({
+      metaId: "io.coinbase.smart-wallet",
+      walletClientType: "coinbase_smart_wallet",
+    });
+
+    expect(
+      getConnectedPrivyWallet(
+        [inactiveWallet, activeWallet],
+        "0x0000000000000000000000000000000000000001",
+        "io.coinbase.smart-wallet"
+      )
+    ).toBe(activeWallet);
+  });
+
+  it("distinguishes known smart-wallet clients from regular Coinbase Wallet", () => {
+    expect(getIsKnownSmartWalletClient("safe")).toBe(true);
+    expect(getIsKnownSmartWalletClient("coinbase_smart_wallet")).toBe(true);
+    expect(getIsKnownSmartWalletClient("base_account")).toBe(true);
+    expect(getIsKnownSmartWalletClient("coinbase_wallet")).toBe(false);
+    expect(getIsKnownSmartWalletClient("metamask")).toBe(false);
   });
 
   it("marks all Privy-backed wagmi connectors disconnected", async () => {

--- a/src/lib/wallets/privyWagmi.ts
+++ b/src/lib/wallets/privyWagmi.ts
@@ -6,6 +6,35 @@ import { getWagmiConfig } from "./walletConfig";
 
 type PrivyWagmiWallet = Pick<ConnectedWallet, "address" | "meta" | "walletClientType">;
 
+const KNOWN_EOA_WALLET_CLIENT_TYPES = new Set([
+  "privy",
+  "metamask",
+  "phantom",
+  "brave_wallet",
+  "rainbow",
+  "uniswap_wallet_extension",
+  "uniswap_extension",
+  "rabby_wallet",
+  "bybit_wallet",
+  "ronin_wallet",
+  "haha_wallet",
+  "crypto.com_wallet_extension",
+  "crypto.com_onchain",
+  "binance",
+  "binanceus",
+  "bitget_wallet",
+  "coinbase_wallet",
+  "zerion",
+  "cryptocom",
+  "uniswap",
+  "okx_wallet",
+  "solflare",
+  "backpack",
+  "jupiter",
+  "kraken_wallet",
+  "robinhood_wallet",
+]);
+
 export function getPrivyWagmiConnectorId(wallet: PrivyWagmiWallet): string {
   return wallet.walletClientType === "privy" ? `${wallet.meta.id}.${wallet.address}` : wallet.meta.id;
 }
@@ -23,10 +52,8 @@ export function getConnectedPrivyWallet(
   );
 }
 
-export function getIsKnownSmartWalletClient(walletClientType: string | undefined): boolean {
-  return (
-    walletClientType === "safe" || walletClientType === "base_account" || walletClientType === "coinbase_smart_wallet"
-  );
+export function getIsSmartWalletClient(walletClientType: string | undefined): boolean {
+  return walletClientType !== undefined && !KNOWN_EOA_WALLET_CLIENT_TYPES.has(walletClientType);
 }
 
 export async function disconnectPrivyWalletsFromWagmi(wallets: PrivyWagmiWallet[], config: Config = getWagmiConfig()) {

--- a/src/lib/wallets/privyWagmi.ts
+++ b/src/lib/wallets/privyWagmi.ts
@@ -1,4 +1,5 @@
 import type { ConnectedWallet } from "@privy-io/react-auth";
+import { type Address, isAddressEqual } from "viem";
 import type { Config } from "wagmi";
 
 import { getWagmiConfig } from "./walletConfig";
@@ -7,6 +8,25 @@ type PrivyWagmiWallet = Pick<ConnectedWallet, "address" | "meta" | "walletClient
 
 export function getPrivyWagmiConnectorId(wallet: PrivyWagmiWallet): string {
   return wallet.walletClientType === "privy" ? `${wallet.meta.id}.${wallet.address}` : wallet.meta.id;
+}
+
+export function getConnectedPrivyWallet(
+  wallets: PrivyWagmiWallet[],
+  address: Address | undefined,
+  connectorId: string | undefined
+): PrivyWagmiWallet | undefined {
+  return wallets.find(
+    (wallet) =>
+      address !== undefined &&
+      isAddressEqual(wallet.address as Address, address) &&
+      (!connectorId || getPrivyWagmiConnectorId(wallet) === connectorId)
+  );
+}
+
+export function getIsKnownSmartWalletClient(walletClientType: string | undefined): boolean {
+  return (
+    walletClientType === "safe" || walletClientType === "base_account" || walletClientType === "coinbase_smart_wallet"
+  );
 }
 
 export async function disconnectPrivyWalletsFromWagmi(wallets: PrivyWagmiWallet[], config: Config = getWagmiConfig()) {

--- a/src/lib/wallets/signing.spec.ts
+++ b/src/lib/wallets/signing.spec.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { shouldSwitchToVerificationChain } from "./signing";
+import { shouldSwitchToVerificationChain, withNetworkRestoration } from "./signing";
 
 describe("shouldSwitchToVerificationChain", () => {
   it("switches when a smart wallet is deployed on the verification chain", () => {
@@ -61,5 +61,43 @@ describe("shouldSwitchToVerificationChain", () => {
         isKnownSmartAccount: true,
       })
     ).toBe(true);
+  });
+});
+
+describe("withNetworkRestoration", () => {
+  it("returns the action result after restoring the original network", async () => {
+    const restore = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      withNetworkRestoration({
+        action: () => Promise.resolve("signature"),
+        restore,
+      })
+    ).resolves.toBe("signature");
+    expect(restore).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces a restoration failure after a successful action", async () => {
+    const restoreError = new Error("User rejected network restoration");
+
+    await expect(
+      withNetworkRestoration({
+        action: () => Promise.resolve("signature"),
+        restore: () => Promise.reject(restoreError),
+      })
+    ).rejects.toBe(restoreError);
+  });
+
+  it("preserves the action error if restoration also fails", async () => {
+    const actionError = new Error("Signing failed");
+    const restore = vi.fn().mockRejectedValue(new Error("Restoration failed"));
+
+    await expect(
+      withNetworkRestoration({
+        action: () => Promise.reject(actionError),
+        restore,
+      })
+    ).rejects.toBe(actionError);
+    expect(restore).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/wallets/signing.spec.ts
+++ b/src/lib/wallets/signing.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSwitchToVerificationChain } from "./signing";
+
+describe("shouldSwitchToVerificationChain", () => {
+  it("switches when a smart wallet is deployed on the verification chain", () => {
+    expect(
+      shouldSwitchToVerificationChain({
+        currentChainId: 1,
+        verificationChainId: 42161,
+        hasCodeOnCurrentChain: false,
+        hasCodeOnVerificationChain: true,
+        isKnownSmartAccount: false,
+      })
+    ).toBe(true);
+  });
+
+  it("switches for a counterfactual wallet detected on the current chain", () => {
+    expect(
+      shouldSwitchToVerificationChain({
+        currentChainId: 1,
+        verificationChainId: 42161,
+        hasCodeOnCurrentChain: true,
+        hasCodeOnVerificationChain: false,
+        isKnownSmartAccount: false,
+      })
+    ).toBe(true);
+  });
+
+  it("does not switch an EOA", () => {
+    expect(
+      shouldSwitchToVerificationChain({
+        currentChainId: 1,
+        verificationChainId: 42161,
+        hasCodeOnCurrentChain: false,
+        hasCodeOnVerificationChain: false,
+        isKnownSmartAccount: false,
+      })
+    ).toBe(false);
+  });
+
+  it("does not switch when already connected to the verification chain", () => {
+    expect(
+      shouldSwitchToVerificationChain({
+        currentChainId: 42161,
+        verificationChainId: 42161,
+        hasCodeOnCurrentChain: true,
+        hasCodeOnVerificationChain: true,
+        isKnownSmartAccount: false,
+      })
+    ).toBe(false);
+  });
+
+  it("switches a known counterfactual smart-wallet connector", () => {
+    expect(
+      shouldSwitchToVerificationChain({
+        currentChainId: 1,
+        verificationChainId: 42161,
+        hasCodeOnCurrentChain: false,
+        hasCodeOnVerificationChain: false,
+        isKnownSmartAccount: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/lib/wallets/signing.ts
+++ b/src/lib/wallets/signing.ts
@@ -107,6 +107,27 @@ function providerSendSign(signer: ProviderSigner, from: string, eip712: object) 
   );
 }
 
+export async function withNetworkRestoration<T>({
+  action,
+  restore,
+}: {
+  action: () => Promise<T>;
+  restore: () => Promise<void>;
+}): Promise<T> {
+  let result: T;
+
+  try {
+    result = await action();
+  } catch (actionError) {
+    await restore().catch(() => undefined);
+    throw actionError;
+  }
+
+  await restore();
+
+  return result;
+}
+
 async function withSmartWalletChainSwap<T>(
   {
     signer,
@@ -134,22 +155,23 @@ async function withSmartWalletChainSwap<T>(
 
   await switchNetwork(verificationChainId!, true);
 
-  try {
-    const account = getAccount(config).address;
-    if (!account) {
-      throw new Error("Wallet disconnected while switching to the Express signing network");
-    }
-    if (!isAddressEqual(account, address as Address)) {
-      throw new Error("Wallet account changed while switching to the Express signing network");
-    }
+  return withNetworkRestoration({
+    action: async () => {
+      const account = getAccount(config).address;
+      if (!account) {
+        throw new Error("Wallet disconnected while switching to the Express signing network");
+      }
+      if (!isAddressEqual(account, address as Address)) {
+        throw new Error("Wallet account changed while switching to the Express signing network");
+      }
 
-    const walletClient = await getWalletClient(config);
-    const chainSigner = clientToSigner(walletClient, account);
+      const walletClient = await getWalletClient(config);
+      const chainSigner = clientToSigner(walletClient, account);
 
-    return await action(chainSigner);
-  } finally {
-    await switchNetwork(startingChainId, true).catch(() => undefined);
-  }
+      return action(chainSigner);
+    },
+    restore: () => switchNetwork(startingChainId, true),
+  });
 }
 
 export async function signTypedData({

--- a/src/lib/wallets/signing.ts
+++ b/src/lib/wallets/signing.ts
@@ -1,6 +1,6 @@
 import { getAccount, getChainId, getWalletClient } from "@wagmi/core";
-import { AbstractSigner, type Wallet } from "ethers";
-import { hashTypedData, withRetry, type Hex } from "viem";
+import { AbstractSigner, TypedDataEncoder, type Wallet } from "ethers";
+import { type Address, isAddressEqual, withRetry } from "viem";
 
 import { parseError } from "lib/errors";
 import { ISigner } from "lib/transactions/iSigner";
@@ -26,35 +26,74 @@ export type SignTypedDataParams = {
   domain: SignatureDomain;
   shouldUseSignerMethod?: boolean;
   minified?: boolean;
-  /** Chain the on-chain verifier runs on; smart wallets must sign with their wallet on this chain. */
   verificationChainId?: number;
 };
 
+type ProviderSigner = WalletSigner | Wallet | AbstractSigner | ISigner;
 type RpcSendable = Pick<WalletSigner["provider"], "send">;
 
-type AnySigner = WalletSigner | Wallet | AbstractSigner | ISigner;
+export function shouldSwitchToVerificationChain({
+  currentChainId,
+  verificationChainId,
+  hasCodeOnCurrentChain,
+  hasCodeOnVerificationChain,
+  isKnownSmartAccount,
+}: {
+  currentChainId: number;
+  verificationChainId: number | undefined;
+  hasCodeOnCurrentChain: boolean;
+  hasCodeOnVerificationChain: boolean;
+  isKnownSmartAccount: boolean;
+}): boolean {
+  return Boolean(
+    verificationChainId !== undefined &&
+      verificationChainId !== currentChainId &&
+      (hasCodeOnCurrentChain || hasCodeOnVerificationChain || isKnownSmartAccount)
+  );
+}
+
+async function hasCode(chainId: number, address: string): Promise<boolean> {
+  const code = await getPublicClientWithRpc(chainId).getCode({ address });
+  return Boolean(code && code !== "0x");
+}
 
 async function needsChainSwapForSmartWallet({
   address,
   currentChainId,
-  targetChainId,
+  verificationChainId,
+  isKnownSmartAccount,
 }: {
   address: string;
   currentChainId: number;
-  targetChainId: number | undefined;
+  verificationChainId: number | undefined;
+  isKnownSmartAccount: boolean;
 }): Promise<boolean> {
-  if (targetChainId === undefined || targetChainId === currentChainId) {
+  if (verificationChainId === undefined || verificationChainId === currentChainId) {
     return false;
   }
-  try {
-    const code = await getPublicClientWithRpc(currentChainId).getCode({ address });
-    return Boolean(code && code !== "0x");
-  } catch {
-    return false;
+
+  if (isKnownSmartAccount) {
+    return true;
   }
+
+  const [currentChainCodeResult, verificationChainCodeResult] = await Promise.allSettled([
+    hasCode(currentChainId, address),
+    hasCode(verificationChainId, address),
+  ]);
+  const hasCodeOnCurrentChain = currentChainCodeResult.status === "fulfilled" && currentChainCodeResult.value;
+  const hasCodeOnVerificationChain =
+    verificationChainCodeResult.status === "fulfilled" && verificationChainCodeResult.value;
+
+  return shouldSwitchToVerificationChain({
+    currentChainId,
+    verificationChainId,
+    hasCodeOnCurrentChain,
+    hasCodeOnVerificationChain,
+    isKnownSmartAccount,
+  });
 }
 
-function providerSendSign(signer: AnySigner, from: string, eip712: object) {
+function providerSendSign(signer: ProviderSigner, from: string, eip712: object) {
   return withRetry<string>(
     () => (signer.provider as RpcSendable).send("eth_signTypedData_v4", [from, JSON.stringify(eip712)]),
     {
@@ -72,60 +111,45 @@ async function withSmartWalletChainSwap<T>(
   {
     signer,
     address,
-    targetChainId,
+    verificationChainId,
   }: {
-    signer: AnySigner;
+    signer: ProviderSigner;
     address: string;
-    targetChainId: number | undefined;
+    verificationChainId: number | undefined;
   },
-  action: (signer: AnySigner) => Promise<T>
+  action: (signer: ProviderSigner) => Promise<T>
 ): Promise<T> {
   const config = getWagmiConfig();
   const startingChainId = getChainId(config);
-  const needsSwap = await needsChainSwapForSmartWallet({
+  const needsChainSwap = await needsChainSwapForSmartWallet({
     address,
     currentChainId: startingChainId,
-    targetChainId,
+    verificationChainId,
+    isKnownSmartAccount: "isSmartAccount" in signer && signer.isSmartAccount === true,
   });
 
-  if (!needsSwap) return action(signer);
+  if (!needsChainSwap) {
+    return action(signer);
+  }
 
-  await switchNetwork(targetChainId!, true);
-  const account = getAccount(config).address;
-  if (!account) throw new Error("No account after chain swap");
-  const swappedWalletClient = await getWalletClient(config);
-  const swappedSigner = clientToSigner(swappedWalletClient, account);
+  await switchNetwork(verificationChainId!, true);
+
   try {
-    return await action(swappedSigner);
+    const account = getAccount(config).address;
+    if (!account) {
+      throw new Error("Wallet disconnected while switching to the Express signing network");
+    }
+    if (!isAddressEqual(account, address as Address)) {
+      throw new Error("Wallet account changed while switching to the Express signing network");
+    }
+
+    const walletClient = await getWalletClient(config);
+    const chainSigner = clientToSigner(walletClient, account);
+
+    return await action(chainSigner);
   } finally {
-    await switchNetwork(startingChainId, true).catch(() => {
-      // restoring is best-effort
-    });
+    await switchNetwork(startingChainId, true).catch(() => undefined);
   }
-}
-
-// TODO: it this needed or we can just use [0] as primaryType?
-function hashTypedDataWithViem({
-  domain,
-  types,
-  message,
-}: {
-  domain: SignatureDomain;
-  types: SignatureTypes;
-  message: Record<string, any>;
-}): Hex {
-  const primaryType = Object.keys(types).find((t) => t !== "EIP712Domain");
-
-  if (!primaryType) {
-    throw new Error("Unable to determine EIP-712 primary type");
-  }
-
-  return hashTypedData({
-    domain,
-    types,
-    primaryType,
-    message,
-  });
 }
 
 export async function signTypedData({
@@ -161,11 +185,7 @@ export async function signTypedData({
   let messageToSign = typedData;
 
   if (minified) {
-    const digest = hashTypedDataWithViem({
-      domain,
-      types,
-      message: typedData,
-    });
+    const digest = TypedDataEncoder.hash(domain, types, typedData);
     const minifiedTypes = {
       Minified: [{ name: "digest", type: "bytes32" }],
     };
@@ -201,15 +221,23 @@ export async function signTypedData({
     message: messageToSign,
   };
 
-  return withSmartWalletChainSwap({ signer, address: from, targetChainId: verificationChainId }, (signWith) => {
-    if (shouldUseSignerMethod && signWith.signTypedData) {
-      return signWith.signTypedData(domain, typesToSign, messageToSign).catch((e) => {
-        if (!e.message.includes("requires a provider")) throw e;
-        return providerSendSign(signWith, from, eip712);
-      });
+  return withSmartWalletChainSwap(
+    { signer, address: from, verificationChainId },
+    async (signerForVerificationChain) => {
+      if (shouldUseSignerMethod && signerForVerificationChain.signTypedData) {
+        try {
+          return await signerForVerificationChain.signTypedData(domain, typesToSign, messageToSign);
+        } catch (error) {
+          if (!(error instanceof Error) || !error.message.includes("requires a provider")) {
+            throw error;
+          }
+        }
+      }
+
+      const signingAddress = await signerForVerificationChain.getAddress();
+      return providerSendSign(signerForVerificationChain, signingAddress, eip712);
     }
-    return providerSendSign(signWith, from, eip712);
-  });
+  );
 }
 
 export function splitSignature(signature: string): { r: string; s: string; v: number } {

--- a/src/lib/wallets/useAccountType.spec.ts
+++ b/src/lib/wallets/useAccountType.spec.ts
@@ -1,15 +1,39 @@
-import { ContractFunctionRevertedError, ContractFunctionZeroDataError, type PublicClient } from "viem";
+import { ContractFunctionRevertedError, ContractFunctionZeroDataError, type Hex, type PublicClient } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
-import { ARBITRUM, AVALANCHE } from "config/chains";
+import {
+  ARBITRUM,
+  ARBITRUM_SEPOLIA,
+  AVALANCHE,
+  AVALANCHE_FUJI,
+  SOURCE_BASE_MAINNET,
+  SOURCE_SEPOLIA,
+} from "config/chains";
 import { abis } from "sdk/abis";
 
-import { AccountType, fetchIsErc1271, getAccountCapabilities, getExpressAccountSupport } from "./useAccountType";
+import {
+  AccountType,
+  fetchIsErc1271,
+  getAccountCapabilities,
+  getAccountCapabilityChainIds,
+  getAccountType,
+  getExpressAccountSupport,
+} from "./useAccountType";
 
 const ACCOUNT = "0x1111111111111111111111111111111111111111";
+const SAFE_SINGLETON = "0x3e5c63644e683549055b9be8653de26e0b4cd36e";
+const SAFE_COMPATIBILITY_FALLBACK_HANDLER = "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99";
 
 function createClient(readContract: PublicClient["readContract"]): PublicClient {
-  return { readContract } as PublicClient;
+  return {
+    readContract,
+    getCode: vi.fn().mockResolvedValue("0x6000"),
+    getStorageAt: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PublicClient;
+}
+
+function addressStorageValue(address: string): Hex {
+  return `0x${"0".repeat(24)}${address.slice(2)}` as Hex;
 }
 
 describe("fetchIsErc1271", () => {
@@ -19,13 +43,25 @@ describe("fetchIsErc1271", () => {
     await expect(fetchIsErc1271(client, ACCOUNT)).resolves.toBe(true);
   });
 
-  it("accepts a contract that rejects an invalid signature with revert data", async () => {
+  it("does not treat an arbitrary contract revert as ERC-1271 support", async () => {
     const error = new ContractFunctionRevertedError({
       abi: abis.SmartAccount,
       data: "0x12345678",
       functionName: "isValidSignature",
     });
     const client = createClient(vi.fn().mockRejectedValue(error));
+
+    await expect(fetchIsErc1271(client, ACCOUNT)).resolves.toBe(false);
+  });
+
+  it("accepts a reverting contract with an ERC-1271 implementation", async () => {
+    const error = new ContractFunctionRevertedError({
+      abi: abis.SmartAccount,
+      data: "0x12345678",
+      functionName: "isValidSignature",
+    });
+    const client = createClient(vi.fn().mockRejectedValue(error));
+    vi.mocked(client.getCode).mockResolvedValue("0x631626ba7e");
 
     await expect(fetchIsErc1271(client, ACCOUNT)).resolves.toBe(true);
   });
@@ -41,6 +77,44 @@ describe("fetchIsErc1271", () => {
     const client = createClient(vi.fn().mockRejectedValue(new Error("RPC unavailable")));
 
     await expect(fetchIsErc1271(client, ACCOUNT)).rejects.toThrow("RPC unavailable");
+  });
+});
+
+describe("getAccountType", () => {
+  it("supports a Safe with a compatible signature fallback handler", async () => {
+    const client = {
+      getCode: vi.fn().mockResolvedValue("0x1234"),
+      getStorageAt: vi
+        .fn()
+        .mockResolvedValueOnce(addressStorageValue(SAFE_SINGLETON))
+        .mockResolvedValueOnce(addressStorageValue(SAFE_COMPATIBILITY_FALLBACK_HANDLER)),
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
+
+    await expect(getAccountType(ACCOUNT, client)).resolves.toBe(AccountType.Safe);
+  });
+
+  it("blocks a Safe without a compatible signature fallback handler", async () => {
+    const client = {
+      getCode: vi.fn().mockResolvedValue("0x1234"),
+      getStorageAt: vi
+        .fn()
+        .mockResolvedValueOnce(addressStorageValue(SAFE_SINGLETON))
+        .mockResolvedValueOnce(addressStorageValue("0x0000000000000000000000000000000000000000")),
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
+
+    await expect(getAccountType(ACCOUNT, client)).resolves.toBe(AccountType.SmartAccount);
+  });
+
+  it("supports a generic contract with a decoded ERC-1271 response", async () => {
+    const client = {
+      getCode: vi.fn().mockResolvedValue("0x1234"),
+      getStorageAt: vi.fn().mockResolvedValue(addressStorageValue("0x0000000000000000000000000000000000000000")),
+      readContract: vi.fn().mockResolvedValue("0xffffffff"),
+    } as unknown as PublicClient;
+
+    await expect(getAccountType(ACCOUNT, client)).resolves.toBe(AccountType.ERC1271);
   });
 });
 
@@ -64,6 +138,28 @@ describe("getAccountCapabilities", () => {
       isSmartAccount: true,
       isNonSigningAccountOnAnyChain: true,
     });
+  });
+});
+
+describe("getAccountCapabilityChainIds", () => {
+  it("includes every production account chain before the wallet switches", () => {
+    const chainIds = getAccountCapabilityChainIds(ARBITRUM);
+
+    expect(chainIds).toContain(ARBITRUM);
+    expect(chainIds).toContain(AVALANCHE);
+    expect(chainIds).toContain(SOURCE_BASE_MAINNET);
+    expect(chainIds).not.toContain(ARBITRUM_SEPOLIA);
+    expect(chainIds).not.toContain(AVALANCHE_FUJI);
+  });
+
+  it("keeps testnet capability checks separate from production", () => {
+    const chainIds = getAccountCapabilityChainIds(ARBITRUM_SEPOLIA);
+
+    expect(chainIds).toContain(ARBITRUM_SEPOLIA);
+    expect(chainIds).toContain(AVALANCHE_FUJI);
+    expect(chainIds).toContain(SOURCE_SEPOLIA);
+    expect(chainIds).not.toContain(ARBITRUM);
+    expect(chainIds).not.toContain(SOURCE_BASE_MAINNET);
   });
 });
 

--- a/src/lib/wallets/useAccountType.spec.ts
+++ b/src/lib/wallets/useAccountType.spec.ts
@@ -1,0 +1,161 @@
+import { ContractFunctionRevertedError, ContractFunctionZeroDataError, type PublicClient } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import { ARBITRUM, AVALANCHE } from "config/chains";
+import { abis } from "sdk/abis";
+
+import { AccountType, fetchIsErc1271, getAccountCapabilities, getExpressAccountSupport } from "./useAccountType";
+
+const ACCOUNT = "0x1111111111111111111111111111111111111111";
+
+function createClient(readContract: PublicClient["readContract"]): PublicClient {
+  return { readContract } as PublicClient;
+}
+
+describe("fetchIsErc1271", () => {
+  it("accepts a contract that returns an ERC-1271 response", async () => {
+    const client = createClient(vi.fn().mockResolvedValue("0xffffffff"));
+
+    await expect(fetchIsErc1271(client, ACCOUNT)).resolves.toBe(true);
+  });
+
+  it("accepts a contract that rejects an invalid signature with revert data", async () => {
+    const error = new ContractFunctionRevertedError({
+      abi: abis.SmartAccount,
+      data: "0x12345678",
+      functionName: "isValidSignature",
+    });
+    const client = createClient(vi.fn().mockRejectedValue(error));
+
+    await expect(fetchIsErc1271(client, ACCOUNT)).resolves.toBe(true);
+  });
+
+  it("rejects accounts that return no contract data", async () => {
+    const error = new ContractFunctionZeroDataError({ functionName: "isValidSignature" });
+    const client = createClient(vi.fn().mockRejectedValue(error));
+
+    await expect(fetchIsErc1271(client, ACCOUNT)).resolves.toBe(false);
+  });
+
+  it("does not treat RPC failures as signing support", async () => {
+    const client = createClient(vi.fn().mockRejectedValue(new Error("RPC unavailable")));
+
+    await expect(fetchIsErc1271(client, ACCOUNT)).rejects.toThrow("RPC unavailable");
+  });
+});
+
+describe("getAccountCapabilities", () => {
+  it("allows EOAs and EIP-7702 accounts", () => {
+    expect(getAccountCapabilities([AccountType.EOA, AccountType.PostEip7702EOA])).toEqual({
+      isSmartAccount: false,
+      isNonSigningAccountOnAnyChain: false,
+    });
+  });
+
+  it("allows Safe and ERC-1271 smart accounts", () => {
+    expect(getAccountCapabilities([AccountType.Safe, AccountType.ERC1271])).toEqual({
+      isSmartAccount: true,
+      isNonSigningAccountOnAnyChain: false,
+    });
+  });
+
+  it("blocks a contract without a validated signing path", () => {
+    expect(getAccountCapabilities([AccountType.ERC1271, AccountType.SmartAccount])).toEqual({
+      isSmartAccount: true,
+      isNonSigningAccountOnAnyChain: true,
+    });
+  });
+});
+
+describe("getExpressAccountSupport", () => {
+  it("allows an EOA on supported Express networks", () => {
+    expect(
+      getExpressAccountSupport({
+        chainId: AVALANCHE,
+        isSmartAccount: false,
+        isNonSigningAccountOnAnyChain: false,
+        isLoading: false,
+        hasError: false,
+        hasUnsupportedSigningProvider: false,
+      })
+    ).toEqual({ isExpressAccountSupported: true, unavailableReason: undefined });
+  });
+
+  it("allows a validated smart account on Arbitrum", () => {
+    expect(
+      getExpressAccountSupport({
+        chainId: ARBITRUM,
+        isSmartAccount: true,
+        isNonSigningAccountOnAnyChain: false,
+        isLoading: false,
+        hasError: false,
+        hasUnsupportedSigningProvider: false,
+      })
+    ).toEqual({ isExpressAccountSupported: true, unavailableReason: undefined });
+  });
+
+  it("routes a smart account on an unsupported chain to Classic", () => {
+    expect(
+      getExpressAccountSupport({
+        chainId: AVALANCHE,
+        isSmartAccount: true,
+        isNonSigningAccountOnAnyChain: false,
+        isLoading: false,
+        hasError: false,
+        hasUnsupportedSigningProvider: false,
+      })
+    ).toEqual({ isExpressAccountSupported: false, unavailableReason: "unsupportedChain" });
+  });
+
+  it("routes an unsupported contract account to Classic", () => {
+    expect(
+      getExpressAccountSupport({
+        chainId: ARBITRUM,
+        isSmartAccount: true,
+        isNonSigningAccountOnAnyChain: true,
+        isLoading: false,
+        hasError: false,
+        hasUnsupportedSigningProvider: false,
+      })
+    ).toEqual({ isExpressAccountSupported: false, unavailableReason: "unsupportedWallet" });
+  });
+
+  it("fails closed when capability detection fails", () => {
+    expect(
+      getExpressAccountSupport({
+        chainId: ARBITRUM,
+        isSmartAccount: false,
+        isNonSigningAccountOnAnyChain: false,
+        isLoading: false,
+        hasError: true,
+        hasUnsupportedSigningProvider: false,
+      })
+    ).toEqual({ isExpressAccountSupported: false, unavailableReason: "capabilityCheckFailed" });
+  });
+
+  it("fails closed without showing an error while capability detection is loading", () => {
+    expect(
+      getExpressAccountSupport({
+        chainId: ARBITRUM,
+        isSmartAccount: false,
+        isNonSigningAccountOnAnyChain: false,
+        isLoading: true,
+        hasError: false,
+        hasUnsupportedSigningProvider: false,
+      })
+    ).toEqual({ isExpressAccountSupported: false, unavailableReason: undefined });
+  });
+
+  it("preserves provider-specific signing restrictions", () => {
+    expect(
+      getExpressAccountSupport({
+        chainId: ARBITRUM,
+        isSmartAccount: false,
+        isNonSigningAccountOnAnyChain: false,
+        isLoading: false,
+        hasError: false,
+        hasUnsupportedSigningProvider: true,
+      })
+    ).toEqual({ isExpressAccountSupported: false, unavailableReason: "unsupportedWallet" });
+  });
+});

--- a/src/lib/wallets/useAccountType.ts
+++ b/src/lib/wallets/useAccountType.ts
@@ -8,16 +8,27 @@ import {
   ContractFunctionZeroDataError,
   isAddressEqual,
   type Hex,
+  keccak256,
   type PublicClient,
+  stringToHex,
+  toFunctionSelector,
+  toHex,
   zeroHash,
 } from "viem";
 import { useAccount } from "wagmi";
 
-import { ARBITRUM, ARBITRUM_SEPOLIA } from "config/chains";
+import {
+  type AnyChainId,
+  ARBITRUM,
+  ARBITRUM_SEPOLIA,
+  CONTRACTS_CHAIN_IDS,
+  isTestnetChain,
+  SOURCE_CHAIN_IDS,
+} from "config/chains";
 import { useChainId } from "lib/chains";
 import { abis } from "sdk/abis";
 
-import { getConnectedPrivyWallet, getIsKnownSmartWalletClient } from "./privyWagmi";
+import { getConnectedPrivyWallet, getIsSmartWalletClient } from "./privyWagmi";
 import { getPublicClientWithRpc } from "./walletConfig";
 
 export enum AccountType {
@@ -44,6 +55,19 @@ const KNOWN_SAFE_SINGLETONS: Address[] = [
   "0x29fcb43b46531bca003ddc8fcb67ffe91900c762",
 ];
 
+const KNOWN_SAFE_COMPATIBILITY_FALLBACK_HANDLERS: Address[] = [
+  "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4", // v1.3.0 canonical
+  "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804", // v1.3.0 EIP-155
+  "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99", // v1.4.1 canonical
+];
+
+const SAFE_FALLBACK_HANDLER_STORAGE_SLOT = keccak256(stringToHex("fallback_manager.handler.address"));
+const EIP_1967_IMPLEMENTATION_STORAGE_SLOT = toHex(
+  BigInt(keccak256(stringToHex("eip1967.proxy.implementation"))) - 1n,
+  { size: 32 }
+);
+const ERC1271_IS_VALID_SIGNATURE_SELECTOR = toFunctionSelector("isValidSignature(bytes32,bytes)");
+
 async function isSafeAccount(bytecode: Hex, address: Address, client: PublicClient): Promise<boolean> {
   if (bytecode === "0x") {
     return false;
@@ -57,6 +81,44 @@ async function isSafeAccount(bytecode: Hex, address: Address, client: PublicClie
   const masterCopy = `0x${storage.slice(-40)}` as Address;
 
   return KNOWN_SAFE_SINGLETONS.some((singleton) => isAddressEqual(singleton, masterCopy));
+}
+
+async function hasSupportedSafeFallbackHandler(address: Address, client: PublicClient): Promise<boolean> {
+  const storage = await client.getStorageAt({ address, slot: SAFE_FALLBACK_HANDLER_STORAGE_SLOT });
+  if (!storage || storage === "0x") {
+    return false;
+  }
+
+  const fallbackHandler = `0x${storage.slice(-40)}` as Address;
+
+  return KNOWN_SAFE_COMPATIBILITY_FALLBACK_HANDLERS.some((handler) => isAddressEqual(handler, fallbackHandler));
+}
+
+function bytecodeHasErc1271Selector(bytecode: Hex): boolean {
+  return bytecode.includes(`63${ERC1271_IS_VALID_SIGNATURE_SELECTOR.slice(2)}`);
+}
+
+async function hasErc1271Implementation(bytecode: Hex, address: Address, client: PublicClient): Promise<boolean> {
+  if (bytecodeHasErc1271Selector(bytecode)) {
+    return true;
+  }
+
+  if (await isSafeAccount(bytecode, address, client)) {
+    return hasSupportedSafeFallbackHandler(address, client);
+  }
+
+  const implementationStorage = await client.getStorageAt({
+    address,
+    slot: EIP_1967_IMPLEMENTATION_STORAGE_SLOT,
+  });
+  if (!implementationStorage || implementationStorage === "0x") {
+    return false;
+  }
+
+  const implementationAddress = `0x${implementationStorage.slice(-40)}` as Address;
+  const implementationBytecode = await client.getCode({ address: implementationAddress });
+
+  return Boolean(implementationBytecode && bytecodeHasErc1271Selector(implementationBytecode));
 }
 
 function findError<TError extends Error>(
@@ -75,7 +137,7 @@ function findError<TError extends Error>(
   return undefined;
 }
 
-export async function fetchIsErc1271(client: PublicClient, address: Address): Promise<boolean> {
+export async function fetchIsErc1271(client: PublicClient, address: Address, bytecode?: Hex): Promise<boolean> {
   try {
     await client.readContract({
       address,
@@ -89,9 +151,10 @@ export async function fetchIsErc1271(client: PublicClient, address: Address): Pr
       return false;
     }
 
-    const revertedError = findError(error, ContractFunctionRevertedError);
-    if (revertedError) {
-      return true;
+    if (findError(error, ContractFunctionRevertedError)) {
+      const accountBytecode = bytecode ?? (await client.getCode({ address }));
+
+      return Boolean(accountBytecode && (await hasErc1271Implementation(accountBytecode, address, client)));
     }
 
     throw error;
@@ -109,10 +172,10 @@ export async function getAccountType(address: Address, client: PublicClient): Pr
   }
 
   if (await isSafeAccount(bytecode, address, client)) {
-    return AccountType.Safe;
+    return (await hasSupportedSafeFallbackHandler(address, client)) ? AccountType.Safe : AccountType.SmartAccount;
   }
 
-  if (await fetchIsErc1271(client, address)) {
+  if (await fetchIsErc1271(client, address, bytecode)) {
     return AccountType.ERC1271;
   }
 
@@ -131,27 +194,34 @@ export function getAccountCapabilities(accountTypes: AccountType[]): AccountCapa
   };
 }
 
+export function getAccountCapabilityChainIds(currentChainId: number): AnyChainId[] {
+  const isCurrentChainTestnet = isTestnetChain(currentChainId);
+
+  return uniq([...CONTRACTS_CHAIN_IDS, ...SOURCE_CHAIN_IDS] as AnyChainId[]).filter(
+    (chainId) => isTestnetChain(chainId) === isCurrentChainTestnet
+  );
+}
+
 function useAccountCapabilities(): AccountCapabilities & {
   isLoading: boolean;
   hasError: boolean;
   hasUnsupportedSigningProvider: boolean;
 } {
-  const { address, chainId: connectedChainId, connector } = useAccount();
+  const { address, connector } = useAccount();
   const { wallets, ready: areWalletsReady } = useWallets();
-  const { chainId: settlementChainId } = useChainId();
+  const { chainId } = useChainId();
   const connectedWallet = getConnectedPrivyWallet(wallets, address, connector?.id);
   const walletClientType = connectedWallet?.walletClientType;
+  const isCurrentChainTestnet = isTestnetChain(chainId);
 
   const { data, error, isLoading } = useSWR<AccountCapabilities>(
-    address && [address, connectedChainId, walletClientType, settlementChainId, "detectAccountCapabilities"],
+    address && [address, isCurrentChainTestnet, "detectAccountCapabilities"],
     {
       fetcher: async () => {
-        const chainIds = uniq(
-          [settlementChainId, connectedChainId].filter((chainId): chainId is number => chainId !== undefined)
-        );
-
         const accountTypes = await Promise.all(
-          chainIds.map((chainId) => getAccountType(address!, getPublicClientWithRpc(chainId)))
+          getAccountCapabilityChainIds(chainId).map((accountChainId) =>
+            getAccountType(address!, getPublicClientWithRpc(accountChainId))
+          )
         );
 
         return getAccountCapabilities(accountTypes);
@@ -164,7 +234,7 @@ function useAccountCapabilities(): AccountCapabilities & {
   );
 
   return {
-    isSmartAccount: (data?.isSmartAccount ?? false) || getIsKnownSmartWalletClient(walletClientType),
+    isSmartAccount: (data?.isSmartAccount ?? false) || getIsSmartWalletClient(walletClientType),
     isNonSigningAccountOnAnyChain: data?.isNonSigningAccountOnAnyChain ?? false,
     isLoading: isLoading || (address !== undefined && !areWalletsReady),
     hasError: Boolean(error),

--- a/src/lib/wallets/useAccountType.ts
+++ b/src/lib/wallets/useAccountType.ts
@@ -1,44 +1,50 @@
+import { useWallets } from "@privy-io/react-auth";
 import uniq from "lodash/uniq";
 import useSWR from "swr";
-import { ContractFunctionExecutionError, ContractFunctionZeroDataError, Hex, PublicClient, zeroHash } from "viem";
+import {
+  type Address,
+  BaseError,
+  ContractFunctionRevertedError,
+  ContractFunctionZeroDataError,
+  isAddressEqual,
+  type Hex,
+  type PublicClient,
+  zeroHash,
+} from "viem";
 import { useAccount } from "wagmi";
 
-import { AnyChainId, CONTRACTS_CHAIN_IDS, isTestnetChain, SOURCE_CHAIN_IDS } from "config/chains";
+import { ARBITRUM, ARBITRUM_SEPOLIA } from "config/chains";
 import { useChainId } from "lib/chains";
-import { getIsNonSigningAccountError, nonSigningAccountError } from "lib/errors/customErrors";
 import { abis } from "sdk/abis";
 
+import { getConnectedPrivyWallet, getIsKnownSmartWalletClient } from "./privyWagmi";
 import { getPublicClientWithRpc } from "./walletConfig";
 
-enum AccountType {
+export enum AccountType {
   Safe,
-  SmartAccount, // ERC-4337 compatible smart account
-  PostEip7702EOA, // Post-EIP-7702 EOA (delegated EOA)
-  ERC1271, // ERC-1271 compatible smart account
+  SmartAccount,
+  PostEip7702EOA,
+  ERC1271,
   EOA,
 }
 
-/**
- * Keep this in case if Safe API is down or deprecated some addresses
- * we still should be able to detect Safe accounts
- */
-const KNOWN_SAFE_SINGLETONS = new Set(
-  [
-    "0x3e5c63644e683549055b9be8653de26e0b4cd36e", // v1.3.0 L2 default
-    "0xfb1bffc9d739b8d520daf37df666da4c687191ea", // v1.3.0 L2
-    "0xd9db270c1b5e3bd161e8c8503c55ceabee709552", // v1.3.0
-    "0x69f4d1788e39c87893c980c06edf4b7f686e2938", // v1.3.0
-    "0x41675c099f32341bf84bfc5382af534df5c7461a", // v1.4.1
-    "0x29fcb43b46531bca003ddc8fcb67ffe91900c762", // v1.4.1 L2
-  ].map((a) => a.toLowerCase())
-);
+export type ExpressAccountUnavailableReason = "unsupportedWallet" | "unsupportedChain" | "capabilityCheckFailed";
 
-async function isSafeAccount(
-  bytecode: Hex,
-  address: string,
-  client: PublicClient,
-  safeSingletonAddresses: Set<string>
-): Promise<boolean> {
+type AccountCapabilities = {
+  isSmartAccount: boolean;
+  isNonSigningAccountOnAnyChain: boolean;
+};
+
+const KNOWN_SAFE_SINGLETONS: Address[] = [
+  "0x3e5c63644e683549055b9be8653de26e0b4cd36e",
+  "0xfb1bffc9d739b8d520daf37df666da4c687191ea",
+  "0xd9db270c1b5e3bd161e8c8503c55ceabee709552",
+  "0x69f4d1788e39c87893c980c06edf4b7f686e2938",
+  "0x41675c099f32341bf84bfc5382af534df5c7461a",
+  "0x29fcb43b46531bca003ddc8fcb67ffe91900c762",
+];
+
+async function isSafeAccount(bytecode: Hex, address: Address, client: PublicClient): Promise<boolean> {
   if (bytecode === "0x") {
     return false;
   }
@@ -48,104 +54,28 @@ async function isSafeAccount(
     return false;
   }
 
-  const masterCopy = `0x${storage.slice(-40)}`.toLowerCase();
+  const masterCopy = `0x${storage.slice(-40)}` as Address;
 
-  return KNOWN_SAFE_SINGLETONS.has(masterCopy) || safeSingletonAddresses.has(masterCopy);
+  return KNOWN_SAFE_SINGLETONS.some((singleton) => isAddressEqual(singleton, masterCopy));
 }
 
-async function getAccountType(
-  address: string,
-  client: PublicClient,
-  safeSingletonAddresses: Set<string>
-): Promise<AccountType> {
-  const bytecode = await client.getCode({ address });
-  if (!bytecode || bytecode === "0x") {
-    return AccountType.EOA;
+function findError<TError extends Error>(
+  error: unknown,
+  ErrorClass: new (...args: any[]) => TError
+): TError | undefined {
+  if (error instanceof ErrorClass) {
+    return error;
   }
 
-  if (bytecode.startsWith("0xef0100") && bytecode.length === 48) {
-    return AccountType.PostEip7702EOA;
+  if (error instanceof BaseError) {
+    const cause = error.walk((item) => item instanceof ErrorClass);
+    return cause instanceof ErrorClass ? cause : undefined;
   }
 
-  const isErc1271 = await fetchIsErc1271(client, address);
-  if (isErc1271) {
-    return AccountType.ERC1271;
-  }
-
-  if (safeSingletonAddresses.size > 0) {
-    const isSafe = await isSafeAccount(bytecode, address, client, safeSingletonAddresses);
-    if (isSafe) {
-      return AccountType.Safe;
-    }
-  }
-
-  return AccountType.SmartAccount;
+  return undefined;
 }
 
-export function useNonSigningAccount(): {
-  isNonEoaAccountOnAnyChain: boolean;
-  isLoading: boolean;
-} {
-  const { address } = useAccount();
-  const { chainId: currentChainId } = useChainId();
-  const isCurrentChainTestnet = isTestnetChain(currentChainId);
-
-  const { data: isNonEoaAccountOnAnyChain = false, isLoading } = useSWR<boolean | undefined>(
-    address && [address, isCurrentChainTestnet, "detectIsNonEoaAccountOnAnyChain"],
-    {
-      fetcher: async (): Promise<boolean | undefined> => {
-        if (!address) {
-          return undefined;
-        }
-
-        const chainIds = uniq([...CONTRACTS_CHAIN_IDS, ...SOURCE_CHAIN_IDS] as AnyChainId[]).filter(
-          (chainId) => isTestnetChain(chainId) === isCurrentChainTestnet
-        );
-
-        const isNonSigningAccountOnAnyChain = await Promise.all(
-          chainIds.map(async (chainId) => {
-            const publicClient = getPublicClientWithRpc(chainId);
-
-            if (!publicClient) {
-              return undefined;
-            }
-
-            const accountType = await getAccountType(address, publicClient, new Set<string>());
-
-            const canSign =
-              accountType === AccountType.EOA ||
-              accountType === AccountType.PostEip7702EOA ||
-              accountType === AccountType.ERC1271;
-
-            if (!canSign) {
-              return Promise.reject(nonSigningAccountError(chainId));
-            }
-          })
-        )
-          .then(() => {
-            return false;
-          })
-          .catch((error) => {
-            if (getIsNonSigningAccountError(error)) {
-              return true;
-            }
-
-            return false;
-          });
-
-        return isNonSigningAccountOnAnyChain;
-      },
-      refreshInterval: 0,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      revalidateIfStale: false,
-    }
-  );
-
-  return { isNonEoaAccountOnAnyChain, isLoading };
-}
-
-export async function fetchIsErc1271(client: PublicClient, address: string): Promise<boolean> {
+export async function fetchIsErc1271(client: PublicClient, address: Address): Promise<boolean> {
   try {
     await client.readContract({
       address,
@@ -155,14 +85,162 @@ export async function fetchIsErc1271(client: PublicClient, address: string): Pro
     });
     return true;
   } catch (error) {
-    const contractDoesNotImplement = error instanceof ContractFunctionZeroDataError;
-    const isEoa =
-      error instanceof ContractFunctionExecutionError &&
-      error.shortMessage === `The contract function "isValidSignature" returned no data ("0x").`;
-    if (contractDoesNotImplement || isEoa) {
+    if (findError(error, ContractFunctionZeroDataError)) {
       return false;
     }
 
-    return true;
+    const revertedError = findError(error, ContractFunctionRevertedError);
+    if (revertedError) {
+      return true;
+    }
+
+    throw error;
   }
+}
+
+export async function getAccountType(address: Address, client: PublicClient): Promise<AccountType> {
+  const bytecode = await client.getCode({ address });
+  if (!bytecode || bytecode === "0x") {
+    return AccountType.EOA;
+  }
+
+  if (bytecode.startsWith("0xef0100") && bytecode.length === 48) {
+    return AccountType.PostEip7702EOA;
+  }
+
+  if (await isSafeAccount(bytecode, address, client)) {
+    return AccountType.Safe;
+  }
+
+  if (await fetchIsErc1271(client, address)) {
+    return AccountType.ERC1271;
+  }
+
+  return AccountType.SmartAccount;
+}
+
+export function getAccountCapabilities(accountTypes: AccountType[]): AccountCapabilities {
+  return {
+    isSmartAccount: accountTypes.some(
+      (accountType) =>
+        accountType === AccountType.Safe ||
+        accountType === AccountType.SmartAccount ||
+        accountType === AccountType.ERC1271
+    ),
+    isNonSigningAccountOnAnyChain: accountTypes.some((accountType) => accountType === AccountType.SmartAccount),
+  };
+}
+
+function useAccountCapabilities(): AccountCapabilities & {
+  isLoading: boolean;
+  hasError: boolean;
+  hasUnsupportedSigningProvider: boolean;
+} {
+  const { address, chainId: connectedChainId, connector } = useAccount();
+  const { wallets, ready: areWalletsReady } = useWallets();
+  const { chainId: settlementChainId } = useChainId();
+  const connectedWallet = getConnectedPrivyWallet(wallets, address, connector?.id);
+  const walletClientType = connectedWallet?.walletClientType;
+
+  const { data, error, isLoading } = useSWR<AccountCapabilities>(
+    address && [address, connectedChainId, walletClientType, settlementChainId, "detectAccountCapabilities"],
+    {
+      fetcher: async () => {
+        const chainIds = uniq(
+          [settlementChainId, connectedChainId].filter((chainId): chainId is number => chainId !== undefined)
+        );
+
+        const accountTypes = await Promise.all(
+          chainIds.map((chainId) => getAccountType(address!, getPublicClientWithRpc(chainId)))
+        );
+
+        return getAccountCapabilities(accountTypes);
+      },
+      refreshInterval: 0,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateIfStale: false,
+    }
+  );
+
+  return {
+    isSmartAccount: (data?.isSmartAccount ?? false) || getIsKnownSmartWalletClient(walletClientType),
+    isNonSigningAccountOnAnyChain: data?.isNonSigningAccountOnAnyChain ?? false,
+    isLoading: isLoading || (address !== undefined && !areWalletsReady),
+    hasError: Boolean(error),
+    hasUnsupportedSigningProvider: connector?.id === "gemini",
+  };
+}
+
+export function useIsNonEoaAccountOnAnyChain(): {
+  isNonEoaAccountOnAnyChain: boolean;
+  isLoading: boolean;
+} {
+  const { isSmartAccount, isLoading } = useAccountCapabilities();
+
+  return { isNonEoaAccountOnAnyChain: isSmartAccount, isLoading };
+}
+
+export function useNonSigningAccount(): {
+  isNonSigningAccountOnAnyChain: boolean;
+  isLoading: boolean;
+  hasError: boolean;
+} {
+  const { isNonSigningAccountOnAnyChain, isLoading, hasError } = useAccountCapabilities();
+
+  return { isNonSigningAccountOnAnyChain, isLoading, hasError };
+}
+
+export function getExpressAccountSupport({
+  chainId,
+  isSmartAccount,
+  isNonSigningAccountOnAnyChain,
+  isLoading,
+  hasError,
+  hasUnsupportedSigningProvider,
+}: {
+  chainId: number;
+  isSmartAccount: boolean;
+  isNonSigningAccountOnAnyChain: boolean;
+  isLoading: boolean;
+  hasError: boolean;
+  hasUnsupportedSigningProvider: boolean;
+}): {
+  isExpressAccountSupported: boolean;
+  unavailableReason: ExpressAccountUnavailableReason | undefined;
+} {
+  if (isLoading) {
+    return { isExpressAccountSupported: false, unavailableReason: undefined };
+  }
+
+  if (hasError) {
+    return { isExpressAccountSupported: false, unavailableReason: "capabilityCheckFailed" };
+  }
+
+  if (isNonSigningAccountOnAnyChain || hasUnsupportedSigningProvider) {
+    return { isExpressAccountSupported: false, unavailableReason: "unsupportedWallet" };
+  }
+
+  if (isSmartAccount && chainId !== ARBITRUM && chainId !== ARBITRUM_SEPOLIA) {
+    return { isExpressAccountSupported: false, unavailableReason: "unsupportedChain" };
+  }
+
+  return { isExpressAccountSupported: true, unavailableReason: undefined };
+}
+
+export function useExpressAccountSupport(): {
+  isSmartAccount: boolean;
+  isExpressAccountSupported: boolean;
+  unavailableReason: ExpressAccountUnavailableReason | undefined;
+  isLoading: boolean;
+} {
+  const { chainId } = useChainId();
+  const capabilities = useAccountCapabilities();
+  const support = getExpressAccountSupport({ chainId, ...capabilities });
+
+  return {
+    isSmartAccount: capabilities.isSmartAccount,
+    isLoading: capabilities.isLoading,
+    ...support,
+  };
 }

--- a/src/lib/wallets/useEthersSigner.ts
+++ b/src/lib/wallets/useEthersSigner.ts
@@ -7,7 +7,7 @@ import { Config, useAccount, useConnectorClient } from "wagmi";
 import { UncheckedJsonRpcSigner } from "lib/rpc/UncheckedJsonRpcSigner";
 
 import { WalletSigner } from ".";
-import { getConnectedPrivyWallet, getIsKnownSmartWalletClient } from "./privyWagmi";
+import { getConnectedPrivyWallet, getIsSmartWalletClient } from "./privyWagmi";
 
 export function clientToSigner(
   client: Client<Transport, Chain, Account>,
@@ -38,7 +38,7 @@ export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
   const { wallets } = useWallets();
   const { data: client } = useConnectorClient<Config>({ chainId });
   const connectedWallet = getConnectedPrivyWallet(wallets, address, connector?.id);
-  const isSmartAccount = getIsKnownSmartWalletClient(connectedWallet?.walletClientType);
+  const isSmartAccount = getIsSmartWalletClient(connectedWallet?.walletClientType);
 
   return useMemo(() => {
     if (!address || !client?.account) {

--- a/src/lib/wallets/useEthersSigner.ts
+++ b/src/lib/wallets/useEthersSigner.ts
@@ -1,3 +1,4 @@
+import { useWallets } from "@privy-io/react-auth";
 import { ethers } from "ethers";
 import { useMemo } from "react";
 import type { Account, Chain, Client, Transport } from "viem";
@@ -6,8 +7,13 @@ import { Config, useAccount, useConnectorClient } from "wagmi";
 import { UncheckedJsonRpcSigner } from "lib/rpc/UncheckedJsonRpcSigner";
 
 import { WalletSigner } from ".";
+import { getConnectedPrivyWallet, getIsKnownSmartWalletClient } from "./privyWagmi";
 
-export function clientToSigner(client: Client<Transport, Chain, Account>, account: string): WalletSigner {
+export function clientToSigner(
+  client: Client<Transport, Chain, Account>,
+  account: string,
+  isSmartAccount?: boolean
+): WalletSigner {
   const { chain, transport } = client;
   const network = {
     chainId: chain.id,
@@ -16,19 +22,23 @@ export function clientToSigner(client: Client<Transport, Chain, Account>, accoun
   };
 
   const provider = new ethers.BrowserProvider(transport, network);
-  const signer = new UncheckedJsonRpcSigner(provider, account);
+  const signer = new UncheckedJsonRpcSigner(provider, account) as WalletSigner;
 
   if (!signer.address) {
     signer.address = account;
   }
+  signer.isSmartAccount = isSmartAccount;
 
-  return signer as WalletSigner;
+  return signer;
 }
 
 /** Hook to convert a Viem Client to an ethers.js Signer. */
 export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
-  const { address } = useAccount();
+  const { address, connector } = useAccount();
+  const { wallets } = useWallets();
   const { data: client } = useConnectorClient<Config>({ chainId });
+  const connectedWallet = getConnectedPrivyWallet(wallets, address, connector?.id);
+  const isSmartAccount = getIsKnownSmartWalletClient(connectedWallet?.walletClientType);
 
   return useMemo(() => {
     if (!address || !client?.account) {
@@ -36,9 +46,9 @@ export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
     }
 
     try {
-      return clientToSigner(client, address);
+      return clientToSigner(client, address, isSmartAccount);
     } catch (error) {
       return undefined;
     }
-  }, [client, address]);
+  }, [client, address, isSmartAccount]);
 }

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "Aktion(en)"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Unzureichendes Gas-Guthaben. Zahlen Sie mehr {gasPaymentTokensText} ein."
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "für {comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "Unterstützung für Wallet-Signaturen wird überprüft..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "Eingesetztes Kapital = max(Summe der Sicherheiten offener Positionen - realisierter PnL + anfänglicher ausstehender PnL)."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3049,6 +3049,10 @@ msgstr "LP Belohnungen insgesamt"
 msgid "Invalid decrease size"
 msgstr "Ungültige Verringerungsgröße"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "Dieses Wallet kann Express- oder One-Click-Orders nicht signieren. Verwende stattdessen den klassischen Handel."
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Abonnieren"
@@ -4349,12 +4353,6 @@ msgstr "Empfehlungscode eingeben"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "Smart Wallets werden bei Express Trading oder One-Click Trading nicht unterstützt"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "Permit-Genehmigungen sind für diesen Token deaktiviert."
 msgid "LAST PRICE"
 msgstr "LETZTER PREIS"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "Dieses Smart Wallet kann Express oder One-Click in diesem Netzwerk nicht verwenden. Wechsle zu Arbitrum oder verwende den klassischen Handel."
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "{orderText} wird storniert…"
@@ -11352,6 +11354,10 @@ msgstr "Link kopieren"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "Empfehlungscode erstellt"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "Die Wallet-Signaturunterstützung konnte nicht überprüft werden. Verwende den klassischen Handel und versuche es später erneut."
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -8517,6 +8517,10 @@ msgstr "You must be on this page to accept the transfer. <0>Copy link</0>."
 msgid "for {comment}"
 msgstr "for {comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "Checking wallet signing support..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3049,6 +3049,10 @@ msgstr "Lifetime LP rewards"
 msgid "Invalid decrease size"
 msgstr "Invalid decrease size"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Subscribe"
@@ -4349,12 +4353,6 @@ msgstr "Enter referral code"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr "Referral link copied to clipboard"
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "Smart wallets are not supported on Express Trading or One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "Permit approvals are disabled for this token."
 msgid "LAST PRICE"
 msgstr "LAST PRICE"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "Cancelling {orderText}..."
@@ -11352,6 +11354,10 @@ msgstr "Copy link"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "Referral code created"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "Wallet signing support could not be verified. Use Classic Trading and try again later."
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "Action(s)"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3049,6 +3049,10 @@ msgstr "Recompensas LP acumuladas"
 msgid "Invalid decrease size"
 msgstr "Tamaño de reducción no válido"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "Esta billetera no puede firmar órdenes Express ni One-Click. Usa el trading clásico en su lugar."
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Suscribirse"
@@ -4349,12 +4353,6 @@ msgstr "Ingresa código de referencia"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "Los monederos inteligentes no son compatibles con Express Trading ni con One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "Las aprobaciones con permiso están desactivadas para este token."
 msgid "LAST PRICE"
 msgstr "ÚLTIMO PRECIO"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "Esta billetera inteligente no puede usar Express ni One-Click en esta red. Cambia a Arbitrum o usa el trading clásico."
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "Cancelando {orderText}…"
@@ -11352,6 +11354,10 @@ msgstr "Copiar enlace"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "Código de referido creado"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "No se pudo verificar la compatibilidad de firma de la billetera. Usa el trading clásico e inténtalo de nuevo más tarde."
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "Acción(es)"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Saldo de Gas insuficiente. Deposite más {gasPaymentTokensText}."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "para {comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "Comprobando la compatibilidad con la firma de la billetera..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "Capital usado = max(suma de colateral de posiciones abiertas - PnL realizado + PnL pendiente inicial)."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3049,6 +3049,10 @@ msgstr "Récompenses LP cumulées"
 msgid "Invalid decrease size"
 msgstr "Taille de réduction invalide"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "Ce portefeuille ne peut pas signer les ordres Express ou One-Click. Utilisez plutôt le trading classique."
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "S'abonner"
@@ -4349,12 +4353,6 @@ msgstr "Entrez le code de parrainage"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "Les portefeuilles intelligents ne sont pas pris en charge avec Express Trading ou One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "Les approbations par permis sont désactivées pour ce token."
 msgid "LAST PRICE"
 msgstr "DERNIER PRIX"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "Ce portefeuille intelligent ne peut pas utiliser Express ou One-Click sur ce réseau. Passez à Arbitrum ou utilisez le trading classique."
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "Annulation de {orderText}…"
@@ -11352,6 +11354,10 @@ msgstr "Copier le lien"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "Code de parrainage créé"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "La prise en charge de la signature du portefeuille n’a pas pu être vérifiée. Utilisez le trading classique et réessayez plus tard."
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "pour {comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "Vérification de la prise en charge de la signature du portefeuille..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "Capital utilisé = max(somme du collatéral des positions ouvertes - PnL réalisé + PnL en attente initial)."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "Action(s)"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Solde de Gas insuffisant. Déposez davantage de {gasPaymentTokensText}."
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3049,6 +3049,10 @@ msgstr "累計LP報酬"
 msgid "Invalid decrease size"
 msgstr "無効な減少サイズ"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "このウォレットではExpressまたはOne-Click注文に署名できません。代わりにクラシック取引を使用してください。"
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "購読"
@@ -4349,12 +4353,6 @@ msgstr "リファラルコードを入力"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "スマートウォレットは Express Trading および One-Click Trading に対応していません"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "このトークンではパーミット承認が無効になっていま
 msgid "LAST PRICE"
 msgstr "最終価格"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "このスマートウォレットでは、このネットワーク上でExpressまたはOne-Clickを使用できません。Arbitrumに切り替えるか、クラシック取引を使用してください。"
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "{orderText}をキャンセル中…"
@@ -11352,6 +11354,10 @@ msgstr "リンクをコピー"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "リファラルコードが作成されました"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "ウォレットの署名対応を確認できませんでした。クラシック取引を使用し、後でもう一度お試しください。"
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "{comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "ウォレットの署名対応を確認しています..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "使用資本 = max(オープンポジションの担保合計 - 実現PnL + 開始時の保留PnL)。"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "アクション"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Gas 残高が不足しています。{gasPaymentTokensText} を追加で入金してください。"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "작업"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Gas 잔액이 부족합니다. {gasPaymentTokensText}을(를) 추가로 입금하십시오."
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "{comment}에 대해"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "지갑 서명 지원 여부를 확인하는 중..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "사용 자본 = max(열린 포지션 담보 합계 - 실현 PnL + 시작 보류 PnL)."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3049,6 +3049,10 @@ msgstr "누적 LP 보상"
 msgid "Invalid decrease size"
 msgstr "유효하지 않은 감소 규모"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "이 지갑은 Express 또는 One-Click 주문에 서명할 수 없습니다. 대신 클래식 트레이딩을 사용하세요."
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "구독"
@@ -4349,12 +4353,6 @@ msgstr "추천 코드 입력"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "스마트 지갑은 Express Trading 또는 One-Click Trading에서 지원되지 않습니다"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "이 토큰의 퍼밋 승인은 비활성화되어 있습니다."
 msgid "LAST PRICE"
 msgstr "최종 가격"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "이 스마트 지갑은 이 네트워크에서 Express 또는 One-Click을 사용할 수 없습니다. Arbitrum으로 전환하거나 클래식 트레이딩을 사용하세요."
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "{orderText} 취소 중…"
@@ -11352,6 +11354,10 @@ msgstr "링크 복사"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "추천 코드가 생성되었습니다"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "지갑의 서명 지원 여부를 확인할 수 없습니다. 클래식 트레이딩을 사용하고 나중에 다시 시도하세요."
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr ""
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "Çĥéçķĩñĝ ŵåļļéţ šĩĝñĩñĝ šûþþöŕţ..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "[!! Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL). !!]"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr ""
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr ""
 

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -3049,6 +3049,10 @@ msgstr ""
 msgid "Invalid decrease size"
 msgstr ""
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "Ţĥĩš ŵåļļéţ çåññöţ šĩĝñ Éхþŕéšš öŕ Öñé-Çļĩçķ öŕðéŕš. Ůšé Çļåššĩç Ţŕåðĩñĝ ĩñšţéåð."
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr ""
@@ -4348,12 +4352,6 @@ msgstr ""
 #: src/components/Referrals/shared/cards/ShareReferralCardModal.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
-msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr ""
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
@@ -10730,6 +10728,10 @@ msgstr ""
 msgid "LAST PRICE"
 msgstr ""
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "Ţĥĩš šmåŕţ ŵåļļéţ çåññöţ ůšé Éхþŕéšš öŕ Öñé-Çļĩçķ öñ ţĥĩš ñéţŵöŕķ. Šŵĩţçĥ ţö Åŕбĩţŕům öŕ ůšé Çļåššĩç Ţŕåðĩñĝ."
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr ""
@@ -11352,6 +11354,10 @@ msgstr ""
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr ""
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "Ŵåļļéţ šĩĝñĩñĝ šůþþöŕţ çöůļð ñöţ бé véŕĩƒĩéð. Ůšé Çļåššĩç Ţŕåðĩñĝ åñð ţŕý åĝåĩñ ļåţéŕ."
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "для {comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "Проверка поддержки подписей кошельком..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "Использованный капитал = max(сумма залога открытых позиций - реализованный PnL + начальный ожидающий PnL)."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "Действие(я)"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Недостаточный баланс Gas. Внесите больше {gasPaymentTokensText}."
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -3049,6 +3049,10 @@ msgstr "Совокупные вознаграждения LP"
 msgid "Invalid decrease size"
 msgstr "Недопустимый размер уменьшения"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "Этот кошелёк не может подписывать ордера Express или One-Click. Используйте классический режим торговли."
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Подписаться"
@@ -4349,12 +4353,6 @@ msgstr "Введите реферальный код"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "Смарт-кошельки не поддерживаются в Express Trading и One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "Одобрения через permit отключены для этог�
 msgid "LAST PRICE"
 msgstr "ПОСЛЕДНЯЯ ЦЕНА"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "Этот смарт-кошелёк не может использовать Express или One-Click в этой сети. Переключитесь на Arbitrum или используйте классический режим торговли."
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "Отмена {orderText}…"
@@ -11352,6 +11354,10 @@ msgstr "Скопировать ссылку"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "Реферальный код создан"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "Не удалось проверить поддержку подписей кошельком. Используйте классический режим торговли и повторите попытку позже."
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "操作"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Gas 餘額不足。請存入更多 {gasPaymentTokensText}。"
 

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "用於 {comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "正在檢查錢包簽名支援..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "已用資本 = max(未平倉倉位抵押品總和 - 已實現 PnL + 初始待處理 PnL)。"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -3049,6 +3049,10 @@ msgstr "累計 LP 獎勵"
 msgid "Invalid decrease size"
 msgstr "無效的減少規模"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "此錢包無法簽署 Express 或 One-Click 訂單。請改用 Classic 交易。"
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "訂閱"
@@ -4349,12 +4353,6 @@ msgstr "輸入推薦碼"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "智能錢包不支援 Express Trading 或 One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "此代幣已停用 Permit 授權。"
 msgid "LAST PRICE"
 msgstr "最新價格"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "此智慧錢包無法在此網路上使用 Express 或 One-Click。請切換到 Arbitrum 或使用 Classic 交易。"
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "正在取消 {orderText}..."
@@ -11352,6 +11354,10 @@ msgstr "複製連結"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "推薦碼已建立"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "無法驗證錢包簽名支援。請使用 Classic 交易並稍後再試。"
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3049,6 +3049,10 @@ msgstr "累计 LP 奖励"
 msgid "Invalid decrease size"
 msgstr "无效的减仓规模"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This wallet cannot sign Express or One-Click orders. Use Classic Trading instead."
+msgstr "此钱包无法签署 Express 或 One-Click 订单。请改用经典交易。"
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "订阅"
@@ -4349,12 +4353,6 @@ msgstr "输入推荐码"
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Referral link copied to clipboard"
 msgstr ""
-
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/SettingsModal/TradingSettings.tsx
-#: src/components/TradeBox/TradeBox.tsx
-msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
-msgstr "智能钱包不支持 Express Trading 或 One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Executed"
@@ -10730,6 +10728,10 @@ msgstr "此代币已禁用 Permit 授权。"
 msgid "LAST PRICE"
 msgstr "最新价格"
 
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "This smart wallet cannot use Express or One-Click on this network. Switch to Arbitrum or use Classic Trading."
+msgstr "此智能钱包无法在此网络上使用 Express 或 One-Click。请切换到 Arbitrum 或使用经典交易。"
+
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "Cancelling {orderText}..."
 msgstr "正在取消 {orderText}…"
@@ -11352,6 +11354,10 @@ msgstr "复制链接"
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Referral code created"
 msgstr "推荐码已创建"
+
+#: src/domain/synthetics/express/getExpressAccountUnavailableMessage.ts
+msgid "Wallet signing support could not be verified. Use Classic Trading and try again later."
+msgstr "无法验证钱包签名支持。请使用经典交易并稍后重试。"
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1669,6 +1669,7 @@ msgid "Action(s)"
 msgstr "操作"
 
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
+#: src/components/SettingsModal/TradingSettings.tsx
 msgid "Insufficient gas balance. Deposit more {gasPaymentTokensText}."
 msgstr "Gas 余额不足。请存入更多 {gasPaymentTokensText}。"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -8517,6 +8517,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr "用于 {comment}"
 
+#: src/components/SettingsModal/TradingSettings.tsx
+msgid "Checking wallet signing support..."
+msgstr "正在检查钱包签名支持..."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Capital used = max(sum of collateral of open positions - realized PnL + starting pending PnL)."
 msgstr "已用资本 = max(未平仓仓位抵押品总和 - 已实现盈亏 + 初始待处理盈亏)。"

--- a/src/pages/SyntheticsPage/SyntheticsPage.tsx
+++ b/src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -711,6 +711,7 @@ function useOrdersControl() {
         chainId,
         signer,
         expressParams,
+        requireExpress: true,
         batchParams,
         simulationParams: undefined,
         provider,
@@ -779,6 +780,7 @@ function useOrdersControl() {
         signer,
         provider,
         expressParams,
+        requireExpress: true,
         batchParams,
         simulationParams: undefined,
         callback: makeOrderTxnCallback({


### PR DESCRIPTION
## Summary

- Enable supported Safe, ERC-1271, Coinbase Smart Wallet, and Base Account users to use Express and One-Click on Arbitrum while routing unsupported wallets and networks to Classic Trading.
- Sign smart-wallet payloads on the verification chain, restore the original network, use standard approvals instead of permits, and preserve Express preferences across temporary capability errors.
- Linear: https://linear.app/gmx-io/issue/FEDEV-3682/phase-5-unblock-smart-wallet-users-for-express-and-one-click

