### PR TITLE
Add API SDK e2e tests to CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -60,6 +60,11 @@ jobs:
           cd sdk
           yarn test:multicall
 
+      - name: Run SDK e2e public tests
+        run: |
+          cd sdk
+          yarn test:v2:public
+
   sdk-standalone:
     name: SDK standalone build (publish parity)
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -3,7 +3,8 @@ name: SDK E2E Tests
 on:
   push:
     branches:
-      - release
+      # Must stay within the sdk_e2e environment's deployment branch policy,
+      # otherwise the job cannot read its secrets.
       - "release-*"
   workflow_dispatch:
     inputs:
@@ -20,6 +21,7 @@ jobs:
   e2e:
     name: SDK e2e (funded wallet)
     runs-on: ubuntu-latest
+    environment: sdk_e2e
     timeout-minutes: 90
     env:
       GMX_TEST_PRIVATE_KEY: ${{ secrets.GMX_TEST_PRIVATE_KEY }}

--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -1,0 +1,53 @@
+name: SDK E2E Tests
+
+on:
+  push:
+    branches:
+      - release
+      - "release-*"
+  workflow_dispatch:
+    inputs:
+      run_bridges:
+        description: "Also run bridge tests that move funds cross-chain (sets GMX_TEST_SEND=1)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: sdk-e2e
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: SDK e2e (funded wallet)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      GMX_TEST_PRIVATE_KEY: ${{ secrets.GMX_TEST_PRIVATE_KEY }}
+      GMX_TEST_RPC_URL: ${{ secrets.GMX_TEST_RPC_URL }}
+      GMX_TEST_SOURCE_RPC_URL: ${{ secrets.GMX_TEST_SOURCE_RPC_URL }}
+      GMX_TEST_API_URL: ${{ vars.GMX_TEST_API_URL }}
+      GMX_TEST_SEND: ${{ inputs.run_bridges && '1' || '' }}
+    steps:
+      - name: Check secrets
+        run: |
+          if [ -z "$GMX_TEST_PRIVATE_KEY" ]; then
+            echo "GMX_TEST_PRIVATE_KEY secret is not configured; the funded e2e suite cannot run" >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run SDK e2e tests
+        run: |
+          cd sdk
+          yarn test:v2

--- a/sdk/.env.example
+++ b/sdk/.env.example
@@ -4,10 +4,13 @@
 #  - USDC on Base (source) for bridge-in test
 #  - ETH on Base for LayerZero nativeFee + gas
 #  - some funds on Arbitrum for bridge-out
+# Optional for the public suite (test:v2:public) — an ephemeral throwaway
+# signer is generated when unset.
 GMX_TEST_PRIVATE_KEY=0x...
 
-# API instance with multichain endpoints (e.g. local gmx-api or staging)
-GMX_TEST_API_URL=http://localhost:3004/v1
+# API instance with multichain endpoints (e.g. local gmx-api or staging).
+# No /v1 suffix — SDK request paths already include it.
+GMX_TEST_API_URL=http://localhost:3004
 
 # Settlement chain RPC (Arbitrum). Required for classic submit flows.
 GMX_TEST_RPC_URL=https://arb1.arbitrum.io/rpc

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -506,6 +506,7 @@
     "test:ci": "vitest run",
     "test:multicall": "vitest run --config vitest.multicall.config.ts",
     "test:v2": "vitest run --config vitest.v2.config.ts",
+    "test:v2:public": "vitest run --config vitest.v2.public.config.ts",
     "build": "rm -rf build && yarn build:types && yarn build:cjs && yarn build:esm && yarn clean",
     "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > build/cjs/src/package.json",
     "build:esm": "tsc -p tsconfig.esm.json && echo '{\"type\": \"module\"}' > build/esm/src/package.json",

--- a/sdk/src/clients/v2/__tests__/data.spec.ts
+++ b/sdk/src/clients/v2/__tests__/data.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getTestSdk, getTestSigner } from "./testUtil";
+import { getOrCreateTestSigner, getTestSdk } from "./testUtil";
 
 const sdk = getTestSdk();
