### PR TITLE
Hotfix: prefetch ui-flags during HTML parse to unblock api data requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,30 @@
     <link rel="dns-prefetch" href="//arbitrum.gmxapi.io" />
     <link rel="preconnect" href="https://avalanche.gmxapi.io" crossorigin />
     <link rel="dns-prefetch" href="//avalanche.gmxapi.io" />
+    <link rel="preconnect" href="https://arbitrum-api.gmxinfra.io" crossorigin />
+    <link rel="dns-prefetch" href="//arbitrum-api.gmxinfra.io" />
+    <link rel="preconnect" href="https://avalanche-api.gmxinfra.io" crossorigin />
+    <link rel="dns-prefetch" href="//avalanche-api.gmxinfra.io" />
+    <script>
+      // The app gates its api data requests on ui-flags; fetching them only after the bundle
+      // boots serializes ~2s on first-visit loads, so kick the requests off during HTML parse.
+      window.__uiFlagsPrefetch = {};
+      ["https://arbitrum-api.gmxinfra.io/ui-flags/v2", "https://avalanche-api.gmxinfra.io/ui-flags/v2"].forEach(
+        function (url) {
+          try {
+            window.__uiFlagsPrefetch[url] = fetch(url)
+              .then(function (res) {
+                return res.ok ? res.json() : null;
+              })
+              .catch(function () {
+                return null;
+              });
+          } catch (e) {
+            window.__uiFlagsPrefetch[url] = undefined;
+          }
+        }
+      );
+    </script>
     <link rel="apple-touch-icon" sizes="57x57" href="/favicon/apple-icon-57x57.png" />
     <link rel="apple-touch-icon" sizes="60x60" href="/favicon/apple-icon-60x60.png" />
     <link rel="apple-touch-icon" sizes="72x72" href="/favicon/apple-icon-72x72.png" />

--- a/index.html
+++ b/index.html
@@ -34,24 +34,43 @@
     <link rel="preconnect" href="https://avalanche-api.gmxinfra.io" crossorigin />
     <link rel="dns-prefetch" href="//avalanche-api.gmxinfra.io" />
     <script>
-      // The app gates its api data requests on ui-flags; fetching them only after the bundle
-      // boots serializes ~2s on first-visit loads, so kick the requests off during HTML parse.
+      // Warms ui-flags during HTML parse; consumed once by src/lib/oracleKeeperFetcher/uiFlagsPrefetch.ts.
       window.__uiFlagsPrefetch = {};
-      ["https://arbitrum-api.gmxinfra.io/ui-flags/v2", "https://avalanche-api.gmxinfra.io/ui-flags/v2"].forEach(
-        function (url) {
-          try {
-            window.__uiFlagsPrefetch[url] = fetch(url)
+      [
+        [
+          "https://arbitrum-api.gmxinfra.io/ui-flags/v2",
+          "https://arbitrum-api-fallback.gmxinfra.io/ui-flags/v2",
+          "https://arbitrum-api-fallback.gmxinfra2.io/ui-flags/v2",
+        ],
+        [
+          "https://avalanche-api.gmxinfra.io/ui-flags/v2",
+          "https://avalanche-api-fallback.gmxinfra.io/ui-flags/v2",
+          "https://avalanche-api-fallback.gmxinfra2.io/ui-flags/v2",
+        ],
+      ].forEach(function (urls) {
+        try {
+          var attempt = function (i) {
+            if (i >= urls.length) return Promise.resolve(null);
+            var opts = {};
+            try {
+              if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) {
+                opts.signal = AbortSignal.timeout(10000);
+              }
+            } catch (e) {}
+            return fetch(urls[i], opts)
               .then(function (res) {
-                return res.ok ? res.json() : null;
+                return res.ok ? res.json() : attempt(i + 1);
               })
               .catch(function () {
-                return null;
+                return attempt(i + 1);
               });
-          } catch (e) {
-            window.__uiFlagsPrefetch[url] = undefined;
-          }
-        }
-      );
+          };
+          var promise = attempt(0);
+          urls.forEach(function (url) {
+            window.__uiFlagsPrefetch[url] = promise;
+          });
+        } catch (e) {}
+      });
     </script>
     <link rel="apple-touch-icon" sizes="57x57" href="/favicon/apple-icon-57x57.png" />
     <link rel="apple-touch-icon" sizes="60x60" href="/favicon/apple-icon-60x60.png" />

