### PR TITLE
Fix referral code and used referral code instances FEDEV-4108

### DIFF
--- a/src/components/ShareModal/__tests__/useShareReferralCodeState.spec.tsx
+++ b/src/components/ShareModal/__tests__/useShareReferralCodeState.spec.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ARBITRUM } from "config/chains";
+import type { AffiliateCodesState } from "domain/referrals";
+
+import { useShareReferralCodeState } from "../useShareReferralCodeState";
+
+const mocks = vi.hoisted(() => ({
+  affiliateCodes: { code: null, success: false } as AffiliateCodesState,
+  usedReferralCode: undefined as string | undefined,
+  setStoredValue: vi.fn(),
+}));
+
+vi.mock("domain/referrals", () => ({
+  useAffiliateCodes: () => mocks.affiliateCodes,
+  useUserReferralCode: () => ({ userReferralCodeString: mocks.usedReferralCode }),
+}));
+
+vi.mock("lib/localStorage", () => ({
+  useLocalStorageSerializeKey: () => [false, mocks.setStoredValue],
+}));
+
+vi.mock("lib/userAnalytics", () => ({
+  userAnalytics: { pushEvent: vi.fn() },
+}));
+
+type HookResult = ReturnType<typeof useShareReferralCodeState>;
+
+function Harness({ onResult }: { onResult: (result: HookResult) => void }) {
+  onResult(
+    useShareReferralCodeState({
+      chainId: ARBITRUM,
+      account: "0x123",
+      isOpen: true,
+      source: "positions-list",
+    })
+  );
+  return null;
+}
+
+function setup() {
+  let result!: HookResult;
+  render(<Harness onResult={(nextResult) => (result = nextResult)} />);
+  return () => result;
+}
+
+describe("useShareReferralCodeState", () => {
+  beforeEach(() => {
+    mocks.affiliateCodes = { code: null, success: false };
+    mocks.usedReferralCode = undefined;
+  });
+
+  afterEach(cleanup);
+
+  it("does not show a used code while owned-code lookup is pending", () => {
+    mocks.usedReferralCode = "sonicash";
+
+    const result = setup()();
+
+    expect(result.code).toBeUndefined();
+    expect(result.referralCodeOwnerKind).toBeUndefined();
+    expect(result.shareAffiliateCode).toEqual({ code: null, success: false });
+    expect(result.shouldPromptToCreateReferralCode).toBe(false);
+  });
+
+  it("uses the currently owned code instead of the active discount code", () => {
+    mocks.affiliateCodes = { code: "test_12", success: true };
+    mocks.usedReferralCode = "sonicash";
+
+    const result = setup()();
+
+    expect(result.code).toBe("test_12");
+    expect(result.referralCodeOwnerKind).toBe("created");
+    expect(result.shareAffiliateCode).toEqual({ code: "test_12", success: true });
+  });
+
+  it("uses a regular active code only after confirming there is no owned code", () => {
+    mocks.affiliateCodes = { code: null, success: true };
+    mocks.usedReferralCode = "sonicash";
+
+    const result = setup()();
+
+    expect(result.code).toBe("sonicash");
+    expect(result.referralCodeOwnerKind).toBe("used");
+    expect(result.shareAffiliateCode).toEqual({ code: "sonicash", success: true });
+  });
+
+  it.each(["EARNED_TRADER_DISCOUNT_5", "EARNED_TRADER_DISCOUNT_10", "DIRECT_GMX_DISCOUNT_5", "DIRECT_GMX_DISCOUNT_10"])(
+    "hides protocol-assigned code %s",
+    (protocolCode) => {
+      mocks.affiliateCodes = { code: null, success: true };
+      mocks.usedReferralCode = protocolCode;
+
+      const result = setup()();
+
+      expect(result.code).toBeUndefined();
+      expect(result.referralCodeOwnerKind).toBeUndefined();
+      expect(result.shareAffiliateCode).toEqual({ code: null, success: true });
+    }
+  );
+});

--- a/src/components/ShareModal/useShareReferralCodeState.ts
+++ b/src/components/ShareModal/useShareReferralCodeState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePrevious } from "react-use";
 
 import { useAffiliateCodes, useUserReferralCode } from "domain/referrals";
+import { getProtocolReferralCodeType } from "domain/referrals/utils/referralsHelper";
 import { useLocalStorageSerializeKey } from "lib/localStorage";
 import { userAnalytics } from "lib/userAnalytics";
 import { SharePositionActionEvent, SharePositionActionSource } from "lib/userAnalytics/types";