-const signer = getTestSigner();
+const signer = getOrCreateTestSigner();
 
 describe("GmxApiSdk — data fetching", () => {
   it("fetchMarketsInfo", async () => {
@@ -63,10 +63,10 @@ describe("GmxApiSdk — data fetching", () => {
 });
 
 describe("positions & orders", () => {
-  const account = signer?.address;
+  const account = signer.address;
 
-  it.skipIf(!signer)("fetchPositionsInfo returns positions for account", async () => {
-    const positions = await sdk.fetchPositionsInfo({ address: account! });
+  it("fetchPositionsInfo returns positions for account", async () => {
+    const positions = await sdk.fetchPositionsInfo({ address: account });
     expect(Array.isArray(positions)).toBe(true);
     if (positions.length > 0) {
       expect(positions[0].account).toBe(account);
@@ -75,17 +75,17 @@ describe("positions & orders", () => {
     }
   });
 
-  it.skipIf(!signer)("fetchPositionsInfo with includeRelatedOrders", async () => {
+  it("fetchPositionsInfo with includeRelatedOrders", async () => {
     const [without, withOrders] = await Promise.all([
-      sdk.fetchPositionsInfo({ address: account! }),
-      sdk.fetchPositionsInfo({ address: account!, includeRelatedOrders: true }),
+      sdk.fetchPositionsInfo({ address: account }),
+      sdk.fetchPositionsInfo({ address: account, includeRelatedOrders: true }),
     ]);
     expect(Array.isArray(withOrders)).toBe(true);
     expect(withOrders.length).toBeGreaterThanOrEqual(without.length);
   });
 
-  it.skipIf(!signer)("fetchOrders returns orders array", async () => {
-    const orders = await sdk.fetchOrders({ address: account! });
+  it("fetchOrders returns orders array", async () => {
+    const orders = await sdk.fetchOrders({ address: account });
     expect(Array.isArray(orders)).toBe(true);
   });
 

--- a/sdk/src/clients/v2/__tests__/errors.spec.ts
+++ b/sdk/src/clients/v2/__tests__/errors.spec.ts
@@ -1,17 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  getTestSdk,
-  requireSigner,
-  expressFlow,
-  waitForOrderStatus,
-  TEST_SYMBOL,
-  TEST_SIZE_USD,
-  TEST_COLLATERAL,
-} from "./testUtil";
+import { getOrCreateTestSigner, getTestSdk, TEST_SYMBOL, TEST_SIZE_USD, TEST_COLLATERAL } from "./testUtil";
 
 const sdk = getTestSdk();
-const signer = requireSigner();
+const signer = getOrCreateTestSigner();
 const account = signer.address;
 
 describe("validation errors", () => {
@@ -276,53 +268,6 @@ describe("validation errors", () => {
           from: "0x0000000000000000000000000000000000000001",
         })
       ).rejects.toThrow();
-    });
-  });
-
-  describe("order lifecycle tracking", () => {
-    it("status transitions from initial to executed", async () => {
-      const { submitted } = await expressFlow(sdk, signer, {
-        kind: "increase",
-        symbol: TEST_SYMBOL,
-        direction: "long",
-        orderType: "market",
-        size: TEST_SIZE_USD,
-        collateralToken: "USDC",
-        collateralToPay: TEST_COLLATERAL,
-        mode: "express",
-        from: account,
-      });
-
-      const initial = await sdk.fetchOrderStatus({ requestId: submitted.requestId });
-      expect(["relay_accepted", "relay_pending", "relay_submitted", "created", "executed"]).toContain(initial.status);
-      expect(initial.requestId).toBe(submitted.requestId);
-
-      const terminal = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(terminal.status).toBe("executed");
-      expect(terminal.requestId).toBe(submitted.requestId);
-    });
-
-    it("terminal status has populated fields", async () => {
-      const { submitted } = await expressFlow(sdk, signer, {
-        kind: "increase",
-        symbol: TEST_SYMBOL,
-        direction: "long",
-        orderType: "market",
-        size: TEST_SIZE_USD,
-        collateralToken: "USDC",
-        collateralToPay: TEST_COLLATERAL,
-        mode: "express",
-        from: account,
-      });
-
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
-      expect(status.requestId).toBeDefined();
-      // createdTxnHash may not be populated immediately for all executed orders
-      if (status.createdTxnHash) expect(status.createdTxnHash.startsWith("0x")).toBe(true);
-      if (status.executionTxnHash) expect(status.executionTxnHash.startsWith("0x")).toBe(true);
-      if (status.createdAt) expect(typeof status.createdAt).toBe("string");
-      if (status.updatedAt) expect(typeof status.updatedAt).toBe("string");
     });
   });
 });

--- a/sdk/src/clients/v2/__tests__/errorsLifecycle.spec.ts
+++ b/sdk/src/clients/v2/__tests__/errorsLifecycle.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getTestSdk,
+  requireSigner,
+  expressFlow,
+  waitForOrderStatus,
+  TEST_SYMBOL,
+  TEST_SIZE_USD,
+  TEST_COLLATERAL,
+} from "./testUtil";
+
+const sdk = getTestSdk();
+const signer = requireSigner();
+const account = signer.address;
+
+describe("order lifecycle tracking", () => {
+  it("status transitions from initial to executed", async () => {
+    const { submitted } = await expressFlow(sdk, signer, {
+      kind: "increase",
+      symbol: TEST_SYMBOL,
+      direction: "long",
+      orderType: "market",
+      size: TEST_SIZE_USD,
+      collateralToken: "USDC",
+      collateralToPay: TEST_COLLATERAL,
+      mode: "express",
+      from: account,
+    });
+
+    const initial = await sdk.fetchOrderStatus({ requestId: submitted.requestId });
+    expect(["relay_accepted", "relay_pending", "relay_submitted", "created", "executed"]).toContain(initial.status);
+    expect(initial.requestId).toBe(submitted.requestId);
+
+    const terminal = await waitForOrderStatus(sdk, submitted.requestId);
+    expect(terminal.status).toBe("executed");
+    expect(terminal.requestId).toBe(submitted.requestId);
+  });
+
+  it("terminal status has populated fields", async () => {
+    const { submitted } = await expressFlow(sdk, signer, {
+      kind: "increase",
+      symbol: TEST_SYMBOL,
+      direction: "long",
+      orderType: "market",
+      size: TEST_SIZE_USD,
+      collateralToken: "USDC",
+      collateralToPay: TEST_COLLATERAL,
+      mode: "express",
+      from: account,
+    });
+
+    const status = await waitForOrderStatus(sdk, submitted.requestId);
+    expect(status.status).toBe("executed");
+    expect(status.requestId).toBeDefined();
+    // createdTxnHash may not be populated immediately for all executed orders
+    if (status.createdTxnHash) expect(status.createdTxnHash.startsWith("0x")).toBe(true);
+    if (status.executionTxnHash) expect(status.executionTxnHash.startsWith("0x")).toBe(true);
+    if (status.createdAt) expect(typeof status.createdAt).toBe("string");
+    if (status.updatedAt) expect(typeof status.updatedAt).toBe("string");
+  });
+});

--- a/sdk/src/clients/v2/__tests__/increase.spec.ts
+++ b/sdk/src/clients/v2/__tests__/increase.spec.ts
@@ -117,7 +117,7 @@ describe("increase orders", () => {
     });
 
     it("larger collateral: position fee scales with size not collateral", async () => {
-      const collateral = { amount: 2000000n, token: "USDC" }; // 2 USDC vs 1 USDC in TEST_COLLATERAL
+      const collateral = { amount: TEST_COLLATERAL.amount * 2n, token: "USDC" };
 
       const [small, large] = await Promise.all([
         sdk.prepareOrder({

--- a/sdk/src/clients/v2/__tests__/multichain.spec.ts
+++ b/sdk/src/clients/v2/__tests__/multichain.spec.ts
@@ -13,21 +13,20 @@ import {
   USDC_BASE,
   waitForWithdrawStatus,
 } from "./multichainTestUtil";
-import { getTestSdk, getTestSigner } from "./testUtil";
+import { getOrCreateTestSigner, getTestSdk } from "./testUtil";
 
 beforeAll(() => {
   expectArbitrumSettlement();
 });
 
 const sdk = getTestSdk();
-const signer = getTestSigner();
-const account = signer?.address ?? "";
-const hasSigner = signer !== undefined;
+const signer = getOrCreateTestSigner();
+const account = signer.address;
 
 const DEPOSIT_AMOUNT = 1_000_000n; // 1 USDC
 const WITHDRAW_AMOUNT = 500_000n; // 0.5 USDC
 
-describe.skipIf(!hasSigner)("multichain same-chain (build only)", () => {
+describe("multichain same-chain (build only)", () => {
   it("deposit: multicall(sendTokens + bridgeIn)", () => {
     const built = sdk.buildSameChainDepositTxn({
       tokenAddress: USDC_ARBITRUM,
@@ -52,7 +51,7 @@ describe.skipIf(!hasSigner)("multichain same-chain (build only)", () => {
   });
 });
 
-describe.skipIf(!hasSigner)("multichain cross-chain deposit (Base → Arbitrum, API-driven)", () => {
+describe("multichain cross-chain deposit (Base → Arbitrum, API-driven)", () => {
   it("prepare: server resolves pools + quotes nativeFee + composeGas (tokenSymbol)", async () => {
     const prepared = await sdk.prepareCrossChainDeposit({
       srcChainId: TEST_SOURCE_CHAIN_ID,
@@ -104,7 +103,7 @@ describe.skipIf(!hasSigner)("multichain cross-chain deposit (Base → Arbitrum, 
   });
 });
 
-describe.skipIf(!hasSigner)("multichain cross-chain withdraw (Arbitrum → Base, via Gelato)", () => {
+describe("multichain cross-chain withdraw (Arbitrum → Base, via Gelato)", () => {
   it("prepare: returns typed-data + gasPaymentParams", async () => {
     const bridgeOutParams = sdk.buildCrossChainWithdrawBridgeOutParams({
       tokenAddress: USDC_ARBITRUM,
@@ -132,7 +131,7 @@ describe.skipIf(!hasSigner)("multichain cross-chain withdraw (Arbitrum → Base,
       stargateAddress: STARGATE_USDC_ARBITRUM,
     });
 
-    const submitted = await sdk.executeCrossChainWithdraw(signer!, {
+    const submitted = await sdk.executeCrossChainWithdraw(signer, {
       srcChainId: TEST_SOURCE_CHAIN_ID,
       account,
       bridgeOutParams,

--- a/sdk/src/clients/v2/__tests__/subaccount.spec.ts
+++ b/sdk/src/clients/v2/__tests__/subaccount.spec.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import type { OrderStatusResponse, PrepareOrderRequest, SubmitOrderRequest } from "utils/orderTransactions/api";
+import type { PrepareOrderRequest, SubmitOrderRequest } from "utils/orderTransactions/api";
 import { getEmptySubaccountApproval } from "utils/subaccount";
 
 import { GmxApiSdk } from "../index";
 import {
   buildPreparedOrderResponse,
   buildSubaccountStatusResponse,
+  getOrCreateTestSigner,
   getTestSdk,
-  getTestSigner,
-  RecordingApi,
   ScriptedOrderApi,
   TEST_CHAIN_ID,
   TEST_COLLATERAL,
@@ -17,8 +16,7 @@ import {
   TEST_SYMBOL,
 } from "./testUtil";
 
-const signer = getTestSigner();
-const hasSigner = !!signer;
+const signer = getOrCreateTestSigner();
 
 const LIMIT_TRIGGER_PRICE = 1n * 10n ** 30n;
 const EXTERNAL_SUBACCOUNT_ADDRESS = "0x1111111111111111111111111111111111111111";
@@ -38,47 +36,8 @@ function buildTestPrepareRequest(from: string): PrepareOrderRequest {
   };
 }
 
-async function waitForSubaccountNoopApproval(sdk: GmxApiSdk, account: string): Promise<void> {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < 30000) {
-    await sdk.refreshSubaccountState(account);
-
-    if (sdk.subaccountApprovalMessage?.signature === "0x") {
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-  }
-
-  throw new Error("Timed out waiting for subaccount approval to sync on-chain");
-}
-
-async function waitForOrderCreatedOrExecuted(sdk: GmxApiSdk, requestId: string): Promise<OrderStatusResponse> {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < 180000) {
-    const status = await sdk.fetchOrderStatus({ requestId });
-
-    if (
-      status.status === "created" ||
-      status.status === "executed" ||
-      status.status === "cancelled" ||
-      status.status === "relay_failed" ||
-      status.status === "relay_reverted"
-    ) {
-      return status;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-  }
-
-  return sdk.fetchOrderStatus({ requestId });
-}
-
 describe("GmxApiSdk — subaccount (1CT)", () => {
-  it.skipIf(!hasSigner)("rejects external subaccount details for SDK-managed signing", async () => {
-    const signer = getTestSigner()!;
+  it("rejects external subaccount details for SDK-managed signing", async () => {
     const api = new ScriptedOrderApi(buildPreparedOrderResponse("request-1"));
     const sdk = new GmxApiSdk({ chainId: TEST_CHAIN_ID, api });
     const subaccountAddress = await sdk.generateSubaccount(signer);
@@ -101,8 +60,7 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(api.prepareRequests).toHaveLength(0);
   });
 
-  it.skipIf(!hasSigner)("keeps prepared subaccount approval after failed submit response", async () => {
-    const signer = getTestSigner()!;
+  it("keeps prepared subaccount approval after failed submit response", async () => {
     const requestId = "retry-request";
     const api = new ScriptedOrderApi(
       buildPreparedOrderResponse(requestId),
@@ -147,8 +105,7 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(api.submitRequests[1].eip712Data?.subaccountApproval?.signature).toBe("0x");
   });
 
-  it.skipIf(!hasSigner)("decrements cached subaccount actions only after final order status", async () => {
-    const signer = getTestSigner()!;
+  it("decrements cached subaccount actions only after final order status", async () => {
     const requestId = "accepted-request";
     const api = new ScriptedOrderApi(
       buildPreparedOrderResponse(requestId),
@@ -185,8 +142,7 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(sdk.subaccountStatus?.remainingActions).toBe(1n);
   });
 
-  it.skipIf(!hasSigner)("does not decrement cached subaccount actions for relay_accepted status", async () => {
-    const signer = getTestSigner()!;
+  it("does not decrement cached subaccount actions for relay_accepted status", async () => {
     const requestId = "relay-accepted-request";
     const api = new ScriptedOrderApi(
       buildPreparedOrderResponse(requestId),
@@ -223,8 +179,7 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(sdk.subaccountStatus?.remainingActions).toBe(2n);
   });
 
-  it.skipIf(!hasSigner)("refreshes subaccount state before noop approval when only one action remains", async () => {
-    const signer = getTestSigner()!;
+  it("refreshes subaccount state before noop approval when only one action remains", async () => {
     const api = new ScriptedOrderApi(
       buildPreparedOrderResponse("request-1"),
       [],
@@ -249,8 +204,7 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(api.prepareRequests).toHaveLength(0);
   });
 
-  it.skipIf(!hasSigner)("validates caller-supplied noop approval against exhausted subaccount quota", async () => {
-    const signer = getTestSigner()!;
+  it("validates caller-supplied noop approval against exhausted subaccount quota", async () => {
     const api = new ScriptedOrderApi(
       buildPreparedOrderResponse("request-1"),
       [],
@@ -276,121 +230,30 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(api.prepareRequests).toHaveLength(0);
   });
 
-  it.skipIf(!hasSigner)(
-    "e2e applies approval once and uses noop approval for the next order",
-    async () => {
-      const signer = getTestSigner()!;
-      const account = signer.address;
-      const recordingApi = new RecordingApi(getTestSdk().ctx.api);
-      const sdkSub = new GmxApiSdk({ chainId: TEST_CHAIN_ID, api: recordingApi });
-      const cleanupSdk = new GmxApiSdk({ chainId: TEST_CHAIN_ID, api: recordingApi });
-
-      try {
-        const subaccountAddress = await sdkSub.generateSubaccount(signer);
-        const statusBefore = await sdkSub.refreshSubaccountState(account);
-
-        await sdkSub.activateSubaccount(signer, {
-          expiresInSeconds: 86400,
-          maxAllowedCount: (statusBefore?.maxAllowedCount ?? 0n) + 2n,
-        });
-
-        const signedApproval = sdkSub.subaccountApprovalMessage;
-        expect(signedApproval).toBeDefined();
-        expect(signedApproval!.signature).not.toBe("0x");
-
-        const first = await sdkSub.executeExpressOrder(
-          {
-            kind: "increase",
-            symbol: TEST_SYMBOL,
-            direction: "long",
-            orderType: "limit",
-            size: TEST_SIZE_USD,
-            triggerPrice: LIMIT_TRIGGER_PRICE,
-            collateralToken: "USDC",
-            collateralToPay: TEST_COLLATERAL,
-            mode: "express",
-            from: account,
-          },
-          signer
-        );
-
-        expect(first.requestId).toBeDefined();
-        const firstStatus = await waitForOrderCreatedOrExecuted(sdkSub, first.requestId);
-        expect(["created", "executed"]).toContain(firstStatus.status);
-
-        expect(recordingApi.orderPrepareRequests[0].subaccountAddress).toBe(subaccountAddress);
-        expect(recordingApi.orderPrepareRequests[0].subaccountApproval?.signature).toBe(signedApproval!.signature);
-        expect(recordingApi.orderSubmitRequests[0].eip712Data?.subaccountApproval?.signature).toBe(
-          signedApproval!.signature
-        );
-
-        await waitForSubaccountNoopApproval(sdkSub, account);
-
-        const staleApproval = signedApproval!;
-        await sdkSub.prepareOrder({
-          kind: "increase",
-          symbol: TEST_SYMBOL,
-          direction: "long",
-          orderType: "limit",
-          size: TEST_SIZE_USD,
-          triggerPrice: LIMIT_TRIGGER_PRICE,
-          collateralToken: "USDC",
-          collateralToPay: TEST_COLLATERAL,
-          mode: "express",
-          from: account,
-          subaccountAddress,
-          subaccountApproval: staleApproval,
-        });
-
-        expect(recordingApi.orderPrepareRequests[1].subaccountApproval?.signature).toBe("0x");
-      } finally {
-        try {
-          const prepared = await cleanupSdk.prepareCancelOrder({ all: true, mode: "express", from: account });
-          const cancelSignature = await cleanupSdk.signOrder(prepared, signer);
-          await cleanupSdk.submitOrder({
-            mode: prepared.mode,
-            requestId: prepared.requestId,
-            signature: cancelSignature,
-            from: account,
-            idempotencyKey: prepared.idempotencyKey,
-            eip712Data: {
-              batchParams: prepared.payload.batchParams,
-              relayParams: prepared.payload.relayParams,
-            },
-          });
-        } catch {
-          // cleanup best-effort
-        }
-        sdkSub.clearSubaccount();
-      }
-    },
-    300000
-  );
-
-  it.skipIf(!hasSigner)("generateSubaccount derives address deterministically", async () => {
+  it("generateSubaccount derives address deterministically", async () => {
     const sdk1 = getTestSdk();
     const sdk2 = getTestSdk();
 
-    const addr1 = await sdk1.generateSubaccount(signer!);
-    const addr2 = await sdk2.generateSubaccount(signer!);
+    const addr1 = await sdk1.generateSubaccount(signer);
+    const addr2 = await sdk2.generateSubaccount(signer);
 
     expect(addr1).toBeDefined();
     expect(addr1.startsWith("0x")).toBe(true);
     expect(addr1).toBe(addr2);
   });
 
-  it.skipIf(!hasSigner)("subaccountAddress getter works after generate", async () => {
+  it("subaccountAddress getter works after generate", async () => {
     const sdk = getTestSdk();
     expect(sdk.subaccountAddress).toBeUndefined();
 
-    await sdk.generateSubaccount(signer!);
+    await sdk.generateSubaccount(signer);
     expect(sdk.subaccountAddress).toBeDefined();
     expect(sdk.hasActiveSubaccount).toBe(false);
   });
 
-  it.skipIf(!hasSigner)("clearSubaccount resets state", async () => {
+  it("clearSubaccount resets state", async () => {
     const sdk = getTestSdk();
-    await sdk.generateSubaccount(signer!);
+    await sdk.generateSubaccount(signer);
 
     expect(sdk.subaccountAddress).toBeDefined();
     sdk.clearSubaccount();
@@ -398,10 +261,10 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(sdk.hasActiveSubaccount).toBe(false);
   });
 
-  it.skipIf(!hasSigner)("activateSubaccount prepares and signs approval", async () => {
+  it("activateSubaccount prepares and signs approval", async () => {
     const sdk = getTestSdk();
 
-    const address = await sdk.activateSubaccount(signer!, {
+    const address = await sdk.activateSubaccount(signer, {
       expiresInSeconds: 86400,
       maxAllowedCount: 10,
     });
@@ -411,12 +274,12 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(sdk.hasActiveSubaccount).toBe(true);
   });
 
-  it.skipIf(!hasSigner)("fetchSubaccountStatus returns data", async () => {
+  it("fetchSubaccountStatus returns data", async () => {
     const sdk = getTestSdk();
-    const subAddr = await sdk.generateSubaccount(signer!);
+    const subAddr = await sdk.generateSubaccount(signer);
 
     const status = await sdk.fetchSubaccountStatus({
-      account: signer!.address,
+      account: signer.address,
       subaccountAddress: subAddr,
     });
 
@@ -425,9 +288,9 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
     expect(status.approvalNonce).toBeDefined();
   });
 
-  it.skipIf(!hasSigner)("signOrder uses subaccount signer when active", async () => {
+  it("signOrder uses subaccount signer when active", async () => {
     const sdk = getTestSdk();
-    await sdk.activateSubaccount(signer!, {
+    await sdk.activateSubaccount(signer, {
       expiresInSeconds: 86400,
       maxAllowedCount: 10,
     });
@@ -440,11 +303,11 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
       size: 100n * 10n ** 30n,
       collateralToPay: { amount: 1000000n, token: "USDC" },
       mode: "express",
-      from: signer!.address,
+      from: signer.address,
       subaccountAddress: sdk.subaccountAddress,
     });
 
-    const signature = await sdk.signOrder(prepared, signer!);
+    const signature = await sdk.signOrder(prepared, signer);
     expect(signature).toBeDefined();
     expect(signature.startsWith("0x")).toBe(true);
   });

--- a/sdk/src/clients/v2/__tests__/subaccountLifecycle.spec.ts
+++ b/sdk/src/clients/v2/__tests__/subaccountLifecycle.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import type { OrderStatusResponse } from "utils/orderTransactions/api";
+
+import { GmxApiSdk } from "../index";
+import {
+  getTestSdk,
+  RecordingApi,
+  requireSigner,
+  TEST_CHAIN_ID,
+  TEST_COLLATERAL,
+  TEST_SIZE_USD,
+  TEST_SYMBOL,
+} from "./testUtil";
+
+const signer = requireSigner();
+
+const LIMIT_TRIGGER_PRICE = 1n * 10n ** 30n;
+
+async function waitForSubaccountNoopApproval(sdk: GmxApiSdk, account: string): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 30000) {
+    await sdk.refreshSubaccountState(account);
+
+    if (sdk.subaccountApprovalMessage?.signature === "0x") {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error("Timed out waiting for subaccount approval to sync on-chain");
+}
+
+async function waitForOrderCreatedOrExecuted(sdk: GmxApiSdk, requestId: string): Promise<OrderStatusResponse> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 180000) {
+    const status = await sdk.fetchOrderStatus({ requestId });
+
+    if (
+      status.status === "created" ||
+      status.status === "executed" ||
+      status.status === "cancelled" ||
+      status.status === "relay_failed" ||
+      status.status === "relay_reverted"
+    ) {
+      return status;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  return sdk.fetchOrderStatus({ requestId });
+}
+
+describe("GmxApiSdk — subaccount (1CT) live flow", () => {
+  it("e2e applies approval once and uses noop approval for the next order", async () => {
+    const account = signer.address;
+    const recordingApi = new RecordingApi(getTestSdk().ctx.api);
+    const sdkSub = new GmxApiSdk({ chainId: TEST_CHAIN_ID, api: recordingApi });
+    const cleanupSdk = new GmxApiSdk({ chainId: TEST_CHAIN_ID, api: recordingApi });
+
+    try {
+      const subaccountAddress = await sdkSub.generateSubaccount(signer);
+      const statusBefore = await sdkSub.refreshSubaccountState(account);
+
+      await sdkSub.activateSubaccount(signer, {
+        expiresInSeconds: 86400,
+        maxAllowedCount: (statusBefore?.maxAllowedCount ?? 0n) + 2n,
+      });
+
+      const signedApproval = sdkSub.subaccountApprovalMessage;
+      expect(signedApproval).toBeDefined();
+      expect(signedApproval!.signature).not.toBe("0x");
+
+      const first = await sdkSub.executeExpressOrder(
+        {
+          kind: "increase",
+          symbol: TEST_SYMBOL,
+          direction: "long",
+          orderType: "limit",
+          size: TEST_SIZE_USD,
+          triggerPrice: LIMIT_TRIGGER_PRICE,
+          collateralToken: "USDC",
+          collateralToPay: TEST_COLLATERAL,
+          mode: "express",
+          from: account,
+        },
+        signer
+      );
+
+      expect(first.requestId).toBeDefined();
+      const firstStatus = await waitForOrderCreatedOrExecuted(sdkSub, first.requestId);
+      expect(["created", "executed"]).toContain(firstStatus.status);
+
+      expect(recordingApi.orderPrepareRequests[0].subaccountAddress).toBe(subaccountAddress);
+      expect(recordingApi.orderPrepareRequests[0].subaccountApproval?.signature).toBe(signedApproval!.signature);
+      expect(recordingApi.orderSubmitRequests[0].eip712Data?.subaccountApproval?.signature).toBe(
+        signedApproval!.signature
+      );
+
+      await waitForSubaccountNoopApproval(sdkSub, account);
+
+      const staleApproval = signedApproval!;
+      await sdkSub.prepareOrder({
+        kind: "increase",
+        symbol: TEST_SYMBOL,
+        direction: "long",
+        orderType: "limit",
+        size: TEST_SIZE_USD,
+        triggerPrice: LIMIT_TRIGGER_PRICE,
+        collateralToken: "USDC",
+        collateralToPay: TEST_COLLATERAL,
+        mode: "express",
+        from: account,
+        subaccountAddress,
+        subaccountApproval: staleApproval,
+      });
+
+      expect(recordingApi.orderPrepareRequests[1].subaccountApproval?.signature).toBe("0x");
+    } finally {
+      try {
+        const prepared = await cleanupSdk.prepareCancelOrder({ all: true, mode: "express", from: account });
+        const cancelSignature = await cleanupSdk.signOrder(prepared, signer);
+        await cleanupSdk.submitOrder({
+          mode: prepared.mode,
+          requestId: prepared.requestId,
+          signature: cancelSignature,
+          from: account,
+          idempotencyKey: prepared.idempotencyKey,
+          eip712Data: {
+            batchParams: prepared.payload.batchParams,
+            relayParams: prepared.payload.relayParams,
+          },
+        });
+      } catch {
+        // cleanup best-effort
+      }
+      sdkSub.clearSubaccount();
+    }
+  }, 300000);
+});

--- a/sdk/src/clients/v2/__tests__/testUtil.ts
+++ b/sdk/src/clients/v2/__tests__/testUtil.ts
@@ -23,7 +23,9 @@ export const TEST_CHAIN_ID = ARBITRUM;
 
 export const TEST_SYMBOL = "ETH/USD [WETH-USDC]";
 export const TEST_SIZE_USD = 10n * 10n ** 30n; // $10
-export const TEST_COLLATERAL = { amount: 1000000n, token: "USDC" }; // 1 USDC
+// Must clear MIN_COLLATERAL_USD ($1 on Arbitrum) after fees, otherwise the keeper
+// cancels the order with LiquidatablePosition.
+export const TEST_COLLATERAL = { amount: 3000000n, token: "USDC" }; // 3 USDC
 
 const TERMINAL_STATUSES = new Set(["executed", "cancelled", "relay_failed", "relay_reverted"]);
 const ORDER_PREPARE_PATHS = new Set([

--- a/sdk/src/clients/v2/__tests__/testUtil.ts
+++ b/sdk/src/clients/v2/__tests__/testUtil.ts
@@ -1,3 +1,5 @@
+import { generatePrivateKey } from "viem/accounts";
+
 import { ARBITRUM, getViemChain } from "configs/chains";
 import { sleep } from "utils/common";
 import type { IHttp } from "utils/http/types";
@@ -162,6 +164,17 @@ export function requireSigner(): PrivateKeySigner {
     throw new Error("GMX_TEST_PRIVATE_KEY env var is required for this test");
   }
   return signer;
+}
+
+let ephemeralSigner: PrivateKeySigner | undefined;
+
+export function getOrCreateTestSigner(): PrivateKeySigner {
+  const signer = getTestSigner();
+  if (signer) return signer;
+  if (!ephemeralSigner) {
+    ephemeralSigner = new PrivateKeySigner(generatePrivateKey() as `0x${string}`);
+  }
+  return ephemeralSigner;
 }
 
 export function hasRpcUrl(): boolean {

--- a/sdk/vitest.v2.public.config.ts
+++ b/sdk/vitest.v2.public.config.ts
@@ -1,0 +1,32 @@
+import path from "path";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    testTimeout: 90_000,
+    fileParallelism: false,
+    maxConcurrency: 1,
+    include: [
+      "src/clients/v2/__tests__/data.spec.ts",
+      "src/clients/v2/__tests__/errors.spec.ts",
+      "src/clients/v2/__tests__/subaccount.spec.ts",
+      "src/clients/v2/__tests__/multichain.spec.ts",
+    ],
+    exclude: ["**/build/**", "**/node_modules/**"],
+    // eslint-disable-next-line no-restricted-globals
+    env: loadEnv("test", process.cwd(), ""),
+  },
+  resolve: {
+    alias: {
+      configs: path.resolve(__dirname, "./src/configs"),
+      utils: path.resolve(__dirname, "./src/utils"),
+      codegen: path.resolve(__dirname, "./src/codegen"),
+      abis: path.resolve(__dirname, "./src/abis"),
+      clients: path.resolve(__dirname, "./src/clients"),
+      test: path.resolve(__dirname, "./src/test"),
+    },
+  },
+});


### PR DESCRIPTION
Closes FEDEV-3988

## What

Splits the SDK v2 e2e suite into two tiers and wires both into CI:

- **Public tier** (`yarn test:v2:public`, new step in pr-tests.yml): data, errors, subaccount and multichain specs run against the production API without any secrets — an ephemeral throwaway signer is generated when `GMX_TEST_PRIVATE_KEY` is not set. Signing is local; nothing is funded or broadcast.
- **Funded tier** (`yarn test:v2`, new sdk-e2e.yml workflow): the full suite, including the three tests that submit real orders (moved to `errorsLifecycle.spec.ts` / `subaccountLifecycle.spec.ts`). Runs on every push to `release` / `release-*` and via workflow_dispatch. Bridge tests that move funds cross-chain stay behind `GMX_TEST_SEND`, enabled by a dispatch input.

Also fixes the stale `/v1` suffix in `sdk/.env.example` (SDK request paths already include it).

## Verification

- Public suite: green twice with zero env vars — 50 passed / 2 skipped (~20s) against the production API.
- Funded config collects all 10 files / 130 tests (collection check; a live run needs the funded wallet).
- sdk `tscheck:ci` and `lint:ci` green; unit suite 494/495 — the one failure is the pre-existing live-keeper timeout in `markets.spec.ts`, unrelated to this diff and green in GitHub CI.

## Prerequisites for the funded workflow

Repo secrets (the workflow fails with a clear message until they are set):
- `GMX_TEST_PRIVATE_KEY` — dedicated e2e wallet (USDC on Arbitrum; ETH + USDC on Base for bridges)
- `GMX_TEST_RPC_URL` — Arbitrum RPC for classic on-chain submits
- `GMX_TEST_SOURCE_RPC_URL` — Base RPC for bridges
- optional repo variable `GMX_TEST_API_URL` to target a non-prod API

Note: the workflow triggers on release branches once this file exists on them, i.e. starting with branches cut after this lands on master.