--- a/src/lib/oracleKeeperFetcher/oracleKeeperFetcher.ts
+++ b/src/lib/oracleKeeperFetcher/oracleKeeperFetcher.ts
@@ -237,7 +237,7 @@ export class OracleKeeperFetcher implements OracleFetcher {
     );
 
     if (prefetched) {
-      return prefetched.then((flags) => (flags ?? this.request("/ui-flags/v2", {})) as Record<string, UiFlag>);
+      return prefetched.then((flags) => (flags ? (flags as Record<string, UiFlag>) : this.request("/ui-flags/v2", {})));
     }
 
     return this.request("/ui-flags/v2", {});

--- a/src/lib/oracleKeeperFetcher/oracleKeeperFetcher.ts
+++ b/src/lib/oracleKeeperFetcher/oracleKeeperFetcher.ts
@@ -28,6 +28,7 @@ import {
   RawIncentivesStats,
   TickersResponse,
 } from "./types";
+import { consumeUiFlagsPrefetch } from "./uiFlagsPrefetch";
 
 function parseOracleCandle(rawCandle: number[]): Bar {
   const [time, open, high, low, close] = rawCandle;
@@ -231,6 +232,14 @@ export class OracleKeeperFetcher implements OracleFetcher {
   }
 
   fetchUiFlags(): Promise<Record<string, UiFlag>> {
+    const prefetched = consumeUiFlagsPrefetch(
+      buildUrl(this.oracleTracker.getCurrentEndpoints().primary, "/ui-flags/v2")
+    );
+
+    if (prefetched) {
+      return prefetched.then((flags) => (flags ?? this.request("/ui-flags/v2", {})) as Record<string, UiFlag>);
+    }
+
     return this.request("/ui-flags/v2", {});
   }
 

--- a/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.spec.ts
+++ b/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { consumeUiFlagsPrefetch } from "./uiFlagsPrefetch";
 
@@ -7,6 +7,16 @@ const URL = "https://arbitrum-api.gmxinfra.io/ui-flags/v2";
 describe("consumeUiFlagsPrefetch", () => {
   afterEach(() => {
     delete window.__uiFlagsPrefetch;
+    vi.restoreAllMocks();
+  });
+
+  it("does not consume a prefetch after the boot window", () => {
+    const promise = Promise.resolve({ apiPositions: true });
+    window.__uiFlagsPrefetch = { [URL]: promise };
+    vi.spyOn(performance, "now").mockReturnValue(20_000);
+
+    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
+    expect(window.__uiFlagsPrefetch[URL]).toBeUndefined();
   });
 
   it("returns undefined when no prefetch was registered", () => {

--- a/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.spec.ts
+++ b/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.spec.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { consumeUiFlagsPrefetch } from "./uiFlagsPrefetch";
+
+const URL = "https://arbitrum-api.gmxinfra.io/ui-flags/v2";
+
+describe("consumeUiFlagsPrefetch", () => {
+  afterEach(() => {
+    delete window.__uiFlagsPrefetch;
+  });
+
+  it("returns undefined when no prefetch was registered", () => {
+    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
+
+    window.__uiFlagsPrefetch = {};
+    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
+  });
+
+  it("returns the prefetched promise exactly once", async () => {
+    const promise = Promise.resolve({ apiPositions: true });
+    window.__uiFlagsPrefetch = { [URL]: promise };
+
+    expect(consumeUiFlagsPrefetch(URL)).toBe(promise);
+    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
+  });
+
+  it("does not consume prefetches registered for other urls", () => {
+    const promise = Promise.resolve(null);
+    window.__uiFlagsPrefetch = { [URL]: promise };
+
+    expect(consumeUiFlagsPrefetch("https://avalanche-api.gmxinfra.io/ui-flags/v2")).toBeUndefined();
+    expect(consumeUiFlagsPrefetch(URL)).toBe(promise);
+  });
+});

--- a/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.spec.ts
+++ b/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.spec.ts
@@ -2,43 +2,62 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { consumeUiFlagsPrefetch } from "./uiFlagsPrefetch";
 
-const URL = "https://arbitrum-api.gmxinfra.io/ui-flags/v2";
+const PRIMARY_URL = "https://arbitrum-api.gmxinfra.io/ui-flags/v2";
+const FALLBACK_URL = "https://arbitrum-api-fallback.gmxinfra.io/ui-flags/v2";
+const OTHER_CHAIN_URL = "https://avalanche-api.gmxinfra.io/ui-flags/v2";
 
 describe("consumeUiFlagsPrefetch", () => {
   afterEach(() => {
     delete window.__uiFlagsPrefetch;
     vi.restoreAllMocks();
-  });
-
-  it("does not consume a prefetch after the boot window", () => {
-    const promise = Promise.resolve({ apiPositions: true });
-    window.__uiFlagsPrefetch = { [URL]: promise };
-    vi.spyOn(performance, "now").mockReturnValue(20_000);
-
-    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
-    expect(window.__uiFlagsPrefetch[URL]).toBeUndefined();
+    vi.useRealTimers();
   });
 
   it("returns undefined when no prefetch was registered", () => {
-    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
+    expect(consumeUiFlagsPrefetch(PRIMARY_URL)).toBeUndefined();
 
     window.__uiFlagsPrefetch = {};
-    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
+    expect(consumeUiFlagsPrefetch(PRIMARY_URL)).toBeUndefined();
   });
 
-  it("returns the prefetched promise exactly once", async () => {
+  it("resolves with the prefetched value and consumes all aliases of the same promise", async () => {
     const promise = Promise.resolve({ apiPositions: true });
-    window.__uiFlagsPrefetch = { [URL]: promise };
+    const otherChainPromise = Promise.resolve({ apiPositions: false });
+    window.__uiFlagsPrefetch = {
+      [PRIMARY_URL]: promise,
+      [FALLBACK_URL]: promise,
+      [OTHER_CHAIN_URL]: otherChainPromise,
+    };
 
-    expect(consumeUiFlagsPrefetch(URL)).toBe(promise);
-    expect(consumeUiFlagsPrefetch(URL)).toBeUndefined();
+    await expect(consumeUiFlagsPrefetch(FALLBACK_URL)).resolves.toEqual({ apiPositions: true });
+    expect(consumeUiFlagsPrefetch(PRIMARY_URL)).toBeUndefined();
+    expect(window.__uiFlagsPrefetch[OTHER_CHAIN_URL]).toBe(otherChainPromise);
   });
 
   it("does not consume prefetches registered for other urls", () => {
     const promise = Promise.resolve(null);
-    window.__uiFlagsPrefetch = { [URL]: promise };
+    window.__uiFlagsPrefetch = { [PRIMARY_URL]: promise };
 
-    expect(consumeUiFlagsPrefetch("https://avalanche-api.gmxinfra.io/ui-flags/v2")).toBeUndefined();
-    expect(consumeUiFlagsPrefetch(URL)).toBe(promise);
+    expect(consumeUiFlagsPrefetch(OTHER_CHAIN_URL)).toBeUndefined();
+    expect(window.__uiFlagsPrefetch[PRIMARY_URL]).toBe(promise);
+  });
+
+  it("does not consume a prefetch after the boot window", () => {
+    const promise = Promise.resolve({ apiPositions: true });
+    window.__uiFlagsPrefetch = { [PRIMARY_URL]: promise };
+    vi.spyOn(performance, "now").mockReturnValue(20_000);
+
+    expect(consumeUiFlagsPrefetch(PRIMARY_URL)).toBeUndefined();
+    expect(window.__uiFlagsPrefetch[PRIMARY_URL]).toBeUndefined();
+  });
+
+  it("resolves null instead of waiting forever on a hung prefetch", async () => {
+    vi.useFakeTimers();
+    window.__uiFlagsPrefetch = { [PRIMARY_URL]: new Promise(() => undefined) };
+
+    const consumed = consumeUiFlagsPrefetch(PRIMARY_URL)!;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(consumed).resolves.toBeNull();
   });
 });

--- a/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.ts
+++ b/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.ts
@@ -5,25 +5,35 @@ declare global {
 }
 
 const PREFETCH_MAX_AGE_MS = 15_000;
+const PREFETCH_WAIT_TIMEOUT_MS = 5_000;
 
-// index.html kicks off ui-flags requests during HTML parse (see the inline script there); the
-// first fetchUiFlags call for a url consumes that in-flight promise instead of re-requesting.
+// Started by the inline script in index.html during HTML parse; one promise per chain is
+// registered under every keeper host alias and consumed at most once.
 export function consumeUiFlagsPrefetch(url: string): Promise<unknown> | undefined {
-  if (typeof window === "undefined") {
+  if (typeof window === "undefined" || !window.__uiFlagsPrefetch) {
     return undefined;
   }
 
-  const prefetched = window.__uiFlagsPrefetch?.[url];
+  const prefetched = window.__uiFlagsPrefetch[url];
 
-  if (window.__uiFlagsPrefetch) {
-    delete window.__uiFlagsPrefetch[url];
+  if (prefetched === undefined) {
+    return undefined;
   }
 
-  // Boot-time optimization only: consuming it long after load (e.g. on a later chain switch)
-  // would replay stale flags as a fresh response.
+  for (const [key, value] of Object.entries(window.__uiFlagsPrefetch)) {
+    if (value === prefetched) {
+      delete window.__uiFlagsPrefetch[key];
+    }
+  }
+
   if (performance.now() > PREFETCH_MAX_AGE_MS) {
     return undefined;
   }
 
-  return prefetched;
+  return Promise.race([
+    prefetched,
+    new Promise<null>((resolve) => {
+      window.setTimeout(() => resolve(null), PREFETCH_WAIT_TIMEOUT_MS);
+    }),
+  ]);
 }

--- a/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.ts
+++ b/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.ts
@@ -1,0 +1,21 @@
+declare global {
+  interface Window {
+    __uiFlagsPrefetch?: Record<string, Promise<unknown> | undefined>;
+  }
+}
+
+// index.html kicks off ui-flags requests during HTML parse (see the inline script there); the
+// first fetchUiFlags call for a url consumes that in-flight promise instead of re-requesting.
+export function consumeUiFlagsPrefetch(url: string): Promise<unknown> | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  const prefetched = window.__uiFlagsPrefetch?.[url];
+
+  if (window.__uiFlagsPrefetch) {
+    delete window.__uiFlagsPrefetch[url];
+  }
+
+  return prefetched;
+}

--- a/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.ts
+++ b/src/lib/oracleKeeperFetcher/uiFlagsPrefetch.ts
@@ -4,6 +4,8 @@ declare global {
   }
 }
 
+const PREFETCH_MAX_AGE_MS = 15_000;
+
 // index.html kicks off ui-flags requests during HTML parse (see the inline script there); the
 // first fetchUiFlags call for a url consumes that in-flight promise instead of re-requesting.
 export function consumeUiFlagsPrefetch(url: string): Promise<unknown> | undefined {
@@ -15,6 +17,12 @@ export function consumeUiFlagsPrefetch(url: string): Promise<unknown> | undefine
 
   if (window.__uiFlagsPrefetch) {
     delete window.__uiFlagsPrefetch[url];
+  }
+
+  // Boot-time optimization only: consuming it long after load (e.g. on a later chain switch)
+  // would replay stale flags as a fresh response.
+  if (performance.now() > PREFETCH_MAX_AGE_MS) {
+    return undefined;
   }
 
   return prefetched;


### PR DESCRIPTION
## Problem

On a first visit (empty localStorage) the app's api data requests (markets config/values, positions, orders) are hard-serialized behind the network `ui-flags/v2` response. Profiled on prod: the flags request only starts after the bundle boots (~2.6s) and takes ~2s on a cold connection (gmxinfra.io had no preconnect; the warm endpoint answers in ~170-400ms), so the api data requests start at ~4.7s and positions data lands at ~5s — on a fast machine; slower devices stretch every stage. Returning visits (flags cached in localStorage) start data requests at ~0.5s and are unaffected.

## Change

- `index.html`: preconnect/dns-prefetch for `arbitrum-api.gmxinfra.io` / `avalanche-api.gmxinfra.io` (parity with the existing gmxapi.io preconnects) plus an inline script that kicks off the `ui-flags/v2` requests during HTML parse into `window.__uiFlagsPrefetch`.
- `fetchUiFlags` consumes the prefetched promise at most once (registered under every keeper host alias per chain, bounded by a 5s wait and a 15s boot window); a failed, hung, or absent prefetch falls back to the unchanged request path with its retry/fallback machinery.

Flags remain the single source of truth: this starts the same network request earlier (in parallel with the bundle download) — no bundled defaults, no optimism. An emergency server-side flag flip reaches cold users no later than it does today.

## Verification

- `yarn tscheck` clean; `yarn test:ci` green; new `uiFlagsPrefetch.spec.ts` (consume-once semantics, url isolation)
- production build: inline script and preconnects present in built `index.html`
- e2e on the built bundle against real endpoints: flags request fires during HTML parse (~0.2s) and is consumed by the app without a duplicate request; api data requests no longer wait for boot + flags round-trip

