### PR TITLE
Fix percentage-scaled factor formatting FEDEV-4149

### DIFF
--- a/sdk/src/utils/__tests__/numbers.spec.ts
+++ b/sdk/src/utils/__tests__/numbers.spec.ts
@@ -411,6 +411,14 @@ describe("formatFactor", () => {
     expect(formatFactor(1000000000000000000000000000n)).toBe("0.001");
     expect(formatFactor(1000000000000000000000000000000n)).toBe("1");
   });
+
+  it("should format percentage-scaled factors", () => {
+    expect(formatFactor(PRECISION * 10n)).toBe("10");
+    expect(formatFactor(PRECISION * 30n)).toBe("30");
+    expect(formatFactor(PRECISION * 80n)).toBe("80");
+    expect(formatFactor(PRECISION * 100n)).toBe("100");
+    expect(formatFactor(PRECISION * 1000n)).toBe("1000");
+  });
 });
 
 describe("formatPercentage", () => {

--- a/sdk/src/utils/numbers/utils.ts
+++ b/sdk/src/utils/numbers/utils.ts
@@ -544,8 +544,8 @@ export function formatFactor(factor: bigint) {
       .abs(factor)
       .toString()
       .match(/^(.+?)(?<zeroes>0*)$/)?.groups?.zeroes?.length || 0;
-  const factorDecimals = 30 - trailingZeroes;
-  return formatAmount(factor, 30, factorDecimals);
+  const factorDecimals = Math.max(PRECISION_DECIMALS - trailingZeroes, 0);
+  return formatAmount(factor, PRECISION_DECIMALS, factorDecimals);
 }
 export function numberWithCommas(x: BigNumberish, { showDollar = false }: { showDollar?: boolean } = {}) {
   if (x === undefined || x === null) {


### PR DESCRIPTION
## Summary

Prevent Borrowing Fees tooltips on the Monitor page from crashing when kink-model optimal usage factors format as integer percentages.

Linear: https://linear.app/gmx-io/issue/FEDEV-4149

## Root cause

`formatFactor` derived its display precision by subtracting the factor's trailing zero count from the 30-decimal factor precision. Percentage-scaled integer values such as 30%, 80%, and 100% have more than 30 trailing zeroes, producing a negative display precision that reached `String.repeat` and threw a `RangeError`.

## Changes

- Clamp the inferred factor display precision to zero.
- Reuse `PRECISION_DECIMALS` instead of duplicating the factor precision.
- Add regression coverage for percentage-scaled factors from 10% through 1000%, including 30%, 80%, and 100%.

## Validation

- `yarn test:ci` — 1,163 passed, 14 skipped
- `yarn test:ct` — 187 passed
- `cd sdk && yarn test:ci` — 573 passed
- `cd sdk && yarn lint:ci`
- `cd sdk && yarn tscheck:ci`
- Repository pre-commit quality gate
