### PR TITLE
Sync release with master

### DIFF
--- a/src/domain/api/apiHealthTracker.spec.ts
+++ b/src/domain/api/apiHealthTracker.spec.ts
@@ -4,9 +4,18 @@ import type { ContractsChainId } from "sdk/configs/chains";
 
 import { ApiHealthTracker } from "./apiHealthTracker";
 
+const CONFIRMATION_MS = 3_000;
 const COOLDOWN_MS = 15_000;
 
 const tracker = ApiHealthTracker.getInstance();
+
+// Reports stale at startAt and again once the confirmation window has elapsed.
+function makeUnhealthy(chainId: ContractsChainId, startAt = 0) {
+  vi.setSystemTime(startAt);
+  tracker.reportMarketsFreshness(chainId, true);
+  vi.setSystemTime(startAt + CONFIRMATION_MS);
+  tracker.reportMarketsFreshness(chainId, true);
+}
 
 // Each test uses a distinct chainId so the shared singleton's per-chain state stays isolated.
 describe("ApiHealthTracker", () => {
@@ -27,31 +36,64 @@ describe("ApiHealthTracker", () => {
     expect(tracker.isHealthy(111 as ContractsChainId)).toBe(true);
   });
 
-  it("goes unhealthy immediately on a stale report", () => {
+  it("stays healthy on a brief stale blip", () => {
     const chainId = 222 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+
+    vi.setSystemTime(1_000);
+    tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+  });
+
+  it("goes unhealthy once staleness persists for the confirmation window", () => {
+    const chainId = 232 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(CONFIRMATION_MS - 1);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+
+    vi.setSystemTime(CONFIRMATION_MS);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(false);
+  });
+
+  it("resets the confirmation window when freshness returns before it elapses", () => {
+    const chainId = 242 as ContractsChainId;
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(1_000);
+    tracker.reportMarketsFreshness(chainId, false);
+
+    vi.setSystemTime(2_000);
+    tracker.reportMarketsFreshness(chainId, true);
+    vi.setSystemTime(4_000);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(tracker.isHealthy(chainId)).toBe(true);
+
+    vi.setSystemTime(2_000 + CONFIRMATION_MS);
     tracker.reportMarketsFreshness(chainId, true);
     expect(tracker.isHealthy(chainId)).toBe(false);
   });
 
   it("stays unhealthy while fresh but within the restore cooldown", () => {
     const chainId = 333 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainId, true);
-    vi.setSystemTime(COOLDOWN_MS - 1);
+    makeUnhealthy(chainId);
+    vi.setSystemTime(CONFIRMATION_MS + COOLDOWN_MS - 1);
     tracker.reportMarketsFreshness(chainId, false);
     expect(tracker.isHealthy(chainId)).toBe(false);
   });
 
   it("restores once freshness holds continuously for the cooldown", () => {
     const chainId = 444 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainId, true);
-    vi.setSystemTime(COOLDOWN_MS);
+    makeUnhealthy(chainId);
+    vi.setSystemTime(CONFIRMATION_MS + COOLDOWN_MS);
     tracker.reportMarketsFreshness(chainId, false);
     expect(tracker.isHealthy(chainId)).toBe(true);
   });
 
   it("resets the cooldown when staleness recurs during recovery", () => {
     const chainId = 555 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainId, true);
+    makeUnhealthy(chainId);
     vi.setSystemTime(10_000);
     tracker.reportMarketsFreshness(chainId, false);
     vi.setSystemTime(12_000);
@@ -68,22 +110,31 @@ describe("ApiHealthTracker", () => {
   it("isolates health per chain", () => {
     const chainA = 666 as ContractsChainId;
     const chainB = 777 as ContractsChainId;
-    tracker.reportMarketsFreshness(chainA, true);
+    makeUnhealthy(chainA);
     expect(tracker.isHealthy(chainA)).toBe(false);
     expect(tracker.isHealthy(chainB)).toBe(true);
   });
 
-  it("notifies subscribers on a health flip", () => {
+  it("notifies subscribers only on actual health flips", () => {
     const chainId = 888 as ContractsChainId;
     const listener = vi.fn();
     const unsubscribe = tracker.subscribe(listener);
 
     tracker.reportMarketsFreshness(chainId, true);
+    expect(listener).toHaveBeenCalledTimes(0);
+
+    vi.setSystemTime(CONFIRMATION_MS);
+    tracker.reportMarketsFreshness(chainId, true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(CONFIRMATION_MS + 1_000);
+    tracker.reportMarketsFreshness(chainId, true);
     expect(listener).toHaveBeenCalledTimes(1);
 
     unsubscribe();
-    vi.setSystemTime(COOLDOWN_MS);
+    vi.setSystemTime(CONFIRMATION_MS + 1_000 + COOLDOWN_MS);
     tracker.reportMarketsFreshness(chainId, false);
+    expect(tracker.isHealthy(chainId)).toBe(true);
     expect(listener).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/domain/api/apiHealthTracker.ts
+++ b/src/domain/api/apiHealthTracker.ts
@@ -2,10 +2,13 @@ import { useSyncExternalStore } from "react";
 
 import type { ContractsChainId } from "sdk/configs/chains";
 
+// A single stale render (e.g. right after a tab refocus, before the refetch lands) must not tear
+// down the api: staleness has to persist this long before the chain flips unhealthy.
+const UNHEALTHY_CONFIRMATION_MS = 3_000;
 // Require continuous freshness for this long before restoring, to avoid flapping at the threshold.
 const RESTORE_COOLDOWN_MS = 15_000;
 
-type ChainHealth = { healthy: boolean; lastStaleAt: number };
+type ChainHealth = { healthy: boolean; lastStaleAt: number; staleSince: number | undefined };
 
 export class ApiHealthTracker {
   private static instance: ApiHealthTracker | null = null;
@@ -22,19 +25,26 @@ export class ApiHealthTracker {
 
   reportMarketsFreshness(chainId: ContractsChainId, isStale: boolean): void {
     const now = Date.now();
-    const current = this.healthByChain.get(chainId) ?? { healthy: true, lastStaleAt: 0 };
+    const current = this.healthByChain.get(chainId) ?? { healthy: true, lastStaleAt: 0, staleSince: undefined };
 
     if (isStale) {
-      this.healthByChain.set(chainId, { healthy: false, lastStaleAt: now });
-      if (current.healthy) {
+      const staleSince = current.staleSince ?? now;
+      const healthy = current.healthy && now - staleSince < UNHEALTHY_CONFIRMATION_MS;
+      this.healthByChain.set(chainId, { healthy, lastStaleAt: now, staleSince });
+      if (current.healthy && !healthy) {
         this.emit();
       }
       return;
     }
 
     if (!current.healthy && now - current.lastStaleAt >= RESTORE_COOLDOWN_MS) {
-      this.healthByChain.set(chainId, { healthy: true, lastStaleAt: 0 });
+      this.healthByChain.set(chainId, { healthy: true, lastStaleAt: 0, staleSince: undefined });
       this.emit();
+      return;
+    }
+
+    if (current.staleSince !== undefined) {
+      this.healthByChain.set(chainId, { ...current, staleSince: undefined });
     }
   }
 

--- a/src/domain/synthetics/common/useApiDataRequest.spec.tsx
+++ b/src/domain/synthetics/common/useApiDataRequest.spec.tsx
@@ -11,26 +11,35 @@ type ApiDataRequestResult = ReturnType<typeof useApiDataRequest<{ ok: boolean }>
 
 const swrKey = ["apiDataRequestTest"];
 
+type TestComponentProps = {
+  enabled?: boolean;
+  requestKey?: unknown[];
+};
+
 function renderApiDataRequest(fetcher: () => Promise<{ ok: boolean }>, cache = new Map()) {
   let latestState: ApiDataRequestResult | undefined;
 
-  function TestComponent() {
-    latestState = useApiDataRequest(42161, swrKey, fetcher, FreshnessMetricId.ApiMarketsInfo, {
+  function TestComponent({ enabled, requestKey }: TestComponentProps) {
+    latestState = useApiDataRequest(42161, requestKey ?? swrKey, fetcher, FreshnessMetricId.ApiMarketsInfo, {
       refreshInterval: 1000,
       apiStaleMs: 500,
+      enabled,
     });
     return null;
   }
 
-  render(
-    // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-    <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>
-      <TestComponent />
+  const swrConfig = { provider: () => cache, dedupingInterval: 0 };
+  const renderElement = (props: TestComponentProps = {}) => (
+    <SWRConfig value={swrConfig}>
+      <TestComponent {...props} />
     </SWRConfig>
   );
 
+  const result = render(renderElement());
+
   return {
     getState: () => latestState!,
+    rerenderWith: (props: TestComponentProps) => result.rerender(renderElement(props)),
   };
 }
 
@@ -74,6 +83,32 @@ describe("useApiDataRequest", () => {
     });
 
     expect(rendered.getState().isStale).toBe(true);
+  });
+
+  it("retains the last response while the request is disabled and drops it when the key changes", async () => {
+    const fetcher = vi.fn(() => Promise.resolve({ ok: true }));
+    const rendered = renderApiDataRequest(fetcher);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(rendered.getState().data).toEqual({ ok: true });
+
+    rendered.rerenderWith({ enabled: false });
+
+    expect(rendered.getState().data).toEqual({ ok: true });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(rendered.getState().data).toEqual({ ok: true });
+    expect(rendered.getState().isStale).toBe(true);
+
+    rendered.rerenderWith({ enabled: false, requestKey: ["apiDataRequestTest", "other-account"] });
+
+    expect(rendered.getState().data).toBeUndefined();
   });
 
   it("marks cached stale data as stale on the first render", () => {

--- a/src/domain/synthetics/common/useApiDataRequest.spec.tsx
+++ b/src/domain/synthetics/common/useApiDataRequest.spec.tsx
@@ -11,35 +11,26 @@ type ApiDataRequestResult = ReturnType<typeof useApiDataRequest<{ ok: boolean }>
 
 const swrKey = ["apiDataRequestTest"];
 
-type TestComponentProps = {
-  enabled?: boolean;
-  requestKey?: unknown[];
-};
-
 function renderApiDataRequest(fetcher: () => Promise<{ ok: boolean }>, cache = new Map()) {
   let latestState: ApiDataRequestResult | undefined;
 
-  function TestComponent({ enabled, requestKey }: TestComponentProps) {
-    latestState = useApiDataRequest(42161, requestKey ?? swrKey, fetcher, FreshnessMetricId.ApiMarketsInfo, {
+  function TestComponent() {
+    latestState = useApiDataRequest(42161, swrKey, fetcher, FreshnessMetricId.ApiMarketsInfo, {
       refreshInterval: 1000,
       apiStaleMs: 500,
-      enabled,
     });
     return null;
   }
 
-  const swrConfig = { provider: () => cache, dedupingInterval: 0 };
-  const renderElement = (props: TestComponentProps = {}) => (
-    <SWRConfig value={swrConfig}>
-      <TestComponent {...props} />
+  render(
+    // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+    <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>
+      <TestComponent />
     </SWRConfig>
   );
 
-  const result = render(renderElement());
-
   return {
     getState: () => latestState!,
-    rerenderWith: (props: TestComponentProps) => result.rerender(renderElement(props)),
   };
 }
 
@@ -83,32 +74,6 @@ describe("useApiDataRequest", () => {
     });
 
     expect(rendered.getState().isStale).toBe(true);
-  });
-
-  it("retains the last response while the request is disabled and drops it when the key changes", async () => {
-    const fetcher = vi.fn(() => Promise.resolve({ ok: true }));
-    const rendered = renderApiDataRequest(fetcher);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
-
-    expect(rendered.getState().data).toEqual({ ok: true });
-
-    rendered.rerenderWith({ enabled: false });
-
-    expect(rendered.getState().data).toEqual({ ok: true });
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-
-    expect(rendered.getState().data).toEqual({ ok: true });
-    expect(rendered.getState().isStale).toBe(true);
-
-    rendered.rerenderWith({ enabled: false, requestKey: ["apiDataRequestTest", "other-account"] });
-
-    expect(rendered.getState().data).toBeUndefined();
   });
 
   it("marks cached stale data as stale on the first render", () => {

--- a/src/domain/synthetics/common/useApiDataRequest.ts
+++ b/src/domain/synthetics/common/useApiDataRequest.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useRef } from "react";
-import useSWR, { unstable_serialize } from "swr";
+import useSWR from "swr";
 import type { Key } from "swr";
 
 import { FreshnessMetricId } from "lib/metrics";
@@ -20,7 +20,6 @@ type ApiDataResponse<T> = {
 type UseApiDataRequestOptions = {
   refreshInterval?: number;
   apiStaleMs?: number;
-  enabled?: boolean;
 };
 
 export function useApiDataRequest<T>(
@@ -32,29 +31,17 @@ export function useApiDataRequest<T>(
 ) {
   const refreshInterval = options?.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
   const apiStaleMs = options?.apiStaleMs ?? DEFAULT_API_STALE_MS;
-  const enabled = options?.enabled ?? true;
 
   const mountedAtRef = useRef<number | undefined>(mountedAtCache.get(chainId));
 
   const { data: response, error } = useSWR<ApiDataResponse<T>>(
-    enabled ? swrKey : null,
+    swrKey,
     async () => {
       const data = await fetcher();
       return { data, updatedAt: Date.now() };
     },
     { refreshInterval }
   );
-
-  // Keep the last response while the request is disabled (e.g. api-health flips) so consumers can
-  // keep rendering it instead of flashing a loading state; dropped when the logical key changes.
-  const serializedKey = swrKey ? unstable_serialize(swrKey) : undefined;
-  const retainedRef = useRef<{ key: string; response: ApiDataResponse<T> } | undefined>(undefined);
-  if (response && serializedKey) {
-    retainedRef.current = { key: serializedKey, response };
-  }
-  const effectiveResponse =
-    response ??
-    (serializedKey && retainedRef.current?.key === serializedKey ? retainedRef.current.response : undefined);
 
   useEffect(() => {
     if (!mountedAtRef.current) {
@@ -67,7 +54,7 @@ export function useApiDataRequest<T>(
   const [, forceStaleCheck] = useReducer((tick: number) => tick + 1, 0);
 
   useEffect(() => {
-    if (!effectiveResponse?.updatedAt) {
+    if (!response?.updatedAt) {
       return;
     }
 
@@ -75,7 +62,7 @@ export function useApiDataRequest<T>(
       forceStaleCheck();
     }, refreshInterval);
     return () => clearInterval(intervalId);
-  }, [effectiveResponse?.updatedAt, refreshInterval, apiStaleMs]);
+  }, [response?.updatedAt, refreshInterval, apiStaleMs]);
 
   useEffect(() => {
     if (response?.data) {
@@ -83,14 +70,14 @@ export function useApiDataRequest<T>(
     }
   }, [chainId, freshnessMetricId, response?.data]);
 
-  const isCurrentResponseStale = effectiveResponse?.updatedAt
-    ? Date.now() - effectiveResponse.updatedAt > refreshInterval + apiStaleMs
+  const isCurrentResponseStale = response?.updatedAt
+    ? Date.now() - response.updatedAt > refreshInterval + apiStaleMs
     : false;
 
   return {
-    data: effectiveResponse?.data,
+    data: response?.data,
     mountedAt: mountedAtRef.current,
-    updatedAt: effectiveResponse?.updatedAt,
+    updatedAt: response?.updatedAt,
     isStale: isCurrentResponseStale,
     error,
   };

--- a/src/domain/synthetics/common/useApiDataRequest.ts
+++ b/src/domain/synthetics/common/useApiDataRequest.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useRef } from "react";
-import useSWR from "swr";
+import useSWR, { unstable_serialize } from "swr";
 import type { Key } from "swr";
 
 import { FreshnessMetricId } from "lib/metrics";
@@ -20,6 +20,7 @@ type ApiDataResponse<T> = {
 type UseApiDataRequestOptions = {
   refreshInterval?: number;
   apiStaleMs?: number;
+  enabled?: boolean;
 };
 
 export function useApiDataRequest<T>(
@@ -31,17 +32,29 @@ export function useApiDataRequest<T>(
 ) {
   const refreshInterval = options?.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
   const apiStaleMs = options?.apiStaleMs ?? DEFAULT_API_STALE_MS;
+  const enabled = options?.enabled ?? true;
 
   const mountedAtRef = useRef<number | undefined>(mountedAtCache.get(chainId));
 
   const { data: response, error } = useSWR<ApiDataResponse<T>>(
-    swrKey,
+    enabled ? swrKey : null,
     async () => {
       const data = await fetcher();
       return { data, updatedAt: Date.now() };
     },
     { refreshInterval }
   );
+
+  // Keep the last response while the request is disabled (e.g. api-health flips) so consumers can
+  // keep rendering it instead of flashing a loading state; dropped when the logical key changes.
+  const serializedKey = swrKey ? unstable_serialize(swrKey) : undefined;
+  const retainedRef = useRef<{ key: string; response: ApiDataResponse<T> } | undefined>(undefined);
+  if (response && serializedKey) {
+    retainedRef.current = { key: serializedKey, response };
+  }
+  const effectiveResponse =
+    response ??
+    (serializedKey && retainedRef.current?.key === serializedKey ? retainedRef.current.response : undefined);
 
   useEffect(() => {
     if (!mountedAtRef.current) {
@@ -54,7 +67,7 @@ export function useApiDataRequest<T>(
   const [, forceStaleCheck] = useReducer((tick: number) => tick + 1, 0);
 
   useEffect(() => {
-    if (!response?.updatedAt) {
+    if (!effectiveResponse?.updatedAt) {
       return;
     }
 
@@ -62,7 +75,7 @@ export function useApiDataRequest<T>(
       forceStaleCheck();
     }, refreshInterval);
     return () => clearInterval(intervalId);
-  }, [response?.updatedAt, refreshInterval, apiStaleMs]);
+  }, [effectiveResponse?.updatedAt, refreshInterval, apiStaleMs]);
 
   useEffect(() => {
     if (response?.data) {
@@ -70,14 +83,14 @@ export function useApiDataRequest<T>(
     }
   }, [chainId, freshnessMetricId, response?.data]);
 
-  const isCurrentResponseStale = response?.updatedAt
-    ? Date.now() - response.updatedAt > refreshInterval + apiStaleMs
+  const isCurrentResponseStale = effectiveResponse?.updatedAt
+    ? Date.now() - effectiveResponse.updatedAt > refreshInterval + apiStaleMs
     : false;
 
   return {
-    data: response?.data,
+    data: effectiveResponse?.data,
     mountedAt: mountedAtRef.current,
-    updatedAt: response?.updatedAt,
+    updatedAt: effectiveResponse?.updatedAt,
     isStale: isCurrentResponseStale,
     error,
   };

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ContractsChainId } from "sdk/configs/chains";
 import type { RawMarketConfig, RawMarketValues } from "sdk/utils/markets/types";
 
-import { MARKETS_STALE_THRESHOLD_MS, hasStaleMarketValues } from "./useApiMarketsInfoRequest";
+import {
+  MARKETS_STALE_THRESHOLD_MS,
+  getIsValuesSnapshotFrozen,
+  hasStaleMarketValues,
+  trackValuesSnapshot,
+} from "./useApiMarketsInfoRequest";
 
 function value(marketTokenAddress: string, updatedAt: number | null): RawMarketValues {
   return { marketTokenAddress, updatedAt } as RawMarketValues;
@@ -29,12 +35,30 @@ describe("hasStaleMarketValues", () => {
     expect(hasStaleMarketValues([config("0xa")], [value("0xa", 1_000_000 - 1_000)], new Set())).toBe(false);
   });
 
-  it("flags an enabled market older than the threshold as stale", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1_000_000);
+  it("flags an enabled market lagging the newest market beyond the threshold as stale", () => {
+    const newest = 1_000_000;
     expect(
-      hasStaleMarketValues([config("0xa")], [value("0xa", 1_000_000 - MARKETS_STALE_THRESHOLD_MS - 1)], new Set())
+      hasStaleMarketValues(
+        [config("0xa"), config("0xlagging")],
+        [value("0xa", newest), value("0xlagging", newest - MARKETS_STALE_THRESHOLD_MS - 1)],
+        new Set()
+      )
     ).toBe(true);
+    expect(
+      hasStaleMarketValues(
+        [config("0xa"), config("0xlagging")],
+        [value("0xa", newest), value("0xlagging", newest - MARKETS_STALE_THRESHOLD_MS)],
+        new Set()
+      )
+    ).toBe(false);
+  });
+
+  it("is immune to client clock skew", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(50_000_000);
+    expect(
+      hasStaleMarketValues([config("0xa"), config("0xb")], [value("0xa", 1_000), value("0xb", 900)], new Set())
+    ).toBe(false);
   });
 
   it("flags an enabled market with null updatedAt as stale", () => {
@@ -79,5 +103,51 @@ describe("hasStaleMarketValues", () => {
     expect(hasStaleMarketValues([config("0xa"), config("0xmissing", true)], [value("0xa", 1_000_000)], disabled)).toBe(
       false
     );
+  });
+});
+
+describe("values snapshot freshness", () => {
+  const chainId = 42161 as ContractsChainId;
+
+  it("is not frozen while re-evaluating the same response", () => {
+    const snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000)).toBe(false);
+  });
+
+  it("freezes when responses keep arriving but the newest updatedAt never moves", () => {
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    snapshot = trackValuesSnapshot(snapshot, chainId, [value("0xa", 1_000)], 5_000 + MARKETS_STALE_THRESHOLD_MS);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS)).toBe(false);
+
+    snapshot = trackValuesSnapshot(snapshot, chainId, [value("0xa", 1_000)], 5_000 + MARKETS_STALE_THRESHOLD_MS + 1);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS + 1)).toBe(true);
+  });
+
+  it("unfreezes as soon as the newest updatedAt changes", () => {
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    snapshot = trackValuesSnapshot(snapshot, chainId, [value("0xa", 2_000)], 5_000 + MARKETS_STALE_THRESHOLD_MS + 1);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS + 1)).toBe(false);
+  });
+
+  it("resets when the chain changes", () => {
+    const otherChainId = 43114 as ContractsChainId;
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    snapshot = trackValuesSnapshot(
+      snapshot,
+      otherChainId,
+      [value("0xa", 1_000)],
+      5_000 + MARKETS_STALE_THRESHOLD_MS + 1
+    );
+    expect(snapshot?.chainId).toBe(otherChainId);
+    expect(getIsValuesSnapshotFrozen(snapshot, 5_000 + MARKETS_STALE_THRESHOLD_MS + 1)).toBe(false);
+  });
+
+  it("keeps the snapshot for the same chain while data is temporarily missing", () => {
+    let snapshot = trackValuesSnapshot(undefined, chainId, [value("0xa", 1_000)], 5_000);
+    const kept = trackValuesSnapshot(snapshot, chainId, undefined, undefined);
+    expect(kept).toBe(snapshot);
+
+    const dropped = trackValuesSnapshot(snapshot, 43114 as ContractsChainId, undefined, undefined);
+    expect(dropped).toBeUndefined();
   });
 });

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
@@ -17,6 +17,20 @@ function getApiMarketsConfigRequestKey(chainId: ContractsChainId) {
   return ["apiMarketsConfigRequest", chainId] as const;
 }
 
+export function getNewestValuesUpdatedAt(valuesData: RawMarketValues[] | undefined): number | undefined {
+  let newest: number | undefined = undefined;
+
+  for (const value of valuesData ?? []) {
+    if (value.updatedAt != null && (newest === undefined || value.updatedAt > newest)) {
+      newest = value.updatedAt;
+    }
+  }
+
+  return newest;
+}
+
+// Server updatedAt must never be compared to the client clock (skew would misfire): a market is
+// stale when it lags the newest market of the same response beyond the threshold.
 export function hasStaleMarketValues(
   configData: RawMarketConfig[] | undefined,
   valuesData: RawMarketValues[] | undefined,
@@ -26,7 +40,7 @@ export function hasStaleMarketValues(
     return false;
   }
 
-  const now = Date.now();
+  const newestUpdatedAt = getNewestValuesUpdatedAt(valuesData);
   const valuesByAddress = new Map(valuesData.map((v) => [v.marketTokenAddress, v]));
 
   for (const config of configData) {
@@ -36,12 +50,52 @@ export function hasStaleMarketValues(
 
     const value = valuesByAddress.get(config.marketTokenAddress);
 
-    if (!value || value.updatedAt == null || now - value.updatedAt > MARKETS_STALE_THRESHOLD_MS) {
+    if (!value || value.updatedAt == null) {
+      return true;
+    }
+
+    if (newestUpdatedAt !== undefined && newestUpdatedAt - value.updatedAt > MARKETS_STALE_THRESHOLD_MS) {
       return true;
     }
   }
 
   return false;
+}
+
+export type MarketValuesSnapshot = {
+  chainId: ContractsChainId;
+  newestUpdatedAt: number;
+  receivedAt: number;
+};
+
+export function trackValuesSnapshot(
+  prev: MarketValuesSnapshot | undefined,
+  chainId: ContractsChainId,
+  valuesData: RawMarketValues[] | undefined,
+  receivedAt: number | undefined
+): MarketValuesSnapshot | undefined {
+  const newestUpdatedAt = getNewestValuesUpdatedAt(valuesData);
+
+  if (newestUpdatedAt === undefined || receivedAt === undefined) {
+    return prev?.chainId === chainId ? prev : undefined;
+  }
+
+  if (!prev || prev.chainId !== chainId || prev.newestUpdatedAt !== newestUpdatedAt) {
+    return { chainId, newestUpdatedAt, receivedAt };
+  }
+
+  return prev;
+}
+
+// A backend whose puller died keeps serving the same snapshot: responses keep arriving but the
+// newest server updatedAt never moves. Compares client receipt times only, so clock skew is moot.
+export function getIsValuesSnapshotFrozen(
+  snapshot: MarketValuesSnapshot | undefined,
+  receivedAt: number | undefined
+): boolean {
+  return (
+    snapshot !== undefined && receivedAt !== undefined && receivedAt - snapshot.receivedAt > MARKETS_STALE_THRESHOLD_MS
+  );
 }
 
 export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = true }: { enabled?: boolean } = {}) {
@@ -61,6 +115,7 @@ export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = 
 
   const {
     data: valuesData,
+    updatedAt: valuesUpdatedAt,
     isStale: isValuesStale,
     error: valuesError,
   } = useApiDataRequest<RawMarketValues[]>(
@@ -104,7 +159,12 @@ export function useApiMarketsInfoRequest(chainId: ContractsChainId, { enabled = 
     [configData]
   );
 
-  const isMarketsDataStale = hasStaleMarketValues(configData, valuesData, disabledMarketAddresses);
+  const valuesSnapshotRef = useRef<MarketValuesSnapshot | undefined>(undefined);
+  valuesSnapshotRef.current = trackValuesSnapshot(valuesSnapshotRef.current, chainId, valuesData, valuesUpdatedAt);
+
+  const isMarketsDataStale =
+    hasStaleMarketValues(configData, valuesData, disabledMarketAddresses) ||
+    getIsValuesSnapshotFrozen(valuesSnapshotRef.current, valuesUpdatedAt);
   if (configData) {
     ApiHealthTracker.getInstance().reportMarketsFreshness(chainId, isMarketsDataStale);
   }

--- a/src/domain/synthetics/positions/useApiPositionsInfoRequest.ts
+++ b/src/domain/synthetics/positions/useApiPositionsInfoRequest.ts
@@ -18,7 +18,7 @@ export function useApiPositionsInfoRequest(
 
   const { data: positionsInfoData, ...rest } = useApiDataRequest<ApiPositionsInfoData>(
     chainId,
-    enabled && account && sdk ? ["apiPositionsInfoRequest", chainId, account] : null,
+    account && sdk ? ["apiPositionsInfoRequest", chainId, account] : null,
     async () => {
       const positions: ApiPositionInfo[] = await sdk!.fetchPositionsInfo({
         address: account!,
@@ -26,7 +26,8 @@ export function useApiPositionsInfoRequest(
       });
       return keyBy(positions, "key");
     },
-    FreshnessMetricId.ApiPositionsInfo
+    FreshnessMetricId.ApiPositionsInfo,
+    { enabled }
   );
 
   return {

--- a/src/domain/synthetics/positions/useApiPositionsInfoRequest.ts
+++ b/src/domain/synthetics/positions/useApiPositionsInfoRequest.ts
@@ -18,7 +18,7 @@ export function useApiPositionsInfoRequest(
 
   const { data: positionsInfoData, ...rest } = useApiDataRequest<ApiPositionsInfoData>(
     chainId,
-    account && sdk ? ["apiPositionsInfoRequest", chainId, account] : null,
+    enabled && account && sdk ? ["apiPositionsInfoRequest", chainId, account] : null,
     async () => {
       const positions: ApiPositionInfo[] = await sdk!.fetchPositionsInfo({
         address: account!,
@@ -26,8 +26,7 @@ export function useApiPositionsInfoRequest(
       });
       return keyBy(positions, "key");
     },
-    FreshnessMetricId.ApiPositionsInfo,
-    { enabled }
+    FreshnessMetricId.ApiPositionsInfo
   );
 
   return {

--- a/src/domain/synthetics/positions/usePositionsInfo.ts
+++ b/src/domain/synthetics/positions/usePositionsInfo.ts
@@ -19,6 +19,10 @@ import { getAllPossiblePositionsKeys, useOptimisticPositionsInfo } from "./useOp
 import { usePositions } from "./usePositions";
 import { usePositionsConstantsRequest } from "./usePositionsConstants";
 
+// Wait this long for API positions before warming the RPC backup. The API is usually fast and a
+// cold RPC detour is slower than waiting, so we give API a grace window before paying RPC load.
+const RPC_WARMUP_DELAY_MS = 5_000;
+
 function composeApiPositionInfo(apiPosition: ApiPositionInfo, marketsInfoData: MarketsInfoData): PositionInfo | null {
   const marketInfo = getByKey(marketsInfoData, apiPosition.marketAddress);
 
@@ -80,6 +84,7 @@ export function usePositionsInfoRequest(
     apiError,
     isEnabled: Boolean(account),
     resetKey: account,
+    initialFallbackTimeout: RPC_WARMUP_DELAY_MS,
   });
 
   const { positionsData, error: positionsError } = usePositions(chainId, {
@@ -211,8 +216,12 @@ export function usePositionsInfoRequest(
   ]);
 
   const fallbackPositionsInfoData = rpcPositionsInfoData;
+  // Prefer API data that exists (including data retained across api-health flips) and hand over to
+  // RPC only once the fallback actually has data — a rendered list must never fall back to loading.
   const shouldUseApiPositionsInfoData =
-    isApiSdkEnabled && Boolean(recomputedApiPositionsInfoData) && (!shouldFallbackToRpc || !fallbackPositionsInfoData);
+    Boolean(apiPositionsInfoData) &&
+    Boolean(recomputedApiPositionsInfoData) &&
+    (!shouldFallbackToRpc || !fallbackPositionsInfoData);
 
   const positionsInfoData = useMemo(() => {
     if (shouldUseApiPositionsInfoData) {

--- a/src/domain/synthetics/positions/usePositionsInfo.ts
+++ b/src/domain/synthetics/positions/usePositionsInfo.ts
@@ -19,10 +19,6 @@ import { getAllPossiblePositionsKeys, useOptimisticPositionsInfo } from "./useOp
 import { usePositions } from "./usePositions";
 import { usePositionsConstantsRequest } from "./usePositionsConstants";
 
-// Wait this long for API positions before warming the RPC backup. The API is usually fast and a
-// cold RPC detour is slower than waiting, so we give API a grace window before paying RPC load.
-const RPC_WARMUP_DELAY_MS = 5_000;
-
 function composeApiPositionInfo(apiPosition: ApiPositionInfo, marketsInfoData: MarketsInfoData): PositionInfo | null {
   const marketInfo = getByKey(marketsInfoData, apiPosition.marketAddress);
 
@@ -84,7 +80,6 @@ export function usePositionsInfoRequest(
     apiError,
     isEnabled: Boolean(account),
     resetKey: account,
-    initialFallbackTimeout: RPC_WARMUP_DELAY_MS,
   });
 
   const { positionsData, error: positionsError } = usePositions(chainId, {
@@ -216,12 +211,8 @@ export function usePositionsInfoRequest(
   ]);
 
   const fallbackPositionsInfoData = rpcPositionsInfoData;
-  // Prefer API data that exists (including data retained across api-health flips) and hand over to
-  // RPC only once the fallback actually has data — a rendered list must never fall back to loading.
   const shouldUseApiPositionsInfoData =
-    Boolean(apiPositionsInfoData) &&
-    Boolean(recomputedApiPositionsInfoData) &&
-    (!shouldFallbackToRpc || !fallbackPositionsInfoData);
+    isApiSdkEnabled && Boolean(recomputedApiPositionsInfoData) && (!shouldFallbackToRpc || !fallbackPositionsInfoData);
 
   const positionsInfoData = useMemo(() => {
     if (shouldUseApiPositionsInfoData) {


### PR DESCRIPTION
## Summary

- Sync `master` into `release`.
- Resolve the markets API freshness conflicts by preserving `release`'s v2.2c payload-completeness checks while applying `master`'s clock-skew-safe timestamp comparison and frozen-snapshot detection.
- Preserve the API health debounce and cached positions behavior introduced on `master`.
