### PR TITLE
Handle Trust Wallet popup transaction rejection FEDEV-4023

### DIFF
--- a/src/components/Errors/errorToasts.spec.tsx
+++ b/src/components/Errors/errorToasts.spec.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { ARBITRUM } from "config/chains";
+import { TxErrorType } from "sdk/utils/errors/transactionsErrors";
+
+import { getTxnErrorToast } from "./errorToasts";
+
+describe("getTxnErrorToast", () => {
+  it("uses the default message for other canceled transactions", () => {
+    const result = getTxnErrorToast(
+      ARBITRUM,
+      {
+        txErrorType: TxErrorType.UserDenied,
+      },
+      {}
+    );
+
+    expect(result.errorContent).toBe("Transaction canceled");
+  });
+
+  it("uses a custom user denied message", () => {
+    const result = getTxnErrorToast(
+      ARBITRUM,
+      {
+        txErrorType: TxErrorType.UserDenied,
+      },
+      {
+        userDeniedMessage: "Custom cancellation guidance",
+      }
+    );
+
+    expect(result.errorContent).toBe("Custom cancellation guidance");
+  });
+});

--- a/src/components/Errors/errorToasts.tsx
+++ b/src/components/Errors/errorToasts.tsx
@@ -27,6 +27,7 @@ export type AdditionalErrorParams = {
   additionalContent?: ReactNode;
   slippageInputId?: string;
   defaultMessage?: ReactNode;
+  userDeniedMessage?: ReactNode;
   isInternalSwapFallback?: boolean;
   isExternalSwapFallback?: boolean;
   permitIssueType?: PermitIssueType;
@@ -40,6 +41,7 @@ export function getTxnErrorToast(
     additionalContent,
     slippageInputId,
     defaultMessage = getDefaultErrorMessage(errorData),
+    userDeniedMessage,
     isInternalSwapFallback,
     isExternalSwapFallback,
     permitIssueType,
@@ -147,7 +149,7 @@ export function getTxnErrorToast(
       toastParams.errorContent = getInvalidNetworkToastContent(chainId);
       break;
     case TxErrorType.UserDenied:
-      toastParams.errorContent = t`Transaction canceled`;
+      toastParams.errorContent = userDeniedMessage ?? t`Transaction canceled`;
       break;
     case TxErrorType.Slippage:
       toastParams.errorContent = t`Mark price changed. Increase allowed slippage`;

--- a/src/domain/synthetics/orders/trustWallet.spec.ts
+++ b/src/domain/synthetics/orders/trustWallet.spec.ts
@@ -5,37 +5,26 @@ import { getShouldShowTrustWalletSidePanelWarning } from "./trustWallet";
 describe("getShouldShowTrustWalletSidePanelWarning", () => {
   it.each([
     {
-      name: "shows for a rejected Trust Wallet Express signature",
-      isExpress: true,
+      name: "shows for a rejected Trust Wallet request",
       isTrustWallet: true,
       isUserRejectedError: true,
       expected: true,
     },
     {
-      name: "does not show for a Classic transaction",
-      isExpress: false,
-      isTrustWallet: true,
-      isUserRejectedError: true,
-      expected: false,
-    },
-    {
       name: "does not show for another wallet",
-      isExpress: true,
       isTrustWallet: false,
       isUserRejectedError: true,
       expected: false,
     },
     {
       name: "does not show for another error",
-      isExpress: true,
       isTrustWallet: true,
       isUserRejectedError: false,
       expected: false,
     },
-  ])("$name", ({ isExpress, isTrustWallet, isUserRejectedError, expected }) => {
+  ])("$name", ({ isTrustWallet, isUserRejectedError, expected }) => {
     expect(
       getShouldShowTrustWalletSidePanelWarning({
-        isExpress,
         isTrustWallet,
         isUserRejectedError,
       })

--- a/src/domain/synthetics/orders/trustWallet.spec.ts
+++ b/src/domain/synthetics/orders/trustWallet.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { getShouldShowTrustWalletSidePanelWarning } from "./trustWallet";
+
+describe("getShouldShowTrustWalletSidePanelWarning", () => {
+  it.each([
+    {
+      name: "shows for a rejected Trust Wallet Express signature",
+      isExpress: true,
+      isTrustWallet: true,
+      isUserRejectedError: true,
+      expected: true,
+    },
+    {
+      name: "does not show for a Classic transaction",
+      isExpress: false,
+      isTrustWallet: true,
+      isUserRejectedError: true,
+      expected: false,
+    },
+    {
+      name: "does not show for another wallet",
+      isExpress: true,
+      isTrustWallet: false,
+      isUserRejectedError: true,
+      expected: false,
+    },
+    {
+      name: "does not show for another error",
+      isExpress: true,
+      isTrustWallet: true,
+      isUserRejectedError: false,
+      expected: false,
+    },
+  ])("$name", ({ isExpress, isTrustWallet, isUserRejectedError, expected }) => {
+    expect(
+      getShouldShowTrustWalletSidePanelWarning({
+        isExpress,
+        isTrustWallet,
+        isUserRejectedError,
+      })
+    ).toBe(expected);
+  });
+});

--- a/src/domain/synthetics/orders/trustWallet.ts
+++ b/src/domain/synthetics/orders/trustWallet.ts
@@ -1,11 +1,9 @@
 export function getShouldShowTrustWalletSidePanelWarning({
-  isExpress,
   isTrustWallet,
   isUserRejectedError,
 }: {
-  isExpress: boolean;
   isTrustWallet: boolean;
   isUserRejectedError: boolean;
 }) {
-  return isExpress && isTrustWallet && isUserRejectedError;
+  return isTrustWallet && isUserRejectedError;
 }

--- a/src/domain/synthetics/orders/trustWallet.ts
+++ b/src/domain/synthetics/orders/trustWallet.ts
@@ -1,0 +1,11 @@
+export function getShouldShowTrustWalletSidePanelWarning({
+  isExpress,
+  isTrustWallet,
+  isUserRejectedError,
+}: {
+  isExpress: boolean;
+  isTrustWallet: boolean;
+  isUserRejectedError: boolean;
+}) {
+  return isExpress && isTrustWallet && isUserRejectedError;
+}

--- a/src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+++ b/src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
@@ -352,13 +352,12 @@ export function useOrderTxnCallbacks() {
             slippageInputId: ctx.slippageInputId,
             additionalContent: ctx.additionalErrorContent,
             userDeniedMessage: getShouldShowTrustWalletSidePanelWarning({
-              isExpress: Boolean(expressParams),
               isTrustWallet,
               isUserRejectedError: Boolean(errorData?.isUserRejectedError),
             }) ? (
               <Trans>
-                Signature canceled. If Trust Wallet closed automatically, enable "Open in side panel" in Trust Wallet
-                settings and retry.
+                Wallet request canceled. If Trust Wallet closed automatically, enable "Open in side panel" in Trust
+                Wallet settings and retry.
               </Trans>
             ) : undefined,
             isInternalSwapFallback: Boolean(fallbackToInternalSwap),

--- a/src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+++ b/src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
@@ -46,6 +46,7 @@ import { getByKey } from "lib/objects";
 import { TradingActionName } from "lib/tradingErrorTracker";
 import { TxnEvent, TxnEventName } from "lib/transactions";
 import { useBlockNumber } from "lib/useBlockNumber";
+import { useIsTrustWallet } from "lib/wallets/useIsTrustWallet";
 import { isIncreaseOrderType, isMarketOrderType, isSwapOrderType } from "sdk/utils/orders";
 import { OrderInfo, OrdersInfoData } from "sdk/utils/orders/types";
 import {
@@ -65,6 +66,7 @@ import {
 import { getTxnErrorToast, PermitIssueType } from "components/Errors/errorToasts";
 
 import { BatchOrderTxnCtx } from "./sendBatchOrderTxn";
+import { getShouldShowTrustWalletSidePanelWarning } from "./trustWallet";
 import { ExpressTxnParams } from "../express/types";
 
 export type CallbackUiCtx = {
@@ -96,6 +98,7 @@ export function useOrderTxnCallbacks() {
   const { setIsPermitsDisabled, resetTokenPermits } = useTokenPermitsContext();
   const tokensData = useSelector(selectTokensData);
   const blockNumber = useBlockNumber(chainId);
+  const isTrustWallet = useIsTrustWallet();
 
   const batchTxnCallback = useCallback(
     (ctx: CallbackUiCtx, e: TxnEvent<BatchOrderTxnCtx>) => {
@@ -348,6 +351,16 @@ export function useOrderTxnCallbacks() {
             defaultMessage: operationMessage,
             slippageInputId: ctx.slippageInputId,
             additionalContent: ctx.additionalErrorContent,
+            userDeniedMessage: getShouldShowTrustWalletSidePanelWarning({
+              isExpress: Boolean(expressParams),
+              isTrustWallet,
+              isUserRejectedError: Boolean(errorData?.isUserRejectedError),
+            }) ? (
+              <Trans>
+                Signature canceled. If Trust Wallet closed automatically, enable "Open in side panel" in Trust Wallet
+                settings and retry.
+              </Trans>
+            ) : undefined,
             isInternalSwapFallback: Boolean(fallbackToInternalSwap),
             isExternalSwapFallback: Boolean(fallbackToExternalSwap),
             permitIssueType,
@@ -417,6 +430,7 @@ export function useOrderTxnCallbacks() {
       addOptimisticTokensBalancesUpdates,
       blockNumber,
       chainId,
+      isTrustWallet,
       srcChainId,
       ordersInfoData,
       resetTokenPermits,

--- a/src/lib/wallets/useIsTrustWallet.spec.ts
+++ b/src/lib/wallets/useIsTrustWallet.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { getIsTrustWallet } from "./useIsTrustWallet";
+
+describe("getIsTrustWallet", () => {
+  it("detects the Trust Wallet EIP-6963 connector", () => {
+    expect(getIsTrustWallet("com.trustwallet.app")).toBe(true);
+  });
+
+  it("does not match other connectors", () => {
+    expect(getIsTrustWallet("io.metamask")).toBe(false);
+    expect(getIsTrustWallet("trust")).toBe(false);
+    expect(getIsTrustWallet(undefined)).toBe(false);
+  });
+});

--- a/src/lib/wallets/useIsTrustWallet.ts
+++ b/src/lib/wallets/useIsTrustWallet.ts
@@ -1,0 +1,13 @@
+import { useAccount } from "wagmi";
+
+const TRUST_WALLET_ID = "com.trustwallet.app";
+
+export function getIsTrustWallet(connectorId: string | undefined) {
+  return connectorId === TRUST_WALLET_ID;
+}
+
+export function useIsTrustWallet() {
+  const { connector } = useAccount();
+
+  return getIsTrustWallet(connector?.id);
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "Bezahlen"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Signatur abgebrochen. Wenn Trust Wallet automatisch geschlossen wurde, aktiviere „Im Seitenbereich öffnen“ in den Trust-Wallet-Einstellungen und versuche es erneut."
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "Bezahlen"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "Signatur abgebrochen. Wenn Trust Wallet automatisch geschlossen wurde, aktiviere „Im Seitenbereich öffnen“ in den Trust-Wallet-Einstellungen und versuche es erneut."
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "Verdienen Sie {0}% mehr Belohnungen mit dieser Aktion"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Wallet-Anfrage abgebrochen. Wenn Trust Wallet automatisch geschlossen wurde, aktiviere „Im Seitenbereich öffnen“ in den Trust-Wallet-Einstellungen und versuche es erneut."
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1351,10 +1351,6 @@ msgstr "Leverage for the current order. Resulting position leverage: {formattedL
 msgid "Pay"
 msgstr "Pay"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "Earn {0}% more rewards with this action"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1351,6 +1351,10 @@ msgstr "Leverage for the current order. Resulting position leverage: {formattedL
 msgid "Pay"
 msgstr "Pay"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "Pagar"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Firma cancelada. Si Trust Wallet se cerró automáticamente, activa «Abrir en el panel lateral» en la configuración de Trust Wallet y vuelve a intentarlo."
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "Pagar"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "Firma cancelada. Si Trust Wallet se cerró automáticamente, activa «Abrir en el panel lateral» en la configuración de Trust Wallet y vuelve a intentarlo."
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "Obtenga un {0}% más de recompensas con esta acción"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Solicitud de la cartera cancelada. Si Trust Wallet se cerró automáticamente, activa «Abrir en el panel lateral» en la configuración de Trust Wallet y vuelve a intentarlo."
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "Payer"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Signature annulée. Si Trust Wallet s’est fermé automatiquement, activez « Ouvrir dans le panneau latéral » dans les paramètres de Trust Wallet, puis réessayez."
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "Payer"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "Signature annulée. Si Trust Wallet s’est fermé automatiquement, activez « Ouvrir dans le panneau latéral » dans les paramètres de Trust Wallet, puis réessayez."
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "Gagnez {0}% de récompenses supplémentaires avec cette action"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Demande du portefeuille annulée. Si Trust Wallet s’est fermé automatiquement, activez « Ouvrir dans le panneau latéral » dans les paramètres de Trust Wallet, puis réessayez."
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "支払い"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "署名がキャンセルされました。Trust Wallet が自動的に閉じた場合は、Trust Wallet の設定で「サイドパネルで開く」を有効にして、もう一度お試しください。"
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "このアクションで報酬が {0}% 増加します"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "ウォレットリクエストがキャンセルされました。Trust Wallet が自動的に閉じた場合は、Trust Wallet の設定で「サイドパネルで開く」を有効にして、もう一度お試しください。"
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "支払い"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "署名がキャンセルされました。Trust Wallet が自動的に閉じた場合は、Trust Wallet の設定で「サイドパネルで開く」を有効にして、もう一度お試しください。"
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "지불"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "서명이 취소되었습니다. Trust Wallet이 자동으로 닫혔다면 Trust Wallet 설정에서 \"사이드 패널에서 열기\"를 활성화한 후 다시 시도하세요."
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "지불"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "서명이 취소되었습니다. Trust Wallet이 자동으로 닫혔다면 Trust Wallet 설정에서 \"사이드 패널에서 열기\"를 활성화한 후 다시 시도하세요."
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "이 작업으로 {0}% 더 많은 보상을 받으십시오"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "지갑 요청이 취소되었습니다. Trust Wallet이 자동으로 닫혔다면 Trust Wallet 설정에서 \"사이드 패널에서 열기\"를 활성화한 후 다시 시도하세요."
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr ""
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "[!! Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry. !!]"
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr ""
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "[!! Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry. !!]"
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr ""
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "[!! Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry. !!]"
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "Оплатить"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "Подпись отменена. Если Trust Wallet закрылся автоматически, включите «Открывать на боковой панели» в настройках Trust Wallet и повторите попытку."
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "Получите на {0}% больше вознаграждений с 
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Запрос кошелька отменен. Если Trust Wallet закрылся автоматически, включите «Открывать на боковой панели» в настройках Trust Wallet и повторите попытку."
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "Оплатить"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "Подпись отменена. Если Trust Wallet закрылся автоматически, включите «Открывать на боковой панели» в настройках Trust Wallet и повторите попытку."
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "支付"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "簽名已取消。如果 Trust Wallet 自動關閉，請在 Trust Wallet 設定中啟用「在側邊欄中開啟」，然後重試。"
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "透過此操作可多賺取 {0}% 的獎勵"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "錢包請求已取消。如果 Trust Wallet 自動關閉，請在 Trust Wallet 設定中啟用「在側邊欄中開啟」，然後重試。"
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "支付"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "簽名已取消。如果 Trust Wallet 自動關閉，請在 Trust Wallet 設定中啟用「在側邊欄中開啟」，然後重試。"
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1351,10 +1351,6 @@ msgstr ""
 msgid "Pay"
 msgstr "支付"
 
-#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
-msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
-msgstr "签名已取消。如果 Trust Wallet 自动关闭，请在 Trust Wallet 设置中启用“在侧边栏中打开”，然后重试。"
-
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."
@@ -5396,6 +5392,10 @@ msgstr "通过此操作可多赚取 {0}% 的奖励"
 #: src/components/Errors/gasErrors.tsx
 msgid "Insufficient {nativeTokenSymbol} for gas on {0}. <0>Swap</0> or <1>bridge</1> {nativeTokenSymbol}."
 msgstr ""
+
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Wallet request canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "钱包请求已取消。如果 Trust Wallet 自动关闭，请在 Trust Wallet 设置中启用“在侧边栏中打开”，然后重试。"
 
 #: src/components/Seo/SEO.tsx
 msgid "Trade perpetuals with up to 100x leverage, plus spot trading, directly from your wallet on Arbitrum, Ethereum, and other networks"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1351,6 +1351,10 @@ msgstr ""
 msgid "Pay"
 msgstr "支付"
 
+#: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+msgid "Signature canceled. If Trust Wallet closed automatically, enable \"Open in side panel\" in Trust Wallet settings and retry."
+msgstr "签名已取消。如果 Trust Wallet 自动关闭，请在 Trust Wallet 设置中启用“在侧边栏中打开”，然后重试。"
+
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating referral code..."


### PR DESCRIPTION
## Summary

- Detect Trust Wallet's EIP-6963 connector and show side-panel recovery guidance when a wallet request is reported as user-rejected because the popup closes.
- Cover both Classic wallet transactions and Express signatures while preserving the normal cancellation message for other wallets and other errors.
- Add translated guidance for every configured locale and regression coverage for the gating behavior.

Chrome does not allow GMX to force another extension's side panel open, so this is the app-side recovery mitigation for the Trust Wallet popup lifecycle failure rather than an upstream extension fix.

Linear: [FEDEV-4023](https://linear.app/gmx-io/issue/FEDEV-4023/trust-wallet-swap-tx-is-auto-rejected-when-wallet-is-opened-in-a-popup)

## Testing

- `yarn test:ci` (988 tests)
- `yarn test:ct` (159 component tests)
- `cd sdk && yarn test:ci` (506 tests)
- `yarn tscheck:ci`
- `yarn lint:ci`
- Prettier check, localization extraction/compilation, and production build
- No browser screenshot was captured because the Trust Wallet extension popup lifecycle is unavailable in local automation.
