### PR TITLE
Fix api health tracker false positives: clock skew and tab-refocus flaps

### DIFF
--- a/src/domain/api/apiHealthTracker.spec.ts
+++ b/src/domain/api/apiHealthTracker.spec.ts
@@ -4,9 +4,18 @@ import type { ContractsChainId } from "sdk/configs/chains";
 
 import { ApiHealthTracker } from "./apiHealthTracker";
 
+const CONFIRMATION_MS = 3_000;
 const COOLDOWN_MS = 15_000;
 
 const tracker = ApiHealthTracker.getInstance();
+
+// Reports stale at startAt and again once the confirmation window has elapsed.
+function makeUnhealthy(chainId: ContractsChainId, startAt = 0) {
+  vi.setSystemTime(startAt);
+  tracker.reportMarketsFreshness(chainId, true);
+  vi.setSystemTime(startAt + CONFIRMATION_MS);
+  tracker.reportMarketsFreshness(chainId, true);
+}
 
 // Each test uses a distinct chainId so the shared singleton's per-chain state stays isolated.
 describe("ApiHealthTracker", () => {
@@ -27,31 +36,64 @@ describe("ApiHealthTracker", () => {
     expect(tracker.isHealthy(111 as ContractsChainId)).toBe(true);
   });
 
-  it("goes unhealthy immediately on a stale report", () => {
+  it("stays healthy on a brief stale blip", () => {
     const chainId = 222 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+
+    vi.setSystemTime(1_000);
+    tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+  });
+
+  it("goes unhealthy once staleness persists for the confirmation window", () => {
+    const chainId = 232 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(CONFIRMATION_MS - 1);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+
+    vi.setSystemTime(CONFIRMATION_MS);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(false);
+  });
+
+  it("resets the confirmation window when freshness returns before it elapses", () => {
+    const chainId = 242 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(1_000);
+    tracker.reportMarketsFreshness(chainId, false);
+
+    vi.setSystemTime(2_000);
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(4_000);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+
+    vi.setSystemTime(2_000 + CONFIRMATION_MS);
     tracker.reportMarketsFreshness(chainId, true);
     expect(tracker.isHealthy(chainId)).toBe(false);
   });
 
   it("stays unhealthy while fresh but within the restore cooldown", () => {
     const chainId = 333 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainId, true);
-    vi.setSystemTime(COOLDOWN_MS - 1);
+    makeUnhealthy(chainId);
+    vi.setSystemTime(CONFIRMATION_MS + COOLDOWN_MS - 1);
     tracker.reportMarketsFreshness(chainId, false);
     expect(tracker.isHealthy(chainId)).toBe(false);
   });
 
   it("restores once freshness holds continuously for the cooldown", () => {
     const chainId = 444 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainId, true);
-    vi.setSystemTime(COOLDOWN_MS);
+    makeUnhealthy(chainId);
+    vi.setSystemTime(CONFIRMATION_MS + COOLDOWN_MS);
     tracker.reportMarketsFreshness(chainId, false);
     expect(tracker.isHealthy(chainId)).toBe(true);
   });
 
   it("resets the cooldown when staleness recurs during recovery", () => {
     const chainId = 555 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainId, true);
+    makeUnhealthy(chainId);
     vi.setSystemTime(10_000);
     tracker.reportMarketsFreshness(chainId, false);
     vi.setSystemTime(12_000);
@@ -68,22 +110,31 @@ describe("ApiHealthTracker", () => {
   it("isolates health per chain", () => {
     const chainA = 666 as ContractsChainId;
     const chainB = 777 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainA, true);
+    makeUnhealthy(chainA);
     expect(tracker.isHealthy(chainA)).toBe(false);
     expect(tracker.isHealthy(chainB)).toBe(true);
   });
 
-  it("notifies subscribers on a health flip", () => {
+  it("notifies subscribers only on actual health flips", () => {
     const chainId = 888 as ContractsChainId;
     const listener = vi.fn();
     const unsubscribe = tracker.subscribe(listener);
 
     tracker.reportMarketsFreshness(chainId, true);
+    expect(listener).toHaveBeenCalledTimes(0);
+
+    vi.setSystemTime(CONFIRMATION_MS);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(CONFIRMATION_MS + 1_000);
+    tracker.reportMarketsFreshness(chainId, true);
     expect(listener).toHaveBeenCalledTimes(1);
 
     unsubscribe();
-    vi.setSystemTime(COOLDOWN_MS);
+    vi.setSystemTime(CONFIRMATION_MS + 1_000 + COOLDOWN_MS);
     tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(true);
     expect(listener).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/domain/api/apiHealthTracker.ts
+++ b/src/domain/api/apiHealthTracker.ts
@@ -2,10 +2,13 @@ import { useSyncExternalStore } from "react";
 
 import type { ContractsChainId } from "sdk/configs/chains";
 
+// A single stale render (e.g. right after a tab refocus, before the refetch lands) must not tear
+// down the api: staleness has to persist this long before the chain flips unhealthy.
+const UNHEALTHY_CONFIRMATION_MS = 3_000;
 // Require continuous freshness for this long before restoring, to avoid flapping at the threshold.
 const RESTORE_COOLDOWN_MS = 15_000;
 
-type ChainHealth = { healthy: boolean; lastStaleAt: number };
+type ChainHealth = { healthy: boolean; lastStaleAt: number; staleSince: number | undefined };
 
 export class ApiHealthTracker {
   private static instance: ApiHealthTracker | null = null;
@@ -22,19 +25,26 @@ export class ApiHealthTracker {
 
   reportMarketsFreshness(chainId: ContractsChainId, isStale: boolean): void {
     const now = Date.now();
-    const current = this.healthByChain.get(chainId) ?? { healthy: true, lastStaleAt: 0 };
+    const current = this.healthByChain.get(chainId) ?? { healthy: true, lastStaleAt: 0, staleSince: undefined };
 
     if (isStale) {
-      this.healthByChain.set(chainId, { healthy: false, lastStaleAt: now });
-      if (current.healthy) {
+      const staleSince = current.staleSince ?? now;
+      const healthy = current.healthy && now - staleSince < UNHEALTHY_CONFIRMATION_MS;
+      this.healthByChain.set(chainId, { healthy, lastStaleAt: now, staleSince });
+      if (current.healthy && !healthy) {
         this.emit();
       }
       return;
     }
 
     if (!current.healthy && now - current.lastStaleAt >= RESTORE_COOLDOWN_MS) {
-      this.healthByChain.set(chainId, { healthy: true, lastStaleAt: 0 });
+      this.healthByChain.set(chainId, { healthy: true, lastStaleAt: 0, staleSince: undefined });
       this.emit();
+      return;
+    }
+
+    if (current.staleSince !== undefined) {
+      this.healthByChain.set(chainId, { ...current, staleSince: undefined });
     }
   }
 

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ContractsChainId } from "sdk/configs/chains";
 import type { RawMarketConfig, RawMarketValues } from "sdk/utils/markets/types";
 
-import { MARKETS_STALE_THRESHOLD_MS, hasStaleMarketValues } from "./useApiMarketsInfoRequest";
+import {
+  MARKETS_STALE_THRESHOLD_MS,
+  getIsValuesSnapshotFrozen,
+  hasStaleMarketValues,
+  trackValuesSnapshot,
+} from "./useApiMarketsInfoRequest";
 
 function value(marketTokenAddress: string, updatedAt: number | null): RawMarketValues {
   return { marketTokenAddress, updatedAt } as RawMarketValues;
@@ -29,12 +35,30 @@ describe("hasStaleMarketValues", () => {
     expect(hasStaleMarketValues([config("0xa")], [value("0xa", 1_000_000 - 1_000)], new Set())).toBe(false);
   });
 
-  it("flags an enabled market older than the threshold as stale", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1_000_000);
+  it("flags an enabled market lagging the newest market beyond the threshold as stale", () => {
+    const newest = 1_000_000;
     expect(
-      hasStaleMarketValues([config("0xa")], [value("0xa", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)], new Set())
+      hasStaleMarketValues(
+        [config("0xa"), config("0xlagging")],
+        [value("0xa", newest), value("0xlagging", newest - MARKETS_STALE_THRESHOLD_MS - 1)],
+        new Set()
+      )
     ).toBe(true);
+    expect(
+      hasStaleMarketValues(
+        [config("0xa"), config("0xlagging")],
+        [value("0xa", newest), value("0xlagging", newest - MARKETS_STALE_THRESHOLD_MS)],
+        new Set()
+      )
+    ).toBe(false);
+  });
+
+  it("is immune to client clock skew", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(50_000_000);
+    expect(
+      hasStaleMarketValues([config("0xa"), config("0xb")], [value("0xa", 1_000), value("0xb", 900)], new Set())
+    ).toBe(false);
   });
 
   it("flags an enabled market with null updatedAt as stale", () => {
@@ -79,5 +103,51 @@ describe("hasStaleMarketValues", () => {
     expect(hasStaleMarketValues([config("0xa"), config("0xmissing", true)], [value("0xa", 1_000_000)], disabled)).toBe(
       false
     );
+  });
+});
+
+describe("values snapshot freshness", () => {
+  const chainId = 42161 as ContractsChainId;
+
+  it("is not frozen while re-evaluating the same response", () => {
+    const snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000)).toBe(false);
+  });
+
+  it("freezes when responses keep arriving but the newest updatedAt never moves", () => {
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    snapshot = trackValuesSnapshot(snapshot, chainId, [value("0xa", 1_000)], 5_000 + MARKETS_STALE_THRESHOLD_MS);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS)).toBe(false);
+
+    snapshot = trackValuesSnapshot(snapshot, chainId, [value("0xa", 1_000)], 5_000 + MARKETS_STALE_THRESHOLD_MS + 1);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS + 1)).toBe(true);
+  });
+
+  it("unfreezes as soon as the newest updatedAt changes", () => {
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    snapshot = trackValuesSnapshot(snapshot, chainId, [value("0xa", 2_000)], 5_000 + MARKETS_STALE_THRESHOLD_MS + 1);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS + 1)).toBe(false);
+  });
+
+  it("resets when the chain changes", () => {
+    const otherChainId = 43114 as ContractsChainId;
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    snapshot = trackValuesSnapshot(
+      snapshot,
+      otherChainId,
+      [value("0xa", 1_000)],
+      5_000 + MARKETS_STALE_THRESHOLD_MS + 1
+    );
+    expect(snapshot?.chainId).toBe(otherChainId);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS + 1)).toBe(false);
+  });
+
+  it("keeps the snapshot for the same chain while data is temporarily missing", () => {
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    const kept = trackValuesSnapshot(snapshot, chainId, undefined, undefined);
+    expect(kept).toBe(snapshot);
+
+    const dropped = trackValuesSnapshot(snapshot, 43114 as ContractsChainId, undefined, undefined);
+    expect(dropped).toBeUndefined();
   });
 });

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
@@ -17,6 +17,20 @@ function getApiMarketsConfigRequestKey(chainId: ContractsChainId) {
   return ["apiMarketsConfigRequest", chainId] as const;
 }
 
