### PR TITLE
Add final delisting notices FEDEV-4132

### DIFF
--- a/src/components/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner/AnnouncementBanner.tsx
@@ -30,6 +30,7 @@ type AnnouncementBannerProps = {
   onPointerEnter?: (event: React.PointerEvent) => void;
   onPointerLeave?: (event: React.PointerEvent) => void;
   className?: string;
+  truncateHeader?: boolean;
 };
 
 const variantContainerClass: Record<AnnouncementVariant, string> = {
@@ -92,6 +93,7 @@ export function AnnouncementBanner({
   onPointerEnter,
   onPointerLeave,
   className,
+  truncateHeader = true,
 }: AnnouncementBannerProps) {
   const accentText = variantAccentTextClass[variant];
 
@@ -110,7 +112,14 @@ export function AnnouncementBanner({
       <div className={cx("flex items-center justify-between gap-8 p-12", variantDividerClass[variant])}>
         <div className="flex min-w-0 items-center gap-8">
           {headerIcon !== undefined && <HeaderIcon kind={headerIcon} className={cx("size-20 shrink-0", accentText)} />}
-          <p className="text-body-medium truncate font-medium text-typography-primary">{headerLabel}</p>
+          <p
+            className={cx(
+              "text-body-medium font-medium text-typography-primary",
+              truncateHeader ? "truncate" : "break-words"
+            )}
+          >
+            {headerLabel}
+          </p>
         </div>
         {onClose && (
           <button

--- a/src/components/DelistingExitAnnouncements/DelistingBanner.spec.tsx
+++ b/src/components/DelistingExitAnnouncements/DelistingBanner.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { DelistingBanner } from "./DelistingBanner";
+import type { DelistingToast } from "./delistingExitAnnouncementsLogic";
+
+const ITEM: DelistingToast = {
+  id: "delisting-final-notice-liquidity",
+  title: "Final notice: market delistings",
+  bodyText:
+    "USDC-DAI will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that.",
+  markets: ["0x1"],
+  link: { text: "Withdraw liquidity", href: "/pools" },
+};
+
+const onDismiss = vi.fn();
+
+describe("DelistingBanner", () => {
+  it("renders the full final notice with error styling", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DelistingBanner item={ITEM} onDismiss={onDismiss} />
+      </MemoryRouter>
+    );
+
+    expect(container.querySelector('[data-qa="announcement-banner"]')?.classList.contains("bg-red-900/90")).toBe(true);
+    expect(screen.getByText(ITEM.title).classList.contains("truncate")).toBe(false);
+    expect(screen.getByText(ITEM.bodyText)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Withdraw liquidity" }).getAttribute("href")).toBe("/pools");
+  });
+});

--- a/src/components/DelistingExitAnnouncements/DelistingBanner.spec.tsx
+++ b/src/components/DelistingExitAnnouncements/DelistingBanner.spec.tsx
@@ -1,6 +1,8 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { DelistingBanner } from "./DelistingBanner";
 import type { DelistingToast } from "./delistingExitAnnouncementsLogic";
@@ -16,17 +18,29 @@ const ITEM: DelistingToast = {
 
 const onDismiss = vi.fn();
 
+beforeAll(() => {
+  i18n.load("en", {});
+  i18n.activate("en");
+});
+
 describe("DelistingBanner", () => {
   it("renders the full final notice with error styling", () => {
     const { container } = render(
-      <MemoryRouter>
-        <DelistingBanner item={ITEM} onDismiss={onDismiss} />
-      </MemoryRouter>
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter>
+          <DelistingBanner item={ITEM} onDismiss={onDismiss} />
+        </MemoryRouter>
+      </I18nProvider>
     );
 
     expect(container.querySelector('[data-qa="announcement-banner"]')?.classList.contains("bg-red-900/90")).toBe(true);
     expect(screen.getByText(ITEM.title).classList.contains("truncate")).toBe(false);
     expect(screen.getByText(ITEM.bodyText)).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Withdraw liquidity" }).getAttribute("href")).toBe("/pools");
+    const actionLink = screen.getByRole("link", { name: "Withdraw liquidity" });
+    expect(actionLink.getAttribute("href")).toBe("/pools");
+    expect(actionLink.classList.contains("font-medium")).toBe(true);
+    expect(screen.getByRole("link", { name: "Read more" }).getAttribute("href")).toBe(
+      "/announcements?id=personal-delisting-final-notice"
+    );
   });
 });

--- a/src/components/DelistingExitAnnouncements/DelistingBanner.tsx
+++ b/src/components/DelistingExitAnnouncements/DelistingBanner.tsx
@@ -1,9 +1,16 @@
+import { Trans } from "@lingui/macro";
 import { useCallback } from "react";
 import { Link } from "react-router-dom";
 
 import { AnnouncementBanner } from "components/AnnouncementBanner/AnnouncementBanner";
 
 import { DelistingToast } from "./delistingExitAnnouncementsLogic";
+import { PERSONAL_DELISTING_ANNOUNCEMENT_ID } from "./personalDelistingAnnouncement";
+
+const READ_MORE_LINK = {
+  text: <Trans>Read more</Trans>,
+  to: `/announcements?id=${encodeURIComponent(PERSONAL_DELISTING_ANNOUNCEMENT_ID)}`,
+};
 
 export function DelistingBanner({
   item,
@@ -22,13 +29,16 @@ export function DelistingBanner({
       headerIcon="alert"
       truncateHeader={false}
       onClose={handleClose}
+      footerLink={READ_MORE_LINK}
     >
       {item.link ? (
         <>
           {item.bodyText}
           <br />
           <br />
-          <Link to={item.link.href}>{item.link.text}</Link>
+          <Link className="font-medium" to={item.link.href}>
+            {item.link.text}
+          </Link>
         </>
       ) : (
         item.bodyText

--- a/src/components/DelistingExitAnnouncements/DelistingBanner.tsx
+++ b/src/components/DelistingExitAnnouncements/DelistingBanner.tsx
@@ -17,9 +17,10 @@ export function DelistingBanner({
   return (
     <AnnouncementBanner
       className="pointer-events-auto"
-      variant="warning"
+      variant="error"
       headerLabel={item.title}
       headerIcon="alert"
+      truncateHeader={false}
       onClose={handleClose}
     >
       {item.link ? (

--- a/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.spec.ts
+++ b/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.spec.ts
@@ -179,7 +179,7 @@ describe("getActiveDelistingAnnouncements", () => {
     expect(result.map((item) => item.id)).toEqual([POSITIONS_TOAST_ID]);
     expect(result[0].markets).toEqual([TON]);
     expect(result[0].title).toBe("Final notice: market delistings");
-    expect(result[0].link).toBeUndefined();
+    expect(result[0].link).toEqual({ text: "Close positions", href: "/trade" });
   });
 
   it("shows only the liquidity toast (with the Withdraw liquidity link) for direct GM holders", () => {

--- a/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.spec.ts
+++ b/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.spec.ts
@@ -1,7 +1,7 @@
 import { i18n } from "@lingui/core";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { ARBITRUM } from "config/chains";
+import { ARBITRUM, AVALANCHE } from "config/chains";
 import type { MarketInfo } from "domain/synthetics/markets/types";
 
 import {
@@ -48,26 +48,26 @@ describe("getDelistingMarketLabel", () => {
 describe("buildPositionsBodyText", () => {
   it("singular market and single position", () =>
     expect(buildPositionsBodyText(["TON/USD"], 1)).toBe(
-      "TON/USD is being delisted. Close your existing position as remaining positions may be auto-closed."
+      "TON/USD will be disabled after August 5, 2026, 23:59 UTC. Close your position before then. Collateral left in open positions won't be accessible after that."
     ));
   it("singular market with plural positions", () =>
     expect(buildPositionsBodyText(["TON/USD"], 2)).toBe(
-      "TON/USD is being delisted. Close your existing positions as remaining positions may be auto-closed."
+      "TON/USD will be disabled after August 5, 2026, 23:59 UTC. Close your positions before then. Collateral left in open positions won't be accessible after that."
     ));
   it("plural markets and positions", () =>
     expect(buildPositionsBodyText(["TON/USD", "PI/USD"], 3)).toBe(
-      "TON/USD and PI/USD are being delisted. Close your existing positions as remaining positions may be auto-closed."
+      "TON/USD and PI/USD will be disabled after August 5, 2026, 23:59 UTC. Close your positions before then. Collateral left in open positions won't be accessible after that."
     ));
 });
 
 describe("buildLiquidityBodyText", () => {
   it("singular pool", () =>
     expect(buildLiquidityBodyText(["KTA/USD"])).toBe(
-      "KTA/USD is being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
+      "KTA/USD will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
     ));
   it("plural pools", () =>
     expect(buildLiquidityBodyText(["KTA/USD", "SATS/USD"])).toBe(
-      "KTA/USD and SATS/USD are being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
+      "KTA/USD and SATS/USD will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
     ));
 });
 
@@ -93,6 +93,8 @@ describe("computeAffectedPositionMarkets", () => {
 
 describe("computeAffectedLiquidityMarkets", () => {
   const KTA = "0x970b730b5dD18de53A230eE8F4af088dBC3a6F8d";
+  const ARBITRUM_DAI_SWAP = "0xe2fEDb9e6139a182B98e7C2688ccFa3e9A53c665";
+  const AVALANCHE_DAI_SWAP = "0xDf8c9BD26e7C1A331902758Eb013548B2D22ab3b";
   const NON_DELISTING = "0x0000000000000000000000000000000000000003";
 
   it("includes GM tokens with a positive balance that are delisting", () => {
@@ -108,6 +110,15 @@ describe("computeAffectedLiquidityMarkets", () => {
   it("excludes markets not in the delisting list", () => {
     const data = { [NON_DELISTING]: { symbol: "GM", balance: 5n } } as any;
     expect(computeAffectedLiquidityMarkets(ARBITRUM, data)).toEqual([]);
+  });
+
+  it("includes the DAI swap pools on Arbitrum and Avalanche", () => {
+    expect(
+      computeAffectedLiquidityMarkets(ARBITRUM, { [ARBITRUM_DAI_SWAP]: { symbol: "GM", balance: 1n } } as any)
+    ).toEqual([ARBITRUM_DAI_SWAP]);
+    expect(
+      computeAffectedLiquidityMarkets(AVALANCHE, { [AVALANCHE_DAI_SWAP]: { symbol: "GM", balance: 1n } } as any)
+    ).toEqual([AVALANCHE_DAI_SWAP]);
   });
 });
 
@@ -167,11 +178,11 @@ describe("getActiveDelistingAnnouncements", () => {
     });
     expect(result.map((item) => item.id)).toEqual([POSITIONS_TOAST_ID]);
     expect(result[0].markets).toEqual([TON]);
-    expect(result[0].title).toBe("Market delistings");
+    expect(result[0].title).toBe("Final notice: market delistings");
     expect(result[0].link).toBeUndefined();
   });
 
-  it("shows only the liquidity toast (with the Manage liquidity link) for direct GM holders", () => {
+  it("shows only the liquidity toast (with the Withdraw liquidity link) for direct GM holders", () => {
     const result = getActiveDelistingAnnouncements({
       chainId: ARBITRUM,
       positionsInfoData: undefined,
@@ -180,7 +191,7 @@ describe("getActiveDelistingAnnouncements", () => {
       now: 1000,
     });
     expect(result.map((item) => item.id)).toEqual([LIQUIDITY_TOAST_ID]);
-    expect(result[0].link).toEqual({ text: "Manage liquidity", href: "/pools" });
+    expect(result[0].link).toEqual({ text: "Withdraw liquidity", href: "/pools" });
   });
 
   it("shows nothing when there is no exposure", () => {
@@ -204,6 +215,23 @@ describe("getActiveDelistingAnnouncements", () => {
       now: 2000,
     });
     expect(result).toEqual([]);
+  });
+
+  it("ignores the earlier warning's dismissal record", () => {
+    localStorage.setItem(
+      "delisting-announcement-dismissed-delisting-positions",
+      JSON.stringify({ dismissedAt: 1000, markets: [TON] })
+    );
+
+    const result = getActiveDelistingAnnouncements({
+      chainId: ARBITRUM,
+      positionsInfoData: { k: { marketAddress: TON } } as any,
+      depositMarketTokensData: undefined,
+      marketsInfoData,
+      now: 2000,
+    });
+
+    expect(result.map((item) => item.id)).toEqual([POSITIONS_TOAST_ID]);
   });
 
   it("waits when marketsInfoData has not loaded (cannot label)", () => {

--- a/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+++ b/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
@@ -169,6 +169,7 @@ export function getActiveDelistingAnnouncementsForExposure(
       title,
       bodyText: buildPositionsBodyText(positionNames, positionCount),
       markets: positionMarkets,
+      link: { text: t`Close positions`, href: "/trade" },
     });
   }
 

--- a/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+++ b/src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
@@ -24,15 +24,13 @@ export function joinMarketNames(names: string[]): string {
 
 export function buildPositionsBodyText(marketNames: string[], positionCount: number): string {
   const markets = joinMarketNames(marketNames);
-  const verb = plural(marketNames.length, { one: "is", other: "are" });
   const positionNoun = plural(positionCount, { one: "position", other: "positions" });
-  return t`${markets} ${verb} being delisted. Close your existing ${positionNoun} as remaining positions may be auto-closed.`;
+  return t`${markets} will be disabled after August 5, 2026, 23:59 UTC. Close your ${positionNoun} before then. Collateral left in open positions won't be accessible after that.`;
 }
 
 export function buildLiquidityBodyText(poolNames: string[]): string {
   const pools = joinMarketNames(poolNames);
-  const verb = plural(poolNames.length, { one: "is", other: "are" });
-  return t`${pools} ${verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning.`;
+  return t`${pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that.`;
 }
 
 export function computeAffectedPositionMarkets(
@@ -65,6 +63,43 @@ export function computeAffectedLiquidityMarkets(
   }
 
   return result;
+}
+
+export type DelistingExposure = {
+  positionMarkets: string[];
+  positionNames: string[];
+  positionCount: number;
+  liquidityMarkets: string[];
+  liquidityNames: string[];
+};
+
+export function getDelistingExposure(params: {
+  chainId: number;
+  positionsInfoData: PositionsData | undefined;
+  depositMarketTokensData: TokensData | undefined;
+  marketsInfoData: MarketsInfoData | undefined;
+}): DelistingExposure {
+  const { chainId, positionsInfoData, depositMarketTokensData, marketsInfoData } = params;
+
+  const labelOf = (addresses: string[]): string[] =>
+    addresses
+      .map((address) => getByKey(marketsInfoData, address))
+      .filter((marketInfo): marketInfo is MarketInfo => Boolean(marketInfo))
+      .map(getDelistingMarketLabel);
+
+  const { marketAddresses: positionMarkets, positionCount } = computeAffectedPositionMarkets(
+    chainId,
+    positionsInfoData
+  );
+  const liquidityMarkets = computeAffectedLiquidityMarkets(chainId, depositMarketTokensData);
+
+  return {
+    positionMarkets,
+    positionNames: labelOf(positionMarkets),
+    positionCount,
+    liquidityMarkets,
+    liquidityNames: labelOf(liquidityMarkets),
+  };
 }
 
 export const DELISTING_ANNOUNCEMENT_COOLDOWN_MS = DAY_MS;
@@ -107,8 +142,8 @@ export function shouldShowDelistingAnnouncement(toastId: string, affectedAddress
   return affectedAddresses.some((address) => !record.markets.includes(address));
 }
 
-export const POSITIONS_TOAST_ID = "delisting-positions";
-export const LIQUIDITY_TOAST_ID = "delisting-liquidity";
+export const POSITIONS_TOAST_ID = "delisting-final-notice-positions";
+export const LIQUIDITY_TOAST_ID = "delisting-final-notice-liquidity";
 
 export type DelistingToast = {
   id: string;
@@ -118,30 +153,16 @@ export type DelistingToast = {
   link?: { text: string; href: string };
 };
 
-export function getActiveDelistingAnnouncements(params: {
-  chainId: number;
-  positionsInfoData: PositionsData | undefined;
-  depositMarketTokensData: TokensData | undefined;
-  marketsInfoData: MarketsInfoData | undefined;
-  now: number;
-}): DelistingToast[] {
-  const { chainId, positionsInfoData, depositMarketTokensData, marketsInfoData, now } = params;
+export function getActiveDelistingAnnouncementsForExposure(
+  params: DelistingExposure & {
+    now: number;
+  }
+): DelistingToast[] {
+  const { positionMarkets, positionNames, positionCount, liquidityMarkets, liquidityNames, now } = params;
 
   const toShow: DelistingToast[] = [];
-  const title = t`Market delistings`;
+  const title = t`Final notice: market delistings`;
 
-  const labelOf = (addresses: string[]): string[] =>
-    addresses
-      .map((address) => getByKey(marketsInfoData, address))
-      .filter((marketInfo): marketInfo is MarketInfo => Boolean(marketInfo))
-      .map(getDelistingMarketLabel);
-
-  // Positions
-  const { marketAddresses: positionMarkets, positionCount } = computeAffectedPositionMarkets(
-    chainId,
-    positionsInfoData
-  );
-  const positionNames = labelOf(positionMarkets);
   if (positionNames.length > 0 && shouldShowDelistingAnnouncement(POSITIONS_TOAST_ID, positionMarkets, now)) {
     toShow.push({
       id: POSITIONS_TOAST_ID,
@@ -151,18 +172,29 @@ export function getActiveDelistingAnnouncements(params: {
     });
   }
 
-  // Liquidity
-  const liquidityMarkets = computeAffectedLiquidityMarkets(chainId, depositMarketTokensData);
-  const liquidityNames = labelOf(liquidityMarkets);
   if (liquidityNames.length > 0 && shouldShowDelistingAnnouncement(LIQUIDITY_TOAST_ID, liquidityMarkets, now)) {
     toShow.push({
       id: LIQUIDITY_TOAST_ID,
       title,
       bodyText: buildLiquidityBodyText(liquidityNames),
       markets: liquidityMarkets,
-      link: { text: t`Manage liquidity`, href: "/pools" },
+      link: { text: t`Withdraw liquidity`, href: "/pools" },
     });
   }
 
   return toShow;
+}
+
+export function getActiveDelistingAnnouncements(params: {
+  chainId: number;
+  positionsInfoData: PositionsData | undefined;
+  depositMarketTokensData: TokensData | undefined;
+  marketsInfoData: MarketsInfoData | undefined;
+  now: number;
+}): DelistingToast[] {
+  const { now, ...exposureParams } = params;
+  return getActiveDelistingAnnouncementsForExposure({
+    ...getDelistingExposure(exposureParams),
+    now,
+  });
 }

--- a/src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.spec.tsx
+++ b/src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.spec.tsx
@@ -1,0 +1,99 @@
+import { i18n } from "@lingui/core";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { reactNodeToText } from "pages/Announcements/announcementsHelpers";
+
+import type { DelistingExposure } from "./delistingExitAnnouncementsLogic";
+import { getPersonalDelistingAnnouncement } from "./personalDelistingAnnouncement";
+
+beforeAll(() => {
+  i18n.load({ en: {} });
+  i18n.activate("en");
+});
+
+function makeExposure(overrides: Partial<DelistingExposure> = {}): DelistingExposure {
+  return {
+    positionMarkets: [],
+    positionNames: [],
+    positionCount: 0,
+    liquidityMarkets: [],
+    liquidityNames: [],
+    ...overrides,
+  };
+}
+
+describe("getPersonalDelistingAnnouncement", () => {
+  const account = "0x104d73283Ae1B380710659d3411C3C89603F80fF";
+
+  it("returns nothing without a connected wallet", () => {
+    const exposure = makeExposure({ positionNames: ["TON/USD"], positionCount: 1 });
+    expect(getPersonalDelistingAnnouncement(undefined, 42161, exposure)).toBeUndefined();
+  });
+
+  it("returns nothing when the wallet has no affected exposure", () => {
+    expect(getPersonalDelistingAnnouncement(account, 42161, makeExposure())).toBeUndefined();
+  });
+
+  it("includes only the applicable position line and action", () => {
+    const event = getPersonalDelistingAnnouncement(
+      account,
+      42161,
+      makeExposure({
+        positionMarkets: ["0x1", "0x2"],
+        positionNames: ["TON/USD", "PI/USD"],
+        positionCount: 2,
+      })
+    );
+
+    expect(event?.title).toBe("Final notice: market delistings");
+    expect(event?.type).toBe("delisting");
+    expect(event?.chains).toEqual([42161]);
+    expect(event?.links).toEqual([{ text: "Close positions", href: "/trade" }]);
+
+    const body = reactNodeToText(event?.description).replace(/\s+/g, " ");
+    expect(body).toContain(`Your wallet ${account} still holds capital`);
+    expect(body).toContain("Positions to close: TON/USD, PI/USD");
+    expect(body).not.toContain("Liquidity to withdraw:");
+    expect(body).toContain("capital left in them won't be accessible from the app");
+  });
+
+  it("includes only the applicable liquidity line and action", () => {
+    const event = getPersonalDelistingAnnouncement(
+      account,
+      42161,
+      makeExposure({
+        liquidityMarkets: ["0x1"],
+        liquidityNames: ["USDC-DAI"],
+      })
+    );
+
+    expect(event?.links).toEqual([{ text: "Withdraw liquidity", href: "/pools" }]);
+
+    const body = reactNodeToText(event?.description).replace(/\s+/g, " ");
+    expect(body).not.toContain("Positions to close:");
+    expect(body).toContain("Liquidity to withdraw: USDC-DAI");
+  });
+
+  it("includes both applicable lines and actions", () => {
+    const event = getPersonalDelistingAnnouncement(
+      account,
+      43114,
+      makeExposure({
+        positionMarkets: ["0x1"],
+        positionNames: ["BTC/USD"],
+        positionCount: 1,
+        liquidityMarkets: ["0x2"],
+        liquidityNames: ["USDC-DAI.e"],
+      })
+    );
+
+    expect(event?.links).toEqual([
+      { text: "Close positions", href: "/trade" },
+      { text: "Withdraw liquidity", href: "/pools" },
+    ]);
+
+    const body = reactNodeToText(event?.description).replace(/\s+/g, " ");
+    expect(body).toContain("Positions to close: BTC/USD");
+    expect(body).toContain("Liquidity to withdraw: USDC-DAI.e");
+  });
+});

--- a/src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+++ b/src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
@@ -1,0 +1,69 @@
+import { i18n, MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/macro";
+
+import type { EventData } from "config/events";
+
+import type { DelistingExposure } from "./delistingExitAnnouncementsLogic";
+
+export const PERSONAL_DELISTING_ANNOUNCEMENT_ID = "personal-delisting-final-notice";
+
+type Translate = (descriptor: MessageDescriptor) => string;
+
+export function getPersonalDelistingAnnouncement(
+  account: string | undefined,
+  chainId: number,
+  exposure: DelistingExposure,
+  translate: Translate = (descriptor) => i18n._(descriptor)
+): EventData | undefined {
+  const { positionNames, liquidityNames } = exposure;
+
+  if (!account || (positionNames.length === 0 && liquidityNames.length === 0)) {
+    return undefined;
+  }
+
+  const links: NonNullable<EventData["links"]> = [];
+  if (positionNames.length > 0) {
+    links.push({ text: translate(msg`Close positions`), href: "/trade" });
+  }
+  if (liquidityNames.length > 0) {
+    links.push({ text: translate(msg`Withdraw liquidity`), href: "/pools" });
+  }
+
+  return {
+    id: PERSONAL_DELISTING_ANNOUNCEMENT_ID,
+    type: "delisting",
+    isActive: true,
+    startDate: "30 Jul 2026, 0:00",
+    endDate: "05 Aug 2026, 23:59",
+    variant: "error",
+    chains: [chainId],
+    title: translate(msg`Final notice: market delistings`),
+    description: (
+      <span className="flex flex-col gap-12 break-words">
+        <span>
+          {translate(
+            msg`Your wallet ${account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC.`
+          )}
+        </span>
+        {positionNames.length > 0 && (
+          <span>
+            <span className="font-medium text-typography-primary">{translate(msg`Positions to close:`)}</span>{" "}
+            {positionNames.join(", ")}
+          </span>
+        )}
+        {liquidityNames.length > 0 && (
+          <span>
+            <span className="font-medium text-typography-primary">{translate(msg`Liquidity to withdraw:`)}</span>{" "}
+            {liquidityNames.join(", ")}
+          </span>
+        )}
+        <span>
+          {translate(
+            msg`After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now.`
+          )}
+        </span>
+      </span>
+    ),
+    links,
+  };
+}

--- a/src/components/DelistingExitAnnouncements/useDelistingExitAnnouncements.ts
+++ b/src/components/DelistingExitAnnouncements/useDelistingExitAnnouncements.ts
@@ -1,13 +1,11 @@
 import { useCallback, useReducer } from "react";
 
-import { hasDelistingMarkets } from "config/static/markets";
-import { useMarketsInfoRequest, useMarketTokensDataRequest } from "domain/synthetics/markets";
-import { usePositions } from "domain/synthetics/positions";
-import { useTokensDataRequest } from "domain/synthetics/tokens";
-import { useChainId } from "lib/chains";
-import useWallet from "lib/wallets/useWallet";
-
-import { DelistingToast, getActiveDelistingAnnouncements, writeDismissal } from "./delistingExitAnnouncementsLogic";
+import {
+  DelistingToast,
+  getActiveDelistingAnnouncementsForExposure,
+  writeDismissal,
+} from "./delistingExitAnnouncementsLogic";
+import { useDelistingExposure } from "./useDelistingExposure";
 
 type Result = {
   announcements: DelistingToast[];
@@ -17,26 +15,8 @@ type Result = {
 // Runs at the app shell for the connected wallet, so the exit warnings appear on every page and never
 // duplicate (a single instance), regardless of which SyntheticsStateContextProvider is mounted.
 export function useDelistingExitAnnouncements(): Result {
-  const { account } = useWallet();
-  const { chainId, srcChainId } = useChainId();
-  const enabled = Boolean(account) && hasDelistingMarkets(chainId);
-
-  const { tokensData } = useTokensDataRequest(chainId, srcChainId);
-  const { marketsInfoData } = useMarketsInfoRequest(chainId, { tokensData });
-
-  const positions = usePositions(chainId, {
-    marketsData: marketsInfoData,
-    tokensData,
-    account,
-    enabled,
-  });
-
-  const { marketTokensData } = useMarketTokensDataRequest(chainId, srcChainId, {
-    isDeposit: true,
-    account,
-    withGlv: false,
-    enabled,
-  });
+  const { account, positionMarkets, positionNames, positionCount, liquidityMarkets, liquidityNames } =
+    useDelistingExposure();
 
   const [, forceRerender] = useReducer((count: number) => count + 1, 0);
 
@@ -45,13 +25,16 @@ export function useDelistingExitAnnouncements(): Result {
     forceRerender();
   }, []);
 
-  const announcements = getActiveDelistingAnnouncements({
-    chainId,
-    positionsInfoData: positions.positionsData,
-    depositMarketTokensData: marketTokensData,
-    marketsInfoData,
-    now: Date.now(),
-  });
+  const announcements = account
+    ? getActiveDelistingAnnouncementsForExposure({
+        positionMarkets,
+        positionNames,
+        positionCount,
+        liquidityMarkets,
+        liquidityNames,
+        now: Date.now(),
+      })
+    : [];
 
   return { announcements, dismiss };
 }

--- a/src/components/DelistingExitAnnouncements/useDelistingExposure.ts
+++ b/src/components/DelistingExitAnnouncements/useDelistingExposure.ts
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+
+import { hasDelistingMarkets } from "config/static/markets";
+import { useMarketsInfoRequest, useMarketTokensDataRequest } from "domain/synthetics/markets";
+import { usePositions } from "domain/synthetics/positions";
+import { useTokensDataRequest } from "domain/synthetics/tokens";
+import { useChainId } from "lib/chains";
+import useWallet from "lib/wallets/useWallet";
+
+import { DelistingExposure, getDelistingExposure } from "./delistingExitAnnouncementsLogic";
+
+const EMPTY_EXPOSURE: DelistingExposure = {
+  positionMarkets: [],
+  positionNames: [],
+  positionCount: 0,
+  liquidityMarkets: [],
+  liquidityNames: [],
+};
+
+export function useDelistingExposure(): DelistingExposure & {
+  account: string | undefined;
+  chainId: number;
+} {
+  const { account } = useWallet();
+  const { chainId, srcChainId } = useChainId();
+  const enabled = Boolean(account) && hasDelistingMarkets(chainId);
+
+  const { tokensData } = useTokensDataRequest(chainId, srcChainId);
+  const { marketsInfoData } = useMarketsInfoRequest(chainId, { tokensData });
+
+  const positions = usePositions(chainId, {
+    marketsData: marketsInfoData,
+    tokensData,
+    account,
+    enabled,
+  });
+
+  const { marketTokensData } = useMarketTokensDataRequest(chainId, srcChainId, {
+    isDeposit: true,
+    account,
+    withGlv: false,
+    enabled,
+  });
+
+  const exposure = useMemo(
+    () =>
+      enabled
+        ? getDelistingExposure({
+            chainId,
+            positionsInfoData: positions.positionsData,
+            depositMarketTokensData: marketTokensData,
+            marketsInfoData,
+          })
+        : EMPTY_EXPOSURE,
+    [chainId, enabled, marketTokensData, marketsInfoData, positions.positionsData]
+  );
+
+  return { account, chainId, ...exposure };
+}

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -15,6 +15,15 @@ import sparkleIcon from "img/sparkle.svg";
 export type AnnouncementType = "listing" | "delisting" | "update" | "maintenance";
 export type AnnouncementVariant = "info" | "warning" | "error" | "success";
 
+export type EventLink = {
+  text: string;
+  href: string;
+  /**
+   * @default false
+   */
+  newTab?: boolean;
+};
+
 export type EventData = {
   id: string;
   type: AnnouncementType;
@@ -33,14 +42,8 @@ export type EventData = {
 
   variant?: AnnouncementVariant;
   chains?: number[];
-  link?: {
-    text: string;
-    href: string;
-    /**
-     * @default false
-     */
-    newTab?: boolean;
-  };
+  link?: EventLink;
+  links?: EventLink[];
 
   requiresOpenPosition?: string;
 };

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX führt Trades gegen einen dynamisch ausbalancierten Liquiditätsp
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "mit 100x Hebel"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Kein Preiseinfluss. Einzelner Ausführungspreis für das<0/>Erhöhen von Longs oder Verringern von Shorts bei<1/>dieser Größe."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "Positionen schließen"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3560,9 +3560,17 @@ msgstr "Fehlergrenze-Debug-Auslöser anzeigen"
 msgid "Autocompound"
 msgstr "Automatisches Reinvestieren"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "Abzuziehende Liquidität:"
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "Marktgraph"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "Nach Ablauf der Frist sind Handel und Auszahlungen auf diesen Märkten deaktiviert, und dort verbliebenes Kapital ist über die App nicht mehr zugänglich. Schließen Sie jetzt Ihre Positionen und ziehen Sie Ihre Liquidität ab."
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "Finanzierungsfaktor"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "Einzahlung gesendet"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "Letzte Warnung: Markt-Delistings"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "Dieser Auslösepreis liegt jenseits des aktuellen Liquidationspreises. D
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "Wird erstellt…"
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {wird} other {werden}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "Perpetuals-Aggregator"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "Markttausch anfordern"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "Zu schließende Positionen:"
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "Geschätzte Zeit bis zur Liquidation"
 msgid "Mark price for the liquidation"
 msgstr "Markpreis für die Liquidation"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets} werden nach dem 5. August 2026 um 23:59 Uhr UTC deaktiviert. Schließen Sie {positionNoun} vorher. Sicherheiten, die in offenen Positionen verbleiben, sind danach nicht mehr zugänglich."
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "Alle Positionen gehören zum selben verbundenen Wallet und werden gemein
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "Genehmigung von {tokenSymbol}..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "Ihr Wallet {account} enthält noch Kapital in Märkten, die aus dem Listing genommen werden. Diese Märkte werden nach dem 5. August 2026 um 23:59 Uhr UTC deaktiviert."
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "Min. Positionsgröße: {0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb} ausgelistet. Schließen Sie {positionNoun}, da verbleibende Positionen automatisch geschlossen werden können."
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "Ausgefallen"
@@ -8827,10 +8843,6 @@ msgstr "~5 Min."
 msgid "New tier:"
 msgstr "Neue Stufe:"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "Markt-Delistings"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "mit 100x Hebel"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Kein Preiseinfluss. Einzelner Ausführungspreis für das<0/>Erhöhen von Longs oder Verringern von Shorts bei<1/>dieser Größe."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "Positionen schließen"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "Escrowed GMX APR"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "Vesting nur verfügbar auf {chainNames}. Wechseln Sie das Netzwerk, um fortzufahren."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools} werden nach dem 5. August 2026 um 23:59 Uhr UTC deaktiviert. Ziehen Sie Ihre Liquidität vorher ab. GM-Token, die in einem deaktivierten Pool verbleiben, sind danach nicht mehr zugänglich."
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "Kaufen Sie APE auf Arbitrum mit <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Wird eingezahlt…"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb} ausgelistet. Ziehen Sie Ihre Liquidität ab, da Einzahlungen nicht mehr verfügbar sind, oder verschieben Sie sie in GLV, um weiterhin Erträge zu erzielen."
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX Trading Chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs Trading-Simulationen"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "Liquidität verwalten"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL Long"
@@ -11150,6 +11162,11 @@ msgstr "GMX Dashboards und Analysen"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "Liquidität abziehen"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3560,9 +3560,17 @@ msgstr "Show error boundary debug trigger"
 msgid "Autocompound"
 msgstr "Autocompound"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "Liquidity to withdraw:"
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "Market graph"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "Funding factor"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "Deposit sent"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "Final notice: market delistings"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "This trigger price is beyond the current liquidation price. Your positio
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "Creating..."
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {is} other {are}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "Perpetuals aggregator"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "Request Market Swap"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "Positions to close:"
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "Estimated time to liquidation"
 msgid "Mark price for the liquidation"
 msgstr "Mark price for the liquidation"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "All positions belong to the same connected wallet and are shown together
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "Approving {tokenSymbol}..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "Min position size: {0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "Down"
@@ -8827,10 +8843,6 @@ msgstr "~5 min"
 msgid "New tier:"
 msgstr "New tier:"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "Market delistings"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "with 100x leverage"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "Close positions"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "Escrowed GMX APR"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "Vesting only available on {chainNames}. Switch networks to continue."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "Buy APE on Arbitrum with <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Depositing..."
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "Manage liquidity"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL long"
@@ -11150,6 +11162,11 @@ msgstr "GMX dashboards and analytics"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "Withdraw liquidity"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX executes trades against a dynamically balanced liquidity pool, un
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "with 100x leverage"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "Close positions"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3560,9 +3560,17 @@ msgstr "Mostrar activador de depuración de error boundary"
 msgid "Autocompound"
 msgstr "Autocompound"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "Liquidez por retirar:"
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "Gráfico de mercado"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "Después de la fecha límite, las operaciones y los retiros en estos mercados quedarán deshabilitados, y el capital que permanezca en ellos dejará de estar accesible desde la aplicación. Cierra tus posiciones y retira tu liquidez ahora."
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "Factor de financiación"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "Depósito enviado"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "Aviso final: baja de mercados"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "Este precio de activación supera el precio de liquidación actual. Tu p
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "Creando…"
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {está} other {están}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "Agregador de perpetuos"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "Solicitar Intercambio de Mercado"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "Posiciones por cerrar:"
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "Tiempo estimado hasta la liquidación"
 msgid "Mark price for the liquidation"
 msgstr "Precio de referencia de la liquidación"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets} se deshabilitarán después del 5 de agosto de 2026 a las 23:59 UTC. Cierra {positionNoun} antes de esa fecha. El colateral que permanezca en posiciones abiertas dejará de estar accesible después."
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "Todas las posiciones pertenecen al mismo monedero conectado y se muestra
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "Aprobando {tokenSymbol}..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "Tu billetera {account} aún tiene capital en mercados que se darán de baja. Estos mercados se deshabilitarán después del 5 de agosto de 2026 a las 23:59 UTC."
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "Tamaño mínimo de posición: {0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb} en proceso de baja. Cierra {positionNoun}, ya que las posiciones restantes podrían cerrarse automáticamente."
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "Caído"
@@ -8827,10 +8843,6 @@ msgstr "~5 min"
 msgid "New tier:"
 msgstr "Nuevo nivel:"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "Baja de mercados"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "con apalancamiento 100x"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Sin impacto en el precio. Precio de ejecución único para<0/>aumentar largos o reducir cortos a<1/>este tamaño."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "Cerrar posiciones"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "APR de GMX Escrowed"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "El periodo de consolidación solo está disponible en {chainNames}. Cambie de red para continuar."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools} se deshabilitarán después del 5 de agosto de 2026 a las 23:59 UTC. Retira tu liquidez antes de esa fecha. Los tokens GM que permanezcan en un pool deshabilitado dejarán de estar accesibles después."
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "Comprar APE en Arbitrum con <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Depositando…"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb} en proceso de baja. Retira tu liquidez, ya que los depósitos ya no están disponibles, o muévela a GLV para seguir generando rendimiento."
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "Gestionar liquidez"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL largo"
@@ -11150,6 +11162,11 @@ msgstr "Paneles de control y análisis de GMX"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "Retirar liquidez"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX ejecuta operaciones contra un pool de liquidez equilibrado dinám
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "con apalancamiento 100x"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Sin impacto en el precio. Precio de ejecución único para<0/>aumentar largos o reducir cortos a<1/>este tamaño."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "Cerrar posiciones"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3560,9 +3560,17 @@ msgstr "Afficher le déclencheur de débogage error boundary"
 msgid "Autocompound"
 msgstr "Recomposer automatiquement"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "Liquidité à retirer :"
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "Graphique du marché"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "Après l'échéance, les transactions et les retraits sur ces marchés seront désactivés, et le capital qui y reste ne sera plus accessible depuis l'application. Fermez vos positions et retirez votre liquidité dès maintenant."
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "Facteur de financement"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "Dépôt envoyé"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "Avis final : retrait de marchés"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "Ce prix de déclenchement dépasse le prix de liquidation actuel. Votre 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "Création en cours…"
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {est} other {sont}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "Agrégateur de perpétuels"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "Demander un échange de marché"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "Positions à fermer :"
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "Temps estimé avant la liquidation"
 msgid "Mark price for the liquidation"
 msgstr "Prix de référence pour la liquidation"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets} seront désactivés après le 5 août 2026 à 23 h 59 UTC. Fermez {positionNoun} avant cette échéance. Le collatéral laissé dans des positions ouvertes ne sera plus accessible après celle-ci."
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "Toutes les positions appartiennent au même portefeuille connecté et so
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "Approbation de {tokenSymbol}..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "Votre portefeuille {account} détient encore du capital sur des marchés en cours de retrait. Ces marchés seront désactivés après le 5 août 2026 à 23 h 59 UTC."
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "Taille de position minimale : {0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb} en cours de retrait. Fermez {positionNoun}, car les positions restantes pourraient être fermées automatiquement."
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "Hors service"
@@ -8827,10 +8843,6 @@ msgstr "~5 min"
 msgid "New tier:"
 msgstr "Nouveau palier :"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "Retrait de marchés"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "avec un effet de levier 100x"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Aucun impact sur le prix. Prix d'exécution unique pour<0/>l'augmentation des longs ou la réduction des shorts à<1/>cette taille."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "Fermer les positions"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "TAEG GMX sous séquestre"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "L'acquisition progressive n'est disponible que sur {chainNames}. Changez de réseau pour continuer."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools} seront désactivés après le 5 août 2026 à 23 h 59 UTC. Retirez votre liquidité avant cette échéance. Les tokens GM laissés dans un pool désactivé ne seront plus accessibles après celle-ci."
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "Acheter APE sur Arbitrum avec <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Dépôt en cours…"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb} en cours de retrait. Retirez votre liquidité, car les dépôts ne sont plus disponibles, ou déplacez-la vers GLV pour continuer à générer des gains."
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "Gérer la liquidité"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL long"
@@ -11150,6 +11162,11 @@ msgstr "Tableaux de bord et analytiques GMX"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "Retirer la liquidité"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX exécute les trades contre un pool de liquidité équilibré dyna
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "avec un effet de levier 100x"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Aucun impact sur le prix. Prix d'exécution unique pour<0/>l'augmentation des longs ou la réduction des shorts à<1/>cette taille."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "Fermer les positions"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMXは伝統的な注文ブックとは異なり、動的にバラン
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "100倍レバレッジで"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "価格への影響はありません。このサイズでの<0/>ロング増加またはショート減少は<1/>単一の約定価格です。"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "ポジションをクローズ"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3560,9 +3560,17 @@ msgstr "エラーバウンダリのデバッグトリガーを表示"
 msgid "Autocompound"
 msgstr "自動複利"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "出金する流動性："
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "マーケットグラフ"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "期限後、これらのマーケットでの取引と出金は無効になり、残された資金にはアプリからアクセスできなくなります。今すぐポジションをクローズし、流動性を出金してください。"
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "ファンディングファクター"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "入金が送信されました"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "最終通知：マーケットの上場廃止"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "このトリガー価格は現在の清算価格を超えています。
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "作成中…"
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {まもなく} other {まもなく}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "パーペチュアルアグリゲーター"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "マーケットスワップリクエスト"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "クローズするポジション："
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "清算までの推定時間"
 msgid "Mark price for the liquidation"
 msgstr "清算時のマーク価格"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets}は2026年8月5日23:59（UTC）以降、無効になります。それまでに{positionNoun}をクローズしてください。オープンポジションに残された担保は、それ以降アクセスできなくなります。"
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "すべてのポジションは同じ接続されたウォレットに属
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "{tokenSymbol}を承認中..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "ウォレット{account}には、上場廃止予定のマーケットにまだ資金が残っています。これらのマーケットは2026年8月5日23:59（UTC）以降、無効になります。"
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "最小ポジションサイズ: {0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets}は{verb}上場廃止されます。既存の{positionNoun}をクローズしてください。残りのポジションは自動的にクローズされる場合があります。"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "停止"
@@ -8827,10 +8843,6 @@ msgstr "約5分"
 msgid "New tier:"
 msgstr "新しいティア:"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "マーケットの上場廃止"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "100倍レバレッジで"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "価格への影響はありません。このサイズでの<0/>ロング増加またはショート減少は<1/>単一の約定価格です。"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "ポジションをクローズ"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "エスクローGMX APR"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "ベスティングは{chainNames}でのみ利用可能です。続行するにはネットワークを切り替えてください。"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools}は2026年8月5日23:59（UTC）以降、無効になります。それまでに流動性を出金してください。無効になったプールに残されたGMトークンは、それ以降アクセスできなくなります。"
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "Arbitrum で APE を <0>Camelot</0> で購入"
 msgid "Depositing..."
 msgstr "入金中…"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools}は{verb}上場廃止されます。入金ができなくなるため、流動性を出金するか、GLVに移動して収益を得続けてください。"
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "流動性を管理"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL ロング"
@@ -11150,6 +11162,11 @@ msgstr "GMX ダッシュボードと分析"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "流動性を出金"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3560,9 +3560,17 @@ msgstr "에러 바운더리 디버그 트리거 표시"
 msgid "Autocompound"
 msgstr "자동 복리"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "인출할 유동성:"
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "마켓 그래프"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "기한이 지나면 이 마켓에서 거래와 인출이 비활성화되며, 남아 있는 자금은 앱에서 접근할 수 없습니다. 지금 포지션을 종료하고 유동성을 인출하세요."
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "펀딩 계수"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "입금이 전송되었습니다"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "최종 안내: 마켓 상장 폐지"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "이 조건가는 현재 청산가를 초과합니다. 이 TP/SL 주문�
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "생성 중…"
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {곧} other {곧}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "무기한 선물 애그리게이터"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "마켓 스왑 요청"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "종료할 포지션:"
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "청산까지 예상 시간"
 msgid "Mark price for the liquidation"
 msgstr "청산 시 기준가"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets}은(는) 2026년 8월 5일 23:59(UTC) 이후 비활성화됩니다. 그 전에 {positionNoun}을(를) 종료하세요. 오픈 포지션에 남은 담보는 이후에 접근할 수 없습니다."
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "모든 포지션은 동일한 연결된 지갑에 속하며, {settlement
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "{tokenSymbol} 승인 중..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "지갑 {account}에 상장 폐지 예정인 마켓의 자금이 아직 남아 있습니다. 이 마켓들은 2026년 8월 5일 23:59(UTC) 이후 비활성화됩니다."
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "최소 포지션 크기: {0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb} 상장 폐지됩니다. 기존 {positionNoun}을(를) 종료하세요. 남은 포지션은 자동으로 종료될 수 있습니다."
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "중단"
@@ -8827,10 +8843,6 @@ msgstr "~5분"
 msgid "New tier:"
 msgstr "신규 등급:"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "마켓 상장 폐지"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "100배 레버리지로"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "가격 영향 없음. 이 규모에서 롱 증가 또는<0/>숏 감소 시 단일 체결가가<1/>적용됩니다."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "포지션 종료"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "에스크로 GMX APR"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "베스팅은 {chainNames}에서만 이용 가능합니다. 계속하려면 네트워크를 전환하십시오."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools}은(는) 2026년 8월 5일 23:59(UTC) 이후 비활성화됩니다. 그 전에 유동성을 인출하세요. 비활성화된 풀에 남은 GM 토큰은 이후에 접근할 수 없습니다."
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "<0>Camelot</0>을 통해 Arbitrum에서 APE를 구매하십시오"
 msgid "Depositing..."
 msgstr "입금 중…"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb} 상장 폐지됩니다. 더 이상 예치할 수 없으므로 유동성을 인출하거나 GLV로 옮겨 계속 수익을 얻으세요."
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "유동성 관리"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL 롱"
@@ -11150,6 +11162,11 @@ msgstr "GMX 대시보드 및 분석"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "유동성 인출"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX는 전통적인 주문장과 달리 동적으로 균형 잡힌 �
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "100배 레버리지로"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "가격 영향 없음. 이 규모에서 롱 증가 또는<0/>숏 감소 시 단일 체결가가<1/>적용됩니다."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "포지션 종료"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -3560,8 +3560,16 @@ msgstr ""
 msgid "Autocompound"
 msgstr ""
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr ""
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
+msgstr ""
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
 msgstr ""
 
 #: src/domain/referrals/utils/referralsHelper.ts
@@ -3619,6 +3627,11 @@ msgstr ""
 #: src/domain/synthetics/markets/createSourceChainDepositTxn.ts
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
+msgstr ""
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
 msgstr ""
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
@@ -3720,11 +3733,6 @@ msgstr ""
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
-msgstr ""
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
 msgstr ""
 
 #: src/pages/Jobs/Jobs.tsx
@@ -4898,6 +4906,10 @@ msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
+msgstr ""
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
 msgstr ""
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
@@ -6999,6 +7011,10 @@ msgstr ""
 msgid "Mark price for the liquidation"
 msgstr ""
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7175,6 +7191,10 @@ msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
+msgstr ""
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
 msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
@@ -8272,10 +8292,6 @@ msgstr ""
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr ""
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr ""
@@ -8827,10 +8843,6 @@ msgstr ""
 msgid "New tier:"
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr ""
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8990,6 +9002,10 @@ msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
+msgstr ""
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10596,6 +10612,10 @@ msgstr ""
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr ""
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr ""
 msgid "Depositing..."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr ""
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr ""
 msgid "Compass Labs trading simulations"
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr ""
@@ -11149,6 +11161,11 @@ msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
+msgstr ""
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
 msgstr ""
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -5436,6 +5436,7 @@ msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr ""
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr ""
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX исполняет сделки против динамическ
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "с 100x левериджем"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Нет влияния на цену. Единая цена исполнения для<0/>увеличения лонг-позиций или уменьшения шорт-позиций<1/>данного размера."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "Закрыть позиции"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -3560,9 +3560,17 @@ msgstr "Показать триггер отладки границы ошибо
 msgid "Autocompound"
 msgstr "Автореинвестирование"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "Ликвидность к выводу:"
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "График рынка"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "После истечения срока торговля и вывод средств на этих рынках будут отключены, а оставшиеся там средства станут недоступны в приложении. Закройте позиции и выведите ликвидность сейчас."
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "Фактор финансирования"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "Депозит отправлен"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "Последнее предупреждение: делистинг рынков"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "Эта цена активации находится за предел�
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "Создание…"
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {выводится} few {выводятся} many {выводятся} other {выводятся}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "Агрегатор бессрочных контрактов"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "Запрос на Рыночный Обмен"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "Позиции к закрытию:"
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "Расчётное время до ликвидации"
 msgid "Mark price for the liquidation"
 msgstr "Расчётная цена на момент ликвидации"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets} будут отключены после 5 августа 2026 года, 23:59 UTC. Закройте {positionNoun} до этого времени. Залог, оставленный в открытых позициях, после этого будет недоступен."
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "Все позиции принадлежат одному и тому ж
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "Одобрение {tokenSymbol}..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "В вашем кошельке {account} всё ещё есть средства на рынках, которые выводятся из листинга. Эти рынки будут отключены после 5 августа 2026 года, 23:59 UTC."
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "Мин размер позиции: {0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb} из листинга. Закройте {positionNoun}, оставшиеся позиции могут быть закрыты автоматически."
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "Недоступен"
@@ -8827,10 +8843,6 @@ msgstr "~5 мин"
 msgid "New tier:"
 msgstr "Новый уровень:"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "Делистинг рынков"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "с 100x левериджем"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "Нет влияния на цену. Единая цена исполнения для<0/>увеличения лонг-позиций или уменьшения шорт-позиций<1/>данного размера."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "Закрыть позиции"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "APR эскроуированного GMX"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "Вестинг доступен только на {chainNames}. Переключите сеть для продолжения."
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools} будут отключены после 5 августа 2026 года, 23:59 UTC. Выведите ликвидность до этого времени. GM-токены, оставленные в отключённом пуле, после этого будут недоступны."
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "Купить APE на Arbitrum через <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Внесение средств…"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb} из листинга. Выведите ликвидность, так как депозиты больше недоступны, или переведите её в GLV, чтобы продолжать зарабатывать."
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "Управление ликвидностью"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL лонг"
@@ -11150,6 +11162,11 @@ msgstr "Дашборды и аналитика GMX"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "Вывести ликвидность"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -3560,9 +3560,17 @@ msgstr "顯示錯誤邊界除錯觸發器"
 msgid "Autocompound"
 msgstr "自動複投"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "待提取流動性："
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "市場圖表"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "截止時間過後，這些市場將停止交易和提領，留在其中的資金將無法透過應用程式存取。請立即平倉並提取流動性。"
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "資金因子"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "存入已送出"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "最終通知：市場下架"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "此觸發價格超過目前清算價格。在此 TP/SL 訂單執行之�
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "建立中..."
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {即將} other {即將}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "永續合約聚合器"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "Request Market Swap"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "待平倉位："
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "預計清算時間"
 msgid "Mark price for the liquidation"
 msgstr "清算的標記價格"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets} 將於 2026 年 8 月 5 日 23:59（UTC）後停用。請在此之前平掉您的{positionNoun}。此後，留在未平倉位中的抵押品將無法存取。"
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "所有倉位皆屬於同一個已連接的錢包，並會一起顯示，
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "正在授權 {tokenSymbol}..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "您的錢包 {account} 仍在即將下架的市場中持有資金。這些市場將於 2026 年 8 月 5 日 23:59（UTC）後停用。"
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "最小倉位大小：{0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb}下架。請平掉您現有的{positionNoun}，剩餘倉位可能會被自動平倉。"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "離線"
@@ -8827,10 +8843,6 @@ msgstr "~5 分鐘"
 msgid "New tier:"
 msgstr "新等級："
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "市場下架"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "以 100 倍槓桿"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "無價格影響。在此規模下加倉做多<0/>或減倉做空為<1/>單一成交價格。"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "平倉"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "託管 GMX APR"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "歸屬僅在 {chainNames} 上可用。請切換網路以繼續。"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools} 將於 2026 年 8 月 5 日 23:59（UTC）後停用。請在此之前提取您的流動性。此後，留在已停用池中的 GM 代幣將無法存取。"
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "透過 <0>Camelot</0> 在 Arbitrum 上購買 APE"
 msgid "Depositing..."
 msgstr "存入中..."
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb}下架。存入已不可用，請提取您的流動性，或將其轉入 GLV 以繼續賺取收益。"
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "管理流動性"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "做多 PnL"
@@ -11150,6 +11162,11 @@ msgstr "GMX 儀表板與分析"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "提取流動性"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX 的交易是透過動態平衡的流動性池執行，不同於�
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "以 100 倍槓桿"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "無價格影響。在此規模下加倉做多<0/>或減倉做空為<1/>單一成交價格。"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "平倉"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -5436,6 +5436,7 @@ msgstr "<0>GMX 与动态平衡的流动性池执行交易，与传统订单簿�
 
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
 #: landing/src/pages/Home/RoadmapSection/RoadmapSection.tsx
+#: src/components/DelistingExitAnnouncements/DelistingBanner.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
 #: src/components/GmxAccountModal/GmxAccountModalShared.tsx
@@ -9004,6 +9005,7 @@ msgstr "使用 100 倍杠杆"
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "无价格影响。在此规模下增加做多<0/>或减少做空仓位的<1/>单一成交价格。"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
 msgid "Close positions"
 msgstr "平仓"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3560,9 +3560,17 @@ msgstr "显示错误边界调试触发器"
 msgid "Autocompound"
 msgstr "自动复利"
 
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Liquidity to withdraw:"
+msgstr "待提取流动性："
+
 #: src/components/TVChart/Chart.tsx
 msgid "Market graph"
 msgstr "市场图表"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "After the deadline, trading and withdrawals on these markets are disabled, and capital left in them won't be accessible from the app. Close your positions and withdraw your liquidity now."
+msgstr "截止时间过后，这些市场将停止交易和提现，留在其中的资金将无法通过应用访问。请立即平仓并提取流动性。"
 
 #: src/domain/referrals/utils/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
@@ -3620,6 +3628,11 @@ msgstr "资金费率因子"
 #: src/domain/synthetics/markets/createSourceChainGlvDepositTxn.ts
 msgid "Deposit sent"
 msgstr "存入已发送"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Final notice: market delistings"
+msgstr "最终通知：市场下架"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>$GMX</1> has rightfully earned its title as the perpetual trading juggernaut, and the reasons behind this recognition are manifold.</0><2><3>@GMX_IO</3> stands out as a project that's navigated its path without relying on VC backing. Remarkably, it has risen to the top, securing the No. #1 spot by TVL on Arbitrum Chain at $488.34M and an impressive overall Rank #23 on DeFiLlama... <4>see more</4></2>"
@@ -3721,11 +3734,6 @@ msgstr "此触发价格超过当前清算价格。在此 TP/SL 订单执行之�
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Creating..."
 msgstr "正在创建…"
-
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{0, plural, one {is} other {are}}"
-msgstr "{0, plural, one {即将} other {即将}}"
 
 #: src/pages/Jobs/Jobs.tsx
 msgid "GMX is not actively hiring. If you think you can contribute, email <0>jobs@gmx.io</0>."
@@ -4899,6 +4907,10 @@ msgstr "永续合约聚合器"
 #: src/components/TradeHistory/keys.ts
 msgid "Request Market Swap"
 msgstr "请求市场交换"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Positions to close:"
+msgstr "待平仓位："
 
 #: src/components/TradeBox/hooks/useCollateralInTooltipContent.tsx
 msgid "Pure {indexSymbol} short. Exposure is only from the position."
@@ -6999,6 +7011,10 @@ msgstr "预计清算时间"
 msgid "Mark price for the liquidation"
 msgstr "清算时的标记价格"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{markets} will be disabled after August 5, 2026, 23:59 UTC. Close your {positionNoun} before then. Collateral left in open positions won't be accessible after that."
+msgstr "{markets} 将于 2026 年 8 月 5 日 23:59（UTC）后停用。请在此之前平掉您的{positionNoun}。此后，留在未平仓位中的抵押品将无法访问。"
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7176,6 +7192,10 @@ msgstr "所有仓位均归属于同一已连接钱包，无论是通过 {settlem
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Approving {tokenSymbol}..."
 msgstr "正在授权 {tokenSymbol}..."
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Your wallet {account} still holds capital in markets that are being delisted. These markets will be disabled after August 5, 2026, 23:59 UTC."
+msgstr "您的钱包 {account} 仍在即将下架的市场中持有资金。这些市场将于 2026 年 8 月 5 日 23:59（UTC）后停用。"
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top PnL (%)"
@@ -8272,10 +8292,6 @@ msgstr "最小头寸大小：{0}"
 msgid "27% of protocol fees are accumulating in the Treasury and will be distributed when GMX reaches $90. Your share is based on staking power (duration × amount staked)."
 msgstr ""
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{markets} {verb} being delisted. Close your existing {positionNoun} as remaining positions may be auto-closed."
-msgstr "{markets} {verb}下架。请平掉您现有的{positionNoun}，剩余仓位可能会被自动平仓。"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Down"
 msgstr "离线"
@@ -8827,10 +8843,6 @@ msgstr "约5分钟"
 msgid "New tier:"
 msgstr "新等级："
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Market delistings"
-msgstr "市场下架"
-
 #: src/components/Referrals/affiliates/dashboard/AffiliatesStats.tsx
 #: src/components/Referrals/traders/dashboard/ReferralsTradersContent.tsx
 msgid "Last updated:"
@@ -8991,6 +9003,10 @@ msgstr "使用 100 倍杠杆"
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No price impact. Single execution price for<0/>increasing longs or decreasing shorts at<1/>this size."
 msgstr "无价格影响。在此规模下增加做多<0/>或减少做空仓位的<1/>单一成交价格。"
+
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Close positions"
+msgstr "平仓"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10596,6 +10612,10 @@ msgstr "托管 GMX 年利率"
 msgid "Vesting only available on {chainNames}. Switch networks to continue."
 msgstr "归属期仅在 {chainNames} 上可用。请切换网络以继续。"
 
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+msgid "{pools} will be disabled after August 5, 2026, 23:59 UTC. Withdraw your liquidity before then. GM tokens left in a disabled pool won't be accessible after that."
+msgstr "{pools} 将于 2026 年 8 月 5 日 23:59（UTC）后停用。请在此之前提取您的流动性。此后，留在已停用池中的 GM 代币将无法访问。"
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "esGMX rewards:"
@@ -10848,10 +10868,6 @@ msgstr "在 Arbitrum 上通过 <0>Camelot</0> 买入 APE"
 msgid "Depositing..."
 msgstr "正在存入…"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "{pools} {verb} being delisted. Withdraw your liquidity as deposits are no longer available, or move it into GLV to keep earning."
-msgstr "{pools} {verb}下架。存入已不可用，请提取您的流动性，或将其转入 GLV 以继续赚取收益。"
-
 #: src/components/Referrals/distributions/table/RebateDistributionRowDetail.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Status"
@@ -11008,10 +11024,6 @@ msgstr "GMX trading chat"
 msgid "Compass Labs trading simulations"
 msgstr "Compass Labs trading simulations"
 
-#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
-msgid "Manage liquidity"
-msgstr "管理流动性"
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL 做多"
@@ -11150,6 +11162,11 @@ msgstr "GMX 仪表盘和数据分析"
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "{column}"
 msgstr "{column}"
+
+#: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
+#: src/components/DelistingExitAnnouncements/personalDelistingAnnouncement.tsx
+msgid "Withdraw liquidity"
+msgstr "提取流动性"
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"

--- a/src/pages/Announcements/AnnouncementCard.tsx
+++ b/src/pages/Announcements/AnnouncementCard.tsx
@@ -30,6 +30,7 @@ export function AnnouncementCard({
 }: AnnouncementCardProps) {
   const date = getEventSortDate(event, uiFlags);
   const titleText = reactNodeToText(event.title);
+  const links = event.links ?? (event.link ? [event.link] : []);
 
   return (
     <article
@@ -55,18 +56,22 @@ export function AnnouncementCard({
           {event.summary !== undefined && <div>{highlightNode(event.summary, searchTokens)}</div>}
           <div>{highlightNode(event.description, searchTokens)}</div>
         </div>
-        {event.link && (
-          <Button
-            variant="secondary"
-            size="small"
-            className="self-start"
-            to={event.link.href}
-            newTab={event.link.newTab}
-            showExternalLinkArrow={false}
-          >
-            {event.link.text}
-            <UpRightArrowIcon className="size-16" />
-          </Button>
+        {links.length > 0 && (
+          <div className="flex flex-wrap gap-8">
+            {links.map((link) => (
+              <Button
+                key={`${link.href}-${link.text}`}
+                variant="secondary"
+                size="small"
+                to={link.href}
+                newTab={link.newTab}
+                showExternalLinkArrow={false}
+              >
+                {link.text}
+                <UpRightArrowIcon className="size-16" />
+              </Button>
+            ))}
+          </div>
         )}
       </div>
     </article>

--- a/src/pages/Announcements/Announcements.tsx
+++ b/src/pages/Announcements/Announcements.tsx
@@ -2,6 +2,7 @@ import { autoUpdate, flip, offset, shift, useFloating } from "@floating-ui/react
 import { Popover, Portal } from "@headlessui/react";
 import { MessageDescriptor } from "@lingui/core";
 import { msg, t, Trans } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import cx from "classnames";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
@@ -15,6 +16,8 @@ import useSearchParams from "lib/useSearchParams";
 
 import AppPageLayout from "components/AppPageLayout/AppPageLayout";
 import { DateRangeSelect } from "components/DateRangeSelect/DateRangeSelect";
+import { getPersonalDelistingAnnouncement } from "components/DelistingExitAnnouncements/personalDelistingAnnouncement";
+import { useDelistingExposure } from "components/DelistingExitAnnouncements/useDelistingExposure";
 import Loader from "components/Loader/Loader";
 import SearchInput from "components/SearchInput/SearchInput";
 import { ButtonRowScrollFadeContainer } from "components/TableScrollFade/TableScrollFade";
@@ -47,7 +50,10 @@ const TAB_LABELS: Record<AnnouncementTab, MessageDescriptor> = {
 export default function AnnouncementsPage() {
   const { id: deepLinkId } = useSearchParams<{ id?: string }>();
   const history = useHistory();
+  const { _ } = useLingui();
   const { uiFlags, isLoading, error } = useAnnouncementsUiFlags();
+  const { account, chainId, positionMarkets, positionNames, positionCount, liquidityMarkets, liquidityNames } =
+    useDelistingExposure();
 
   const [tab, setTab] = useState<AnnouncementTab>("all");
   const [search, setSearch] = useState("");
@@ -76,10 +82,26 @@ export default function AnnouncementsPage() {
   );
 
   const searchTokens = useMemo(() => tokenizeSearchQuery(search), [search]);
+  const personalDelistingAnnouncement = useMemo(
+    () =>
+      getPersonalDelistingAnnouncement(
+        account,
+        chainId,
+        {
+          positionMarkets,
+          positionNames,
+          positionCount,
+          liquidityMarkets,
+          liquidityNames,
+        },
+        _
+      ),
+    [_, account, chainId, liquidityMarkets, liquidityNames, positionCount, positionMarkets, positionNames]
+  );
 
   const allEligible = useMemo<EventData[]>(() => {
     const now = new Date();
-    return appEventsData
+    const events = appEventsData
       .filter((event) => !event.requiresOpenPosition)
       .filter((event) => isEventActiveByFlag(event, uiFlags))
       .filter((event) => hasEventStarted(event, now))
@@ -89,7 +111,9 @@ export default function AnnouncementsPage() {
         if (aTime !== bTime) return bTime - aTime;
         return a.id.localeCompare(b.id);
       });
-  }, [uiFlags]);
+
+    return personalDelistingAnnouncement ? [personalDelistingAnnouncement, ...events] : events;
+  }, [personalDelistingAnnouncement, uiFlags]);
 
   const [fromTimestamp, toTimestamp] = useNormalizeDateRange(startDate, endDate);
 


### PR DESCRIPTION
## Summary

- show red final-notice warnings for wallets with positions or liquidity in delisting markets, including the August 5, 2026 deadline
- add a personalized announcement card with affected markets and relevant exit actions
- add translated copy and coverage for the final-notice behavior

Linear: https://linear.app/gmx-io/issue/FEDEV-4132/delisting-final-notice-red-warning-with-august-5-deadline-and-personal

## Testing

- `yarn test:ci` — 1,126 passed, 14 skipped
- `yarn test:ct` — 187 passed
- `(cd sdk && yarn test:ci)` — 572 passed
