### PR TITLE
Fix pool details routing

### DIFF
--- a/src/pages/PoolsDetails/PoolsDetails.tsx
+++ b/src/pages/PoolsDetails/PoolsDetails.tsx
@@ -13,11 +13,12 @@ import {
   selectGlvAndMarketsInfoData,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
-import { isGlvInfo } from "domain/synthetics/markets/glv";
+import { isGlvAddress, isGlvInfo } from "domain/synthetics/markets/glv";
 import { getTokenData } from "domain/synthetics/tokens";
 import { useBreakpoints } from "lib/useBreakpoints";
 import useRouteQuery from "lib/useRouteQuery";
 import { usePoolsIsMobilePage } from "pages/Pools/usePoolsIsMobilePage";
+import { isMarketTokenAddress } from "sdk/configs/markets";
 
 import AppPageLayout from "components/AppPageLayout/AppPageLayout";
 import { BreadcrumbItem, Breadcrumbs } from "components/Breadcrumbs/Breadcrumbs";
@@ -44,9 +45,13 @@ export function PoolsDetails() {
   const glvOrMarketAddress = useSelector(selectPoolsDetailsGlvOrMarketAddress);
   const glvOrMarketInfo = useSelector(selectPoolsDetailsGlvOrMarketInfo);
   const searchParams = useRouteQuery();
+  const requestedMarketAddress = searchParams.get("market");
   const requestedChainId = Number(searchParams.get("chainId"));
   const isChainChangePending =
     CONTRACTS_CHAIN_IDS.includes(requestedChainId as ContractsChainId) && requestedChainId !== chainId;
+  const isValidMarketAddress =
+    requestedMarketAddress !== null &&
+    (isMarketTokenAddress(chainId, requestedMarketAddress) || isGlvAddress(chainId, requestedMarketAddress));
 
   const marketToken = getTokenData(depositMarketTokensData, glvOrMarketAddress);
 
@@ -60,7 +65,7 @@ export function PoolsDetails() {
 
   const { isDesktop: isInCurtain } = useBreakpoints();
 
-  if (!glvOrMarketAddress && !isChainChangePending) {
+  if (!isValidMarketAddress && !isChainChangePending) {
     return <Redirect to="/pools" />;
   }
 


### PR DESCRIPTION
## Summary

- validate the requested GM or GLV address directly before redirecting from pool details
- prevent valid pool links from bouncing back to the pools list during the route context transition
- preserve the redirect for missing or invalid market parameters

## Root cause

The details-page redirect depended on the provider-derived pool address. During in-app navigation from the pools list, that selector briefly retained the previous route state and returned `undefined`, so the page redirected before the details context could update.

## Verification

- locally verified GM and GLV list-to-details navigation
- locally verified missing and invalid market parameters redirect to `/pools`
- ESLint and Prettier checks
- TypeScript check
- production build
- app unit suite: 1,163 tests passed
- component suite: 187 tests passed
- SDK suite: 572 tests passed
