### PR TITLE
Fix PostCSS audit vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "happy-dom": "20.8.9",
     "husky": "7.0.4",
     "lint-staged": "12.3.4",
-    "postcss": "8.5.12",
+    "postcss": "8.5.23",
     "prettier": "3.2.5",
     "prettier-plugin-tailwindcss": "0.6.5",
     "rollup-plugin-visualizer": "5.12.0",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -18,7 +18,7 @@ const sdk = new GmxSdk({
   rpcUrl: "https://arb1.arbitrum.io/rpc",
   oracleUrl: "https://arbitrum-api.gmxinfra.io",
   walletClient: useWallet().walletClient,
-  subsquidUrl: "https://gmx-test.squids.live/gmx-synthetics-arbitrum@6230c4/api/graphql",
+  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@9c4ad1/api/graphql",
 });
 
 const { marketsInfoData, tokensData } = await sdk.markets.getMarketsInfo();

--- a/sdk/scripts/subsquid-codegen.ts
+++ b/sdk/scripts/subsquid-codegen.ts
@@ -1,7 +1,7 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum@6230c4/api/graphql",
+  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum@9c4ad1/api/graphql",
   overwrite: true,
   debug: true,
   generates: {

--- a/sdk/src/clients/v1/testUtil.ts
+++ b/sdk/src/clients/v1/testUtil.ts
@@ -19,7 +19,7 @@ export const arbitrumSdkConfig: GmxSdkConfig = {
   oracleUrl: "https://arbitrum-api.gmxinfra.io",
   rpcUrl: "https://arb1.arbitrum.io/rpc",
   walletClient: client,
-  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@6230c4/api/graphql",
+  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@9c4ad1/api/graphql",
 };
 
 export const arbitrumSdk = new GmxSdk(arbitrumSdkConfig);

--- a/sdk/yarn.lock
+++ b/sdk/yarn.lock
@@ -4468,12 +4468,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
+  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
   languageName: node
   linkType: hard
 
@@ -4862,13 +4862,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.5.6":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/9e4fbe97574091e9736d0e82a591e29aa100a0bf60276a926308f8c57249698935f35c5d2f4e80de778d0cbb8dcffab4f383d85fd50c5649aca421c3df729b86
+  checksum: 10/8387f421216696bf62a13e5a270e9fefdafc81e196903c0f8d7653f8bab315367cc2261b3c22cf197e492cb075f31bdfc07fd9c3be1cb165ff3cabe14c5a039a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13077,7 +13077,7 @@ __metadata:
     immer: "npm:10.1.1"
     lint-staged: "npm:12.3.4"
     lodash: "npm:4.18.1"
-    postcss: "npm:8.5.12"
+    postcss: "npm:8.5.23"
     prettier: "npm:3.2.5"
     prettier-plugin-tailwindcss: "npm:0.6.5"
     qrcode.react: "npm:3.1.0"
@@ -15213,12 +15213,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
+  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
   languageName: node
   linkType: hard
 
@@ -16349,14 +16349,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.12, postcss@npm:^8.4.23, postcss@npm:^8.5.3":
-  version: 8.5.12
-  resolution: "postcss@npm:8.5.12"
+"postcss@npm:8.5.23, postcss@npm:^8.4.23, postcss@npm:^8.5.3":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/ec6b79b68c363eca3c8ffceb134a4ab637274aee6ac0857614bf7c18d40ce4ce5f9036edec57b7e0be99895724d2599d0ec7328dbd7f407204e7548697b322f1
+  checksum: 10/8387f421216696bf62a13e5a270e9fefdafc81e196903c0f8d7653f8bab315367cc2261b3c22cf197e492cb075f31bdfc07fd9c3be1cb165ff3cabe14c5a039a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade PostCSS from 8.5.12 to 8.5.23 to address GHSA-r28c-9q8g-f849
- refresh the root and SDK lockfiles so every PostCSS resolution uses the patched release
- replace the retired Arbitrum Subsquid deployment in SDK tests, codegen, and quickstart documentation

## Testing

- root and SDK audit workflow commands
- immutable installs for the root and SDK dependency graphs
- app and SDK lint and type checks
- app unit tests (972 passed), SDK unit tests (495 passed), and component tests (159 passed)
- production app and landing builds
- SDK multicall suite (14 passed, 1 skipped)
- Subsquid schema code generation
