### PR TITLE
Fix positions list flashing to loading on api health flips

### DIFF
--- a/src/domain/synthetics/common/useApiDataRequest.spec.tsx
+++ b/src/domain/synthetics/common/useApiDataRequest.spec.tsx
@@ -11,26 +11,35 @@ type ApiDataRequestResult = ReturnType<typeof useApiDataRequest<{ ok: boolean }>
 
 const swrKey = ["apiDataRequestTest"];
 
+type TestComponentProps = {
+  enabled?: boolean;
+  requestKey?: unknown[];
+};
+
 function renderApiDataRequest(fetcher: () => Promise<{ ok: boolean }>, cache = new Map()) {
   let latestState: ApiDataRequestResult | undefined;
 
-  function TestComponent() {
-    latestState = useApiDataRequest(42161, swrKey, fetcher, FreshnessMetricId.ApiMarketsInfo, {
+  function TestComponent({ enabled, requestKey }: TestComponentProps) {
+    latestState = useApiDataRequest(42161, requestKey ?? swrKey, fetcher, FreshnessMetricId.ApiMarketsInfo, {
       refreshInterval: 1000,
       apiStaleMs: 500,
+      enabled,
     });
     return null;
   }
 
-  render(
-    // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-    <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>
-      <TestComponent />
+  const swrConfig = { provider: () => cache, dedupingInterval: 0 };
+  const renderElement = (props: TestComponentProps = {}) => (
+    <SWRConfig value={swrConfig}>
+      <TestComponent {...props} />
     </SWRConfig>
   );
 
+  const result = render(renderElement());
+
   return {
     getState: () => latestState!,
+    rerenderWith: (props: TestComponentProps) => result.rerender(renderElement(props)),
   };
 }
 
@@ -74,6 +83,32 @@ describe("useApiDataRequest", () => {
     });
 
     expect(rendered.getState().isStale).toBe(true);
+  });
+
+  it("retains the last response while the request is disabled and drops it when the key changes", async () => {
+    const fetcher = vi.fn(() => Promise.resolve({ ok: true }));
+    const rendered = renderApiDataRequest(fetcher);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(rendered.getState().data).toEqual({ ok: true });
+
+    rendered.rerenderWith({ enabled: false });
+
+    expect(rendered.getState().data).toEqual({ ok: true });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(rendered.getState().data).toEqual({ ok: true });
+    expect(rendered.getState().isStale).toBe(true);
+
+    rendered.rerenderWith({ enabled: false, requestKey: ["apiDataRequestTest", "other-account"] });
+
+    expect(rendered.getState().data).toBeUndefined();
   });
 
   it("marks cached stale data as stale on the first render", () => {

--- a/src/domain/synthetics/common/useApiDataRequest.ts
+++ b/src/domain/synthetics/common/useApiDataRequest.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useRef } from "react";
-import useSWR from "swr";
+import useSWR, { unstable_serialize } from "swr";
 import type { Key } from "swr";
 
 import { FreshnessMetricId } from "lib/metrics";
@@ -20,6 +20,7 @@ type ApiDataResponse<T> = {
 type UseApiDataRequestOptions = {
   refreshInterval?: number;
   apiStaleMs?: number;
+  enabled?: boolean;
 };
 
 export function useApiDataRequest<T>(
@@ -31,17 +32,29 @@ export function useApiDataRequest<T>(
 ) {
   const refreshInterval = options?.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
   const apiStaleMs = options?.apiStaleMs ?? DEFAULT_API_STALE_MS;
+  const enabled = options?.enabled ?? true;
 
   const mountedAtRef = useRef<number | undefined>(mountedAtCache.get(chainId));
 
   const { data: response, error } = useSWR<ApiDataResponse<T>>(
-    swrKey,
+    enabled ? swrKey : null,
     async () => {
       const data = await fetcher();
       return { data, updatedAt: Date.now() };
     },
     { refreshInterval }
   );
+
+  // Keep the last response while the request is disabled (e.g. api-health flips) so consumers can
+  // keep rendering it instead of flashing a loading state; dropped when the logical key changes.
+  const serializedKey = swrKey ? unstable_serialize(swrKey) : undefined;
+  const retainedRef = useRef<{ key: string; response: ApiDataResponse<T> } | undefined>(undefined);
+  if (response && serializedKey) {
+    retainedRef.current = { key: serializedKey, response };
+  }
+  const effectiveResponse =
+    response ??
+    (serializedKey && retainedRef.current?.key === serializedKey ? retainedRef.current.response : undefined);
 
   useEffect(() => {
     if (!mountedAtRef.current) {
@@ -54,7 +67,7 @@ export function useApiDataRequest<T>(
   const [, forceStaleCheck] = useReducer((tick: number) => tick + 1, 0);
 
   useEffect(() => {
-    if (!response?.updatedAt) {
+    if (!effectiveResponse?.updatedAt) {
       return;
     }
 
@@ -62,7 +75,7 @@ export function useApiDataRequest<T>(
       forceStaleCheck();
     }, refreshInterval);
     return () => clearInterval(intervalId);
-  }, [response?.updatedAt, refreshInterval, apiStaleMs]);
+  }, [effectiveResponse?.updatedAt, refreshInterval, apiStaleMs]);
 
   useEffect(() => {
     if (response?.data) {
@@ -70,14 +83,14 @@ export function useApiDataRequest<T>(
     }
   }, [chainId, freshnessMetricId, response?.data]);
 
-  const isCurrentResponseStale = response?.updatedAt
-    ? Date.now() - response.updatedAt > refreshInterval + apiStaleMs
+  const isCurrentResponseStale = effectiveResponse?.updatedAt
+    ? Date.now() - effectiveResponse.updatedAt > refreshInterval + apiStaleMs
     : false;
 
   return {
-    data: response?.data,
+    data: effectiveResponse?.data,
     mountedAt: mountedAtRef.current,
-    updatedAt: response?.updatedAt,
+    updatedAt: effectiveResponse?.updatedAt,
     isStale: isCurrentResponseStale,
     error,
   };

--- a/src/domain/synthetics/positions/useApiPositionsInfoRequest.ts
+++ b/src/domain/synthetics/positions/useApiPositionsInfoRequest.ts
@@ -18,7 +18,7 @@ export function useApiPositionsInfoRequest(
 
   const { data: positionsInfoData, ...rest } = useApiDataRequest<ApiPositionsInfoData>(
     chainId,
-    enabled && account && sdk ? ["apiPositionsInfoRequest", chainId, account] : null,
+    account && sdk ? ["apiPositionsInfoRequest", chainId, account] : null,
     async () => {
       const positions: ApiPositionInfo[] = await sdk!.fetchPositionsInfo({
         address: account!,
@@ -26,7 +26,8 @@ export function useApiPositionsInfoRequest(
       });
       return keyBy(positions, "key");
     },
-    FreshnessMetricId.ApiPositionsInfo
+    FreshnessMetricId.ApiPositionsInfo,
+    { enabled }
   );
 
   return {

--- a/src/domain/synthetics/positions/usePositionsInfo.ts
+++ b/src/domain/synthetics/positions/usePositionsInfo.ts
@@ -19,6 +19,10 @@ import { getAllPossiblePositionsKeys, useOptimisticPositionsInfo } from "./useOp
 import { usePositions } from "./usePositions";
 import { usePositionsConstantsRequest } from "./usePositionsConstants";
 
+// Wait this long for API positions before warming the RPC backup. The API is usually fast and a
+// cold RPC detour is slower than waiting, so we give API a grace window before paying RPC load.
+const RPC_WARMUP_DELAY_MS = 5_000;
+
 function composeApiPositionInfo(apiPosition: ApiPositionInfo, marketsInfoData: MarketsInfoData): PositionInfo | null {
   const marketInfo = getByKey(marketsInfoData, apiPosition.marketAddress);
 
@@ -80,6 +84,7 @@ export function usePositionsInfoRequest(
     apiError,
     isEnabled: Boolean(account),
     resetKey: account,
+    initialFallbackTimeout: RPC_WARMUP_DELAY_MS,
   });
 
   const { positionsData, error: positionsError } = usePositions(chainId, {
@@ -211,8 +216,12 @@ export function usePositionsInfoRequest(
   ]);
 
   const fallbackPositionsInfoData = rpcPositionsInfoData;
+  // Prefer API data that exists (including data retained across api-health flips) and hand over to
+  // RPC only once the fallback actually has data — a rendered list must never fall back to loading.
   const shouldUseApiPositionsInfoData =
-    isApiSdkEnabled && Boolean(recomputedApiPositionsInfoData) && (!shouldFallbackToRpc || !fallbackPositionsInfoData);
+    Boolean(apiPositionsInfoData) &&
+    Boolean(recomputedApiPositionsInfoData) &&
+    (!shouldFallbackToRpc || !fallbackPositionsInfoData);
 
   const positionsInfoData = useMemo(() => {
     if (shouldUseApiPositionsInfoData) {


### PR DESCRIPTION
## Problem

Two related issues after the API positions rollout (#2535 / #2571):

1. User-reported: the positions list renders, then disappears into a loading state for a few seconds. Reproducible by returning to a tab after ~15s+ in background (seen on `/#/accounts/...`, affects the trade page too).
2. `positionsListLoad` tail regression: within the api cohort, loads that fall back to RPC are p90 ~26s vs ~6.8s for api-served loads (Arbitrum, Jun 13-17), plus a high 10s-timeout share.

## Root cause

1. **Flash:** while a tab is hidden SWR pauses polling, so markets `updatedAt` ages; on refocus the first render reports markets stale, `ApiHealthTracker` flips unhealthy (15s restore cooldown), `isApiSdkEnabled` goes false, the api positions SWR key becomes `null` and the rendered data is dropped instantly — while the RPC request starts cold (`enabled: shouldFallbackToRpc`). The restore edge can flash again (RPC key cleared before fresh api data arrives).
2. **Tail:** when the api misses the 3s initial-fallback window, the user pays the 3s wait plus a cold RPC round-trip serially.

## Change

- `useApiDataRequest`: new `enabled` option; while disabled, the last response is retained (keyed to the request key, ages into stale as usual) instead of being dropped together with the SWR key.
- `useApiPositionsInfoRequest`: passes `enabled` via the option so retention knows the logical key.
- `usePositionsInfo`: the display rule now prefers whichever source actually has data — api first (including data retained across health flips), RPC only once its data has arrived. A rendered list never falls back to a loading state; source switches hand over seamlessly on both health edges. Gated on actual api data presence (not the flag) so flag-off users still get a proper loading state instead of an empty list.
- Initial RPC fallback warm-up staged at 5s (was 3s): the api answers in ~150ms server-side, so a cold RPC detour on a slow-but-alive load is usually a net loss; RPC still warms up in background and takes over if the api has not answered. The 10s metric cap is unchanged.

## Verification

- `yarn tscheck` clean
- `yarn test:ci`: 79 files, 724/724 passed
- new spec: `useApiDataRequest` retains the last response while disabled, marks it stale by age, and drops it when the key changes

Not verified live: the health-flip flash needs an api-flag session with forced markets staleness. Suggest a canary and watching the `positionsListLoad` p90 / timeout split by `apiSdkPositions` after deploy.

Follow-up (separate issue): `hasStaleMarketValues` compares server `updatedAt` to client `Date.now()` — a client clock >10s ahead makes the api permanently unhealthy for that user.
