### PR TITLE
Hotfix point subsquid slots at c9407b

### DIFF
--- a/sdk/scripts/subsquid-codegen.ts
+++ b/sdk/scripts/subsquid-codegen.ts
@@ -1,7 +1,7 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum@bac941/api/graphql",
+  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum@c9407b/api/graphql",
   overwrite: true,
   debug: true,
   generates: {

--- a/sdk/src/clients/v1/testUtil.ts
+++ b/sdk/src/clients/v1/testUtil.ts
@@ -19,7 +19,7 @@ export const arbitrumSdkConfig: GmxSdkConfig = {
   oracleUrl: "https://arbitrum-api.gmxinfra.io",
   rpcUrl: "https://arb1.arbitrum.io/rpc",
   walletClient: client,
-  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@bac941/api/graphql",
+  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@c9407b/api/graphql",
 };
 
 export const arbitrumSdk = new GmxSdk(arbitrumSdkConfig);

--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -21,7 +21,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-arbitrum-referrals/master-240506225935-51167d5/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-260605170830-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@bac941/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@c9407b/api/graphql",
   },
 
   [AVALANCHE]: {
@@ -31,7 +31,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-avalanche-referrals/master-240415215829-f6877d6/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-avalanche-stats/master-260605222642-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche@bac941/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche@c9407b/api/graphql",
   },
 
   [AVALANCHE_FUJI]: {
@@ -43,7 +43,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
   },
 
   [ARBITRUM_SEPOLIA]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia@bac941/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia@c9407b/api/graphql",
   },
 
   [MEGAETH]: {


### PR DESCRIPTION
## Problem

Cross-chain GMX Account funding history is empty for every new operation. Same-chain funding history still works.

## Root cause

Subsquid slots are short commit hashes of `gmx-squid`. Production sits on `@bac941` = `bac9411 Add v2.2c reader bindings` (Jul 24), which predates:

- `777ba45 Index multichain funding for the v2.2c LayerZeroProvider` (Jul 28)
- `c9407b1 Merge PR #192 fix-lz-providers-v22c` (Jul 29)

Once traffic moved to the v2.2c `LayerZeroProvider` today, `@bac941` stopped writing `MultichainFundingSendEvent`. The `OFTReceived` events on the source chain then fell into the unhappy path in `sourceChainMultichainFunding.ts:148` and were stored with `isUncertain: true`. The `multichainFunding` resolver joins send + receive by guid, so with no send it returns no row. `multichainSamechainFundingEvent` is written by a separate mapper, which is why same-chain history survived.

Arbitrum event counts per day, `@bac941`:

| day | send | recv (uncertain) | same-chain |
|---|---|---|---|
| **08-01** | **1** | **69 (68)** | 11 |
| 07-31 | 12 | 12 (0) | 41 |
| 07-30 | 24 | 25 (0) | 23 |
| 07-29 | 24 | 24 (0) | 14 |
| 07-28 | 43 | 43 (0) | 29 |

## Fix

Point Arbitrum, Avalanche and Arbitrum Sepolia at `@c9407b`, which is deployed and in sync.

Verified against a live deposit (`0x74E2366bc3ed994C942e696242842Fed1AB3F004`, Base to Arbitrum, 08-01 16:22 UTC):

| slot | `multichainFunding` rows |
|---|---|
| `@bac941` | 0 |
| `@c9407b` | 1, `step: executed` |

Send events today: `@bac941` 1, `@c9407b` 20.

The `@c9407b` GraphQL schema is a strict superset of `@bac941` (adds `Query.marketsFeeUsdByPeriod` plus `MarketFeeUsdByPeriod` / `MarketsFeeUsdWhereInput`); nothing removed or renamed, so `sdk/src/codegen/subsquid.ts` needs no regeneration.

## Not covered here

- **MegaETH stays on `@bac941`** because `gmx-synthetics-megaeth@c9407b` returns 404. That squid currently has zero multichain events, so the regression does not show there yet, but it will once traffic starts. Needs a separate deploy.
- **`isUncertain` noise.** Even on `@c9407b` today 56 of 76 receives are uncertain, against 0/day for the previous ten days, arriving roughly once a minute from all three source chains. It does not affect history (those rows never join into `multichainFunding`), but it looks like the processor is picking up unrelated Stargate transfers through the same pool. Worth a look at the stargate address filter on the squid side.

## Testing

Local run of everything in `pr-tests.yml` except the `sdk-standalone` job:

- `yarn lint:ci`, `yarn tscheck:ci`, `yarn test:ci` — 1163 passed, 14 skipped
- `cd sdk && yarn build`, `yarn lint:ci`, `yarn tscheck:ci`, `yarn test:ci` — 572 passed
- `cd sdk && yarn test:multicall` — 14 passed, 1 skipped; `trades.spec.ts` hits the new slot through `testUtil.ts` and passes