@@ -24,7 +25,7 @@ export function useShareReferralCodeState({
   createdReferralCode: controlledCreatedReferralCode,
   setCreatedReferralCode: setControlledCreatedReferralCode,
 }: Params) {
-  const userAffiliateCode = useAffiliateCodes(chainId, account);
+  const userAffiliateCode = useAffiliateCodes(chainId, account, isOpen);
   const { userReferralCodeString: usedReferralCode } = useUserReferralCode(chainId, account);
   const [internalCreatedReferralCode, setInternalCreatedReferralCode] = useState<string | null>(null);
   const isCreatedReferralCodeControlled = controlledCreatedReferralCode !== undefined;
@@ -39,23 +40,35 @@ export function useShareReferralCodeState({
   );
   const prevIsOpen = usePrevious(isOpen);
 
-  const shareAffiliateCode = useMemo(() => {
+  const ownedAffiliateCode = useMemo(() => {
     if (createdReferralCode) {
       return { code: createdReferralCode, success: true };
     }
     return userAffiliateCode;
   }, [createdReferralCode, userAffiliateCode]);
-  const hasReferralCode = Boolean(shareAffiliateCode?.code);
+  const hasReferralCode = Boolean(ownedAffiliateCode.code);
+
+  const shareAffiliateCode = useMemo(() => {
+    if (!ownedAffiliateCode.success || ownedAffiliateCode.code) {
+      return ownedAffiliateCode;
+    }
+
+    if (usedReferralCode && !getProtocolReferralCodeType(usedReferralCode)) {
+      return { code: usedReferralCode, success: true };
+    }
+
+    return { code: null, success: true };
+  }, [ownedAffiliateCode, usedReferralCode]);
 
   const { referralCodeOwnerKind, code } = useMemo(() => {
-    if (hasReferralCode && shareAffiliateCode?.code) {
-      return { referralCodeOwnerKind: "created" as const, code: shareAffiliateCode.code };
+    if (ownedAffiliateCode.code) {
+      return { referralCodeOwnerKind: "created" as const, code: ownedAffiliateCode.code };
     }
-    if (usedReferralCode) {
-      return { referralCodeOwnerKind: "used" as const, code: usedReferralCode };
+    if (shareAffiliateCode.code) {
+      return { referralCodeOwnerKind: "used" as const, code: shareAffiliateCode.code };
     }
     return { referralCodeOwnerKind: undefined, code: undefined };
-  }, [hasReferralCode, shareAffiliateCode?.code, usedReferralCode]);
+  }, [ownedAffiliateCode.code, shareAffiliateCode.code]);
 
   useEffect(() => {
     if (!isCreatedReferralCodeControlled) {
@@ -102,7 +115,10 @@ export function useShareReferralCodeState({
 
   const shouldShowCreateReferralCard = userAffiliateCode.success && !userAffiliateCode.code && !createdReferralCode;
   const shouldPromptToCreateReferralCode =
-    !hasReferralCode && !promptedToCreateReferralCode && !isCreateReferralCodeInfoMessageClosed;
+    userAffiliateCode.success &&
+    !hasReferralCode &&
+    !promptedToCreateReferralCode &&
+    !isCreateReferralCodeInfoMessageClosed;
   const shouldShowSkipReferralCodeBanner = promptedToCreateReferralCode && !isCreateReferralCodeInfoMessageClosed;
 
   return {

--- a/src/domain/referrals/hooks/__tests__/useAffiliateCodes.spec.tsx
+++ b/src/domain/referrals/hooks/__tests__/useAffiliateCodes.spec.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ARBITRUM } from "config/chains";
+import { encodeReferralCode } from "sdk/utils/referrals";
+
+import { useAffiliateCodes } from "../index";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("lib/indexers", () => ({
+  getReferralsGraphClient: () => ({ query: mocks.query }),
+}));
+
+type HookResult = ReturnType<typeof useAffiliateCodes>;
+
+function Harness({ enabled, onResult }: { enabled: boolean; onResult: (result: HookResult) => void }) {
+  onResult(useAffiliateCodes(ARBITRUM, "0x123", enabled));
+  return null;
+}
+
+function setup(enabled = true) {
+  let result!: HookResult;
+  render(<Harness enabled={enabled} onResult={(nextResult) => (result = nextResult)} />);
+  return () => result;
+}
+
+describe("useAffiliateCodes", () => {
+  beforeEach(() => {
+    mocks.query.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it("does not query while sharing is closed", () => {
+    const getResult = setup(false);
+
+    expect(mocks.query).not.toHaveBeenCalled();
+    expect(getResult()).toEqual({ code: null, success: false });
+  });
+
+  it("selects the highest-volume code the user still owns", async () => {
+    const transferredCode = encodeReferralCode("sonicash");
+    const ownedCode = encodeReferralCode("test_12");
+    mocks.query.mockResolvedValue({
+      data: {
+        affiliateStats: [{ referralCode: transferredCode }, { referralCode: ownedCode }],
+        referralCodes: [{ code: ownedCode }],
+      },
+    });
+
+    const getResult = setup();
+
+    await waitFor(() => expect(getResult()).toEqual({ code: "test_12", success: true }));
+  });
+
+  it("returns an owned code that has no historical volume", async () => {
+    const ownedCode = encodeReferralCode("new_code");
+    mocks.query.mockResolvedValue({
+      data: {
+        affiliateStats: [],
+        referralCodes: [{ code: ownedCode }],
+      },
+    });
+
+    const getResult = setup();
+
+    await waitFor(() => expect(getResult()).toEqual({ code: "new_code", success: true }));
+  });
+
+  it("confirms that the user owns no code even when historical stats exist", async () => {
+    mocks.query.mockResolvedValue({
+      data: {
+        affiliateStats: [{ referralCode: encodeReferralCode("old_code") }],
+        referralCodes: [],
+      },
+    });
+
+    const getResult = setup();
+
+    await waitFor(() => expect(getResult()).toEqual({ code: null, success: true }));
+  });
+});

--- a/src/domain/referrals/hooks/__tests__/useAffiliateCodes.spec.tsx
+++ b/src/domain/referrals/hooks/__tests__/useAffiliateCodes.spec.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
+import { print } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ARBITRUM } from "config/chains";
@@ -16,14 +17,22 @@ vi.mock("lib/indexers", () => ({
 
 type HookResult = ReturnType<typeof useAffiliateCodes>;
 
-function Harness({ enabled, onResult }: { enabled: boolean; onResult: (result: HookResult) => void }) {
-  onResult(useAffiliateCodes(ARBITRUM, "0x123", enabled));
+function Harness({
+  account,
+  enabled,
+  onResult,
+}: {
+  account: string;
+  enabled: boolean;
+  onResult: (result: HookResult) => void;
+}) {
+  onResult(useAffiliateCodes(ARBITRUM, account, enabled));
   return null;
 }
 
-function setup(enabled = true) {
+function setup(enabled = true, account = "0x123") {
   let result!: HookResult;
-  render(<Harness enabled={enabled} onResult={(nextResult) => (result = nextResult)} />);
+  render(<Harness account={account} enabled={enabled} onResult={(nextResult) => (result = nextResult)} />);
   return () => result;
 }
 
@@ -39,6 +48,27 @@ describe("useAffiliateCodes", () => {
 
     expect(mocks.query).not.toHaveBeenCalled();
     expect(getResult()).toEqual({ code: null, success: false });
+  });
+
+  it("queries owned codes case-insensitively without changing the account casing", async () => {
+    const account = "0x1640e916e10610Ba39aAC5Cd8a08acF3cCae1A4c";
+    const ownedCode = encodeReferralCode("H4X");
+    mocks.query.mockResolvedValue({
+      data: {
+        affiliateStats: [{ referralCode: ownedCode }],
+        referralCodes: [{ code: ownedCode }],
+      },
+    });
+
+    const getResult = setup(true, account);
+
+    await waitFor(() => expect(getResult()).toEqual({ code: "H4X", success: true }));
+
+    const queryOptions = mocks.query.mock.calls[0][0];
+    const queryText = print(queryOptions.query);
+    expect(queryText).toContain("affiliate_contains_nocase: $account");
+    expect(queryText).toContain("owner_contains_nocase: $account");
+    expect(queryOptions.variables).toEqual({ account });
   });
 
   it("selects the highest-volume code the user still owns", async () => {

--- a/src/domain/referrals/hooks/index.ts
+++ b/src/domain/referrals/hooks/index.ts
@@ -422,11 +422,11 @@ const AFFILIATE_CODES_QUERY = gql`
       first: 1000
       orderBy: volume
       orderDirection: desc
-      where: { period: total, affiliate: $account }
+      where: { period: total, affiliate_contains_nocase: $account }
     ) {
       referralCode
     }
-    referralCodes(first: 1000, where: { owner: $account }) {
+    referralCodes(first: 1000, where: { owner_contains_nocase: $account }) {
       code
     }
   }

--- a/src/domain/referrals/hooks/index.ts
+++ b/src/domain/referrals/hooks/index.ts
@@ -408,6 +408,7 @@ export async function validateReferralCodeExists(referralCode: string, chainId: 
 
 type AffiliateCodesQueryResponse = {
   affiliateStats: Array<{ referralCode: Hash }>;
+  referralCodes: Array<{ code: Hash }>;
 };
 
 export type AffiliateCodesState = {
@@ -415,31 +416,63 @@ export type AffiliateCodesState = {
   success: boolean;
 };
 
-export function useAffiliateCodes(chainId: ContractsChainId, account: string | undefined) {
-  const [affiliateCodes, setAffiliateCodes] = useState<AffiliateCodesState>({ code: null, success: false });
-  const query = gql`
-    query userReferralCodes($account: String!) {
-      affiliateStats: affiliateStats(
-        first: 1000
-        orderBy: volume
-        orderDirection: desc
-        where: { period: total, affiliate: $account }
-      ) {
-        referralCode
-      }
+const AFFILIATE_CODES_QUERY = gql`
+  query userReferralCodes($account: String!) {
+    affiliateStats: affiliateStats(
+      first: 1000
+      orderBy: volume
+      orderDirection: desc
+      where: { period: total, affiliate: $account }
+    ) {
+      referralCode
     }
-  `;
+    referralCodes(first: 1000, where: { owner: $account }) {
+      code
+    }
+  }
+`;
+
+export function useAffiliateCodes(chainId: ContractsChainId, account: string | undefined, enabled = true) {
+  const [affiliateCodes, setAffiliateCodes] = useState<AffiliateCodesState>({ code: null, success: false });
+
   useEffect(() => {
-    if (!chainId) return;
-    getReferralsGraphClient(chainId)
-      ?.query<AffiliateCodesQueryResponse>({ query, variables: { account: account?.toLowerCase() } })
+    setAffiliateCodes({ code: null, success: false });
+
+    if (!chainId || !account || !enabled) return;
+
+    const client = getReferralsGraphClient(chainId);
+    if (!client) return;
+
+    let cancelled = false;
+
+    client
+      .query<AffiliateCodesQueryResponse>({
+        query: AFFILIATE_CODES_QUERY,
+        variables: { account },
+        fetchPolicy: "network-only",
+      })
       .then((res) => {
-        const parsedAffiliateCodes = res?.data?.affiliateStats.map((c) => decodeReferralCode(c?.referralCode));
-        setAffiliateCodes({ code: parsedAffiliateCodes[0] ?? null, success: true });
+        if (cancelled) return;
+
+        const ownedCodes = res.data.referralCodes.map((item) => item.code);
+        const ownedCodesSet = new Set(ownedCodes);
+        const highestVolumeOwnedCode = res.data.affiliateStats.find((item) =>
+          ownedCodesSet.has(item.referralCode)
+        )?.referralCode;
+        const code = highestVolumeOwnedCode ?? ownedCodes[0];
+
+        setAffiliateCodes({ code: code ? decodeReferralCode(code) : null, success: true });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAffiliateCodes({ code: null, success: false });
+        }
       });
+
     return () => {
-      setAffiliateCodes({ code: null, success: false });
+      cancelled = true;
     };
-  }, [chainId, query, account]);
+  }, [chainId, account, enabled]);
+
   return affiliateCodes;
 }


### PR DESCRIPTION
## Summary

- resolve share-card referral codes from codes the account currently owns on the selected chain
- wait for ownership confirmation before using an active trader code and exclude protocol-assigned codes
- keep the card, QR code, and copied share link referral parameter consistent
- add regression coverage for transferred, zero-volume, loading, regular used, and protocol-assigned codes

## Root cause

The share card selected an affiliate code from historical volume stats without confirming current ownership. It could also fall back to the active trader code before the ownership lookup completed.

Linear: https://linear.app/gmx-io/issue/FEDEV-4108/fix-referral-code-and-used-referral-code-instances