+export function getNewestValuesUpdatedAt(valuesData: RawMarketValues[] | undefined): number | undefined {
+  let newest: number | undefined = undefined;
+
+  for (const value of valuesData ?? []) {
+    if (value.updatedAt != null && (newest === undefined || value.updatedAt > newest)) {
+      newest = value.updatedAt;
+    }
+  }
+
+  return newest;
+}
+
+// Server updatedAt must never be compared to the client clock (skew would misfire): a market is
+// stale when it lags the newest market of the same response beyond the threshold.
 export function hasStaleMarketValues(
   configData: RawMarketConfig[] | undefined,
   valuesData: RawMarketValues[] | undefined,
@@ -26,7 +40,7 @@ export function hasStaleMarketValues(
     return false;
   }
 
-  const now = Date.now();
+  const newestUpdatedAt = getNewestValuesUpdatedAt(valuesData);
   const valuesByAddress = new Map(valuesData.map((v) => [v.marketTokenAddress, v]));
 
   for (const config of configData) {
@@ -36,12 +50,52 @@ export function hasStaleMarketValues(
 
     const value = valuesByAddress.get(config.marketTokenAddress);
 
-    if (!value || value.updatedAt == null || now - value.updatedAt > MARKETS_STALE_THRESHOLD_MS) {
+    if (!value || value.updatedAt == null) {
+      return true;
+    }
+
+    if (newestUpdatedAt !== undefined && newestUpdatedAt - value.updatedAt > MARKETS_STALE_THRESHOLD_MS) {
       return true;
     }
   }
 
   return false;
+}
+
+export type MarketValuesSnapshot = {
+  chainId: ContractsChainId;
+  newestUpdatedAt: number;
+  receivedAt: number;
+};
+
+export function trackValuesSnapshot(
+  prev: MarketValuesSnapshot | undefined,
+  chainId: ContractsChainId,
+  valuesData: RawMarketValues[] | undefined,
+  receivedAt: number | undefined
+): MarketValuesSnapshot | undefined {
+  const newestUpdatedAt = getNewestValuesUpdatedAt(valuesData);
+
+  if (newestUpdatedAt === undefined || receivedAt === undefined) {
+    return prev?.chainId === chainId ? prev : undefined;
+  }
+
+  if (!prev || prev.chainId !== chainId || prev.newestUpdatedAt !== newestUpdatedAt) {
+    return { chainId, newestUpdatedAt, receivedAt };
+  }
+
+  return prev;
+}
+
+// A backend whose puller died keeps serving the same snapshot: responses keep arriving but the
+// newest server updatedAt never moves. Compares client receipt times only, so clock skew is moot.
+export function getIsValuesSnapshotFrozen(
+  snapshot: MarketValuesSnapshot | undefined,
+  receivedAt: number | undefined
+): boolean {
+  return (
+    snapshot !== undefined && receivedAt !== undefined && receivedAt - snapshot.receivedAt > MARKETS_STALE_THRESHOLD_MS
+  );
 }
 
 export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = true }: { enabled?: boolean } = {}) {
@@ -61,6 +115,7 @@ export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = 
 
   const {
     data: valuesData,
+    updatedAt: valuesUpdatedAt,
     isStale: isValuesStale,
     error: valuesError,
   } = useApiDataRequest<RawMarketValues[]>(
@@ -104,7 +159,12 @@ export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = 
     [configData]
   );
 
-  const isMarketsDataStale = hasStaleMarketValues(configData, valuesData, disabledMarketAddresses);
+  const valuesSnapshotRef = useRef<MarketValuesSnapshot | undefined>(undefined);
+  valuesSnapshotRef.current = trackValuesSnapshot(valuesSnapshotRef.current, chainId, valuesData, valuesUpdatedAt);
+
+  const isMarketsDataStale =
+    hasStaleMarketValues(configData, valuesData, disabledMarketAddresses) ||
+    getIsValuesSnapshotFrozen(valuesSnapshotRef.current, valuesUpdatedAt);
   if (configData) {
     ApiHealthTracker.getInstance().reportMarketsFreshness(chainId, isMarketsDataStale);
   }


### PR DESCRIPTION
## Problem

At 100% api-positions rollout (Jul 20-29, Arbitrum) the `positionsListLoad` metric shows: 25% of successful loads are cold-RPC fallbacks (p50 ~11s, p90 ~28s) and 41.6% of all loads hit the 10s metric timeout — while the backend `/v1/positions` stays fast (p90 ~250ms). The dominant driver is the api health tracker (introduced Jun 16) force-falling everyone back to a cold RPC path on false-positive "markets stale" flips. Two false-positive sources:

1. **Clock skew.** `hasStaleMarketValues` compared server `updatedAt` to the client clock. A client >10s ahead makes the api permanently unhealthy: every load for that user goes through the cold RPC fallback forever.
2. **Tab refocus.** SWR pauses polling in hidden tabs, so on return the first render evaluates aged values and reported stale before the refocus refetch (~1s) could land. One stale render flipped the whole chain unhealthy for >=15s (restore cooldown) — a guaranteed api teardown plus cold RPC detour on every return to the tab (#2669 removed the data flash this caused; this PR removes the flip itself).

## Change

- `hasStaleMarketValues` never mixes clock domains: a market is stale when it lags the newest market of the same response beyond `MARKETS_STALE_THRESHOLD_MS` (server-vs-server), missing/null values stay stale as before.
- A fully frozen backend snapshot (responses keep arriving but the newest `updatedAt` never advances) is still detected, via `trackValuesSnapshot`/`getIsValuesSnapshotFrozen` comparing client receipt times only (skew-free), keyed per chain.
- `ApiHealthTracker` requires staleness to persist for `UNHEALTHY_CONFIRMATION_MS = 3s` before flipping unhealthy. Refocus blips (fresh data lands in ~1s) no longer flip; genuine staleness flips 3s later. Restore-cooldown semantics unchanged; a fresh report resets the pending confirmation window.

## Verification

- `yarn tscheck` clean
- `yarn test:ci`: 981 passed / 14 skipped / 0 failed
- Updated `apiHealthTracker.spec.ts` for the confirmation-window semantics (blip stays healthy, persistence flips, cooldown/reset/notify cases) and `useApiMarketsInfoRequest.spec.ts` for lag-based staleness, clock-skew immunity, and snapshot-freeze tracking.

## Expected effect

Fewer force-fallback windows → the `dataSource:rpc` share inside `apiSdkPositions:true` and the timeout rate should drop after deploy. Worth watching `positionsListLoad` p90 / timeout split by `dataSource` for a few days after release.
