### PR TITLE
Batch approvals and trades with EIP-5792 FEDEV-4153

### DIFF
--- a/src/components/GmxAccountModal/DepositStatusView.tsx
+++ b/src/components/GmxAccountModal/DepositStatusView.tsx
@@ -11,6 +11,7 @@ import { getToken } from "sdk/configs/tokens";
 
 import { Amount } from "components/Amount/Amount";
 import Button from "components/Button/Button";
+import { OneClickTokenApprovalPreview } from "components/OneClickAdvancedSettings/OneClickTokenApprovalPreview";
 import TokenIcon from "components/TokenIcon/TokenIcon";
 
 import CheckCircleIcon from "img/ic_check_circle.svg?react";
@@ -137,6 +138,7 @@ export const DepositStatusView = () => {
         </div>
         <img src={OneClickCoinImage} alt={t`One-Click`} className="mr-6 mt-6 h-93 w-92 transform" />
       </div>
+      <OneClickTokenApprovalPreview className="mt-0" />
       <Button variant="primary" size="medium" onClick={onEnableOneClickClick} disabled={isSubaccountActivating}>
         {isSubaccountActivating ? <SpinnerIcon className="size-16 animate-spin" /> : null}
         <Trans>Enable One-Click Trading</Trans>

--- a/src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.spec.tsx
+++ b/src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.spec.tsx
@@ -1,0 +1,70 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { OneClickTokenApprovalPreview } from "./OneClickTokenApprovalPreview";
+
+const approvalState = vi.hoisted(() => ({
+  current: {
+    canBatch: true,
+    isApproving: false,
+    pendingTokens: [
+      { address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa", symbol: "USDC" },
+      { address: "0xBbbBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbbBBbB", symbol: "WETH" },
+    ],
+  },
+}));
+
+vi.mock("context/SubaccountContext/SubaccountContextProvider", () => ({
+  useSubaccountContext: () => ({ oneClickTokenApproval: approvalState.current }),
+}));
+
+vi.mock("components/TokenIcon/TokenIcon", () => ({
+  default: ({ symbol }: { symbol: string }) => <span data-token-symbol={symbol} />,
+}));
+
+beforeAll(() => {
+  i18n.load("en", {});
+  i18n.activate("en");
+});
+
+afterEach(() => {
+  cleanup();
+  approvalState.current = {
+    canBatch: true,
+    isApproving: false,
+    pendingTokens: [
+      { address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa", symbol: "USDC" },
+      { address: "0xBbbBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbbBBbB", symbol: "WETH" },
+    ],
+  };
+});
+
+describe("OneClickTokenApprovalPreview", () => {
+  it("lists each pending token as an unlimited optional approval", () => {
+    const view = render(
+      <I18nProvider i18n={i18n}>
+        <OneClickTokenApprovalPreview />
+      </I18nProvider>
+    );
+
+    expect(view.getByText("Optional token approvals")).toBeTruthy();
+    expect(view.getByText("USDC")).toBeTruthy();
+    expect(view.getByText("WETH")).toBeTruthy();
+    expect(view.getAllByText("Unlimited")).toHaveLength(2);
+    expect(view.getByText("Skipping this request won't interrupt One-Click setup.")).toBeTruthy();
+  });
+
+  it("stays hidden when atomic batching is unavailable", () => {
+    approvalState.current.canBatch = false;
+
+    const view = render(
+      <I18nProvider i18n={i18n}>
+        <OneClickTokenApprovalPreview />
+      </I18nProvider>
+    );
+
+    expect(view.container.querySelector('[data-qa="one-click-token-approval-preview"]')).toBeNull();
+  });
+});

--- a/src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+++ b/src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
@@ -1,0 +1,55 @@
+import { Trans } from "@lingui/macro";
+import cx from "classnames";
+
+import { useSubaccountContext } from "context/SubaccountContext/SubaccountContextProvider";
+
+import TokenIcon from "components/TokenIcon/TokenIcon";
+
+import SpinnerIcon from "img/ic_spinner.svg?react";
+
+export function OneClickTokenApprovalPreview({ className }: { className?: string }) {
+  const { oneClickTokenApproval } = useSubaccountContext();
+
+  if (!oneClickTokenApproval?.canBatch || oneClickTokenApproval.pendingTokens.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cx("mt-8 rounded-8 border-1/2 border-slate-600 bg-slate-950/40 p-10", className)}
+      data-qa="one-click-token-approval-preview"
+    >
+      <div className="text-13 font-medium text-typography-primary">
+        <Trans>Optional token approvals</Trans>
+      </div>
+      <div className="mt-2 text-12 text-typography-secondary">
+        <Trans>Approve One-Click gas payment tokens in one wallet confirmation.</Trans>
+      </div>
+
+      <div className="mt-8 flex flex-col gap-6">
+        {oneClickTokenApproval.pendingTokens.map((token) => (
+          <div key={token.address} className="flex items-center justify-between gap-8 text-12">
+            <div className="flex items-center gap-6 text-typography-primary">
+              <TokenIcon symbol={token.symbol} displaySize={16} />
+              <span>{token.symbol}</span>
+            </div>
+            <span className="text-typography-secondary">
+              <Trans>Unlimited</Trans>
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 flex items-center gap-6 text-12 text-typography-secondary">
+        {oneClickTokenApproval.isApproving && <SpinnerIcon className="size-14 animate-spin" />}
+        <span>
+          {oneClickTokenApproval.isApproving ? (
+            <Trans>Confirm the optional approval in your wallet</Trans>
+          ) : (
+            <Trans>Skipping this request won't interrupt One-Click setup.</Trans>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PositionEditor/usePositionEditorButtonState.tsx
+++ b/src/components/PositionEditor/usePositionEditorButtonState.tsx
@@ -54,6 +54,7 @@ import {
   ValidationButtonTooltipName,
   ValidationResult,
 } from "domain/synthetics/trade/utils/validation";
+import { useAtomicTokenApproval } from "domain/tokens/useAtomicTokenApproval";
 import { useTokenApproval } from "domain/tokens/useTokenApproval";
 import { bigNumberBinarySearch } from "lib/binarySearch";
 import { useChainId } from "lib/chains";
@@ -72,6 +73,7 @@ import { userAnalytics } from "lib/userAnalytics";
 import type { TokenApproveClickEvent, TokenApproveResultEvent } from "lib/userAnalytics/types";
 import useWallet from "lib/wallets/useWallet";
 import { getToken } from "sdk/configs/tokens";
+import { bigMath } from "sdk/utils/bigmath";
 import {
   BatchOrderTxnParams,
   CreateOrderTxnParams,
@@ -270,7 +272,7 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
     if (expressParams?.gasPaymentParams) {
       list.push({
         tokenAddress: expressParams.gasPaymentParams.gasPaymentTokenAddress,
-        amount: expressParams.gasPaymentParams.gasPaymentTokenAmount,
+        amount: bigMath.mulDiv(expressParams.gasPaymentParams.gasPaymentTokenAmount, 13n, 10n),
       });
     }
 
@@ -279,6 +281,7 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
 
   const {
     tokensToApprove,
+    pendingTokenApprovals,
     isAllowanceLoaded: isAllowanceLoadedRaw,
     isApproving,
     handleApprove,
@@ -286,12 +289,29 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
     chainId,
     spenderAddress: routerAddress,
     tokens: approvalTokens,
-    allowPermit: Boolean(expressParams),
     skip: isCollateralTokenFromGmxAccount,
   });
 
   const isAllowanceLoaded =
     Boolean(selectedCollateralAddress && collateralDeltaAmount !== undefined) && isAllowanceLoadedRaw;
+
+  const atomicApprovalCount = expressParams ? 2 : 1;
+  const hasAtomicApprovalCandidate = pendingTokenApprovals.length >= atomicApprovalCount;
+  const atomicApproval = useAtomicTokenApproval({
+    chainId,
+    spenderAddress: routerAddress,
+    pendingTokenApprovals,
+    source: expressParams ? "Express" : "Classic",
+    enabled: isAllowanceLoaded && hasAtomicApprovalCandidate,
+    minApprovalCount: atomicApprovalCount,
+  });
+  const shouldBatchClassicOrder = !expressParams && atomicApproval.canBatch;
+  const shouldBatchExpressApprovals = Boolean(expressParams) && atomicApproval.canBatch;
+  const isAtomicCapabilityLoading =
+    isAllowanceLoaded &&
+    hasAtomicApprovalCandidate &&
+    !atomicApproval.isAtomicBatchingDisabled &&
+    atomicApproval.isCapabilityLoading;
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -454,8 +474,21 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
       return;
     }
 
-    if (isAllowanceLoaded && tokensToApprove.length && selectedCollateralToken) {
-      if (!chainId || isApproving) return;
+    if (isAllowanceLoaded && tokensToApprove.length && selectedCollateralToken && !shouldBatchClassicOrder) {
+      if (!chainId || isApproving || atomicApproval.isBatchApproving || isAtomicCapabilityLoading) return;
+
+      if (shouldBatchExpressApprovals) {
+        await atomicApproval.submitBatch();
+        return;
+      }
+
+      if (hasAtomicApprovalCandidate) {
+        if (atomicApproval.isAtomicBatchingDisabled) {
+          atomicApproval.trackSessionFallback();
+        } else {
+          atomicApproval.trackFallback(atomicApproval.fallbackReason);
+        }
+      }
 
       userAnalytics.pushEvent<TokenApproveClickEvent>({
         event: "TokenApproveAction",
@@ -524,12 +557,13 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
       return;
     }
 
+    const expressParamsForSubmit = getExpressParamsForSubmit(fulfilledExpressParams);
     const txnPromise = sendBatchOrderTxn({
       chainId,
       signer,
       provider,
       batchParams,
-      expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
+      expressParams: expressParamsForSubmit,
       isGmxAccount: isCollateralTokenFromGmxAccount,
       simulationParams: shouldDisableValidationForTesting
         ? undefined
@@ -544,6 +578,9 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
         actionName: "Edit Collateral",
         collateralSymbol: selectedCollateralToken?.symbol,
       }),
+      approvalCalls: shouldBatchClassicOrder && !expressParamsForSubmit ? atomicApproval.approvalCalls : undefined,
+      approvalAnalytics:
+        shouldBatchClassicOrder && !expressParamsForSubmit ? atomicApproval.analyticsContext : undefined,
     });
 
     if (expressParams?.subaccount) {
@@ -590,6 +627,18 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
     };
   }
 
+  if (atomicApproval.isBatchApproving && tokensToApprove.length) {
+    return {
+      text: (
+        <>
+          <Trans>Approve tokens</Trans> <SpinnerIcon className="ml-4 animate-spin" />
+        </>
+      ),
+      disabled: true,
+      ...commonParams,
+    };
+  }
+
   if (isExpressLoading || isMultichainSubmitDisabled) {
     return {
       text: (
@@ -629,7 +678,28 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
     };
   }
 
-  if (isAllowanceLoaded && tokensToApprove.length && selectedCollateralToken) {
+  if (isAtomicCapabilityLoading) {
+    return {
+      text: (
+        <>
+          {t`Loading...`}
+          <SpinnerIcon className="ml-4 animate-spin" />
+        </>
+      ),
+      disabled: true,
+      ...commonParams,
+    };
+  }
+
+  if (isAllowanceLoaded && tokensToApprove.length && selectedCollateralToken && !shouldBatchClassicOrder) {
+    if (shouldBatchExpressApprovals) {
+      return {
+        text: <Trans>Approve tokens</Trans>,
+        disabled: false,
+        ...commonParams,
+      };
+    }
+
     const tokenToApprove = tokensToApprove[0];
     return {
       text: t`Approve ${getToken(chainId, tokenToApprove).symbol}`,

--- a/src/components/SettingsModal/TradingSettings.tsx
+++ b/src/components/SettingsModal/TradingSettings.tsx
@@ -33,6 +33,7 @@ import { GasPaymentTokenSelector } from "components/GasPaymentTokenSelector/GasP
 import { MarginDestinationSelector } from "components/MarginDestinationSelector/MarginDestinationSelector";
 import { OldSubaccountWithdraw } from "components/OldSubaccountWithdraw/OldSubaccountWithdraw";
 import { OneClickAdvancedSettings } from "components/OneClickAdvancedSettings/OneClickAdvancedSettings";
+import { OneClickTokenApprovalPreview } from "components/OneClickAdvancedSettings/OneClickTokenApprovalPreview";
 import ToggleSwitch from "components/ToggleSwitch/ToggleSwitch";
 
 import ExpressIcon from "img/ic_express.svg?react";
@@ -181,6 +182,8 @@ export function TradingSettings({
               active={tradingMode === TradingMode.Express1CT}
               onClick={() => handleTradingModeChange(TradingMode.Express1CT)}
             />
+
+            <OneClickTokenApprovalPreview />
 
             {canSignTypedData ? (
               isOutOfGasPaymentBalance && <ExpressTradingOutOfGasBanner onClose={onClose} />

--- a/src/components/TradeBox/ExpressTradingWarningCard.tsx
+++ b/src/components/TradeBox/ExpressTradingWarningCard.tsx
@@ -46,6 +46,7 @@ import { getNativeToken, getWrappedToken } from "sdk/configs/tokens";
 import { TradeMode } from "sdk/utils/trade/types";
 
 import { ColorfulBanner, ColorfulButtonLink } from "components/ColorfulBanner/ColorfulBanner";
+import { OneClickTokenApprovalPreview } from "components/OneClickAdvancedSettings/OneClickTokenApprovalPreview";
 
 import ExpressIcon from "img/ic_express.svg?react";
 import OneClickIcon from "img/ic_one_click.svg?react";
@@ -323,6 +324,7 @@ export function ExpressTradingWarningCard({
   let buttonText: ReactNode | undefined = undefined;
   let icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>> | undefined = undefined;
   let color: "blue" | "yellow" | "red" = "blue";
+  let showOneClickTokenApprovalPreview = false;
 
   let onClick: undefined | (() => void) = undefined;
 
@@ -353,12 +355,14 @@ export function ExpressTradingWarningCard({
     color = "yellow";
     content = <Trans>One-Click Trading action limit reached. You're now using Express Trading.</Trans>;
     buttonText = <Trans>Re-enable</Trans>;
+    showOneClickTokenApprovalPreview = true;
   } else if (shouldShowNonceExpiredWarning) {
     onClick = handleUpdateSubaccountSettings;
     icon = OneClickIcon;
     color = "yellow";
     content = <Trans>One-Click Trading approval nonce expired. Re-sign to continue using One-Click Trading.</Trans>;
     buttonText = <Trans>Re-sign</Trans>;
+    showOneClickTokenApprovalPreview = true;
   } else if (shouldShowExpiredSubaccountWarning) {
     onClick = handleUpdateSubaccountSettings;
     onCloseClick = dismissExpiredSubaccountWarning;
@@ -366,6 +370,7 @@ export function ExpressTradingWarningCard({
     color = "yellow";
     content = <Trans>One-Click Trading time limit expired. You're now using Express Trading.</Trans>;
     buttonText = <Trans>Re-enable</Trans>;
+    showOneClickTokenApprovalPreview = true;
   } else if (shouldShowExternalSwapSubaccountBlockedWarning) {
     icon = OneClickIcon;
     color = "red";
@@ -446,6 +451,7 @@ export function ExpressTradingWarningCard({
     );
     buttonText = <Trans>Re-sign</Trans>;
     onClick = handleUpdateSubaccountSettings;
+    showOneClickTokenApprovalPreview = true;
   } else if (shouldShowSubaccountApprovalInvalidWarning) {
     icon = OneClickIcon;
     color = "yellow";
@@ -457,6 +463,7 @@ export function ExpressTradingWarningCard({
     );
     buttonText = <Trans>Re-sign</Trans>;
     onClick = handleUpdateSubaccountSettings;
+    showOneClickTokenApprovalPreview = true;
   } else if (shouldShowExternalSwapGasConflictOptionalWarning) {
     if (!gasTokenCandidate) {
       return null;
@@ -482,6 +489,7 @@ export function ExpressTradingWarningCard({
   return (
     <ColorfulBanner color={color} icon={icon} onClose={onCloseClick}>
       {content}
+      {showOneClickTokenApprovalPreview && <OneClickTokenApprovalPreview />}
       {onClick && (
         <ColorfulButtonLink color="blue" onClick={onClick}>
           {buttonText}

--- a/src/components/TradeBox/hooks/useTradeButtonState.tsx
+++ b/src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -75,6 +75,7 @@ import {
   ValidationButtonTooltipName,
   ValidationResult,
 } from "domain/synthetics/trade/utils/validation";
+import { useAtomicTokenApproval } from "domain/tokens/useAtomicTokenApproval";
 import { useTokenApproval } from "domain/tokens/useTokenApproval";
 import { numericBinarySearch } from "lib/binarySearch";
 import { useMultipleWalletExtensionsChainError } from "lib/chains/getMultipleWalletExtensionsChainError";
@@ -89,6 +90,7 @@ import type { TokenApproveClickEvent, TokenApproveResultEvent } from "lib/userAn
 import { useEthersSigner } from "lib/wallets/useEthersSigner";
 import { getContract } from "sdk/configs/contracts";
 import { getToken, getTokenBySymbol } from "sdk/configs/tokens";
+import { bigMath } from "sdk/utils/bigmath";
 import { ExecutionFee } from "sdk/utils/fees/types";
 import { BatchOrderTxnParams } from "sdk/utils/orderTransactions";
 import { TokenData } from "sdk/utils/tokens/types";
@@ -192,7 +194,7 @@ export function useTradeboxButtonState({
     if (expressParams?.gasPaymentParams && gasPaymentToken) {
       list.push({
         tokenAddress: gasPaymentToken.address,
-        amount: expressParams.gasPaymentParams.gasPaymentTokenAmount,
+        amount: bigMath.mulDiv(expressParams.gasPaymentParams.gasPaymentTokenAmount, 13n, 10n),
       });
     }
 
@@ -201,6 +203,7 @@ export function useTradeboxButtonState({
 
   const {
     tokensToApprove,
+    pendingTokenApprovals,
     isAllowanceLoaded: isAllowanceLoadedRaw,
     isApproving,
     handleApprove,
@@ -208,12 +211,39 @@ export function useTradeboxButtonState({
     chainId,
     spenderAddress: getContract(chainId, "SyntheticsRouter"),
     tokens: approvalTokens,
-    allowPermit: Boolean(expressParams),
     skip: isFromTokenGmxAccount,
   });
 
   const isDataReady = Boolean(fromToken && payAmount !== undefined && gasPaymentToken);
   const isAllowanceLoaded = isDataReady && isAllowanceLoadedRaw;
+  const minimumBatchApprovalCount = expressParams ? 2 : 1;
+  const isAtomicApprovalCandidate =
+    !isFromTokenGmxAccount &&
+    isAllowanceLoaded &&
+    pendingTokenApprovals.length >= minimumBatchApprovalCount &&
+    (Boolean(expressParams) || !isWrapOrUnwrap);
+  const {
+    approvalCalls,
+    analyticsContext: approvalAnalytics,
+    canBatch,
+    fallbackReason,
+    isBatchApproving,
+    isCapabilityLoading,
+    isAtomicBatchingDisabled,
+    submitBatch,
+    trackFallback,
+    trackSessionFallback,
+  } = useAtomicTokenApproval({
+    chainId,
+    spenderAddress: getContract(chainId, "SyntheticsRouter"),
+    pendingTokenApprovals,
+    source: expressParams ? "Express" : "Classic",
+    enabled: isAtomicApprovalCandidate,
+    minApprovalCount: minimumBatchApprovalCount,
+  });
+  const isAtomicCapabilityLoading = isAtomicApprovalCandidate && isCapabilityLoading;
+  const shouldBatchExpressApprovals = Boolean(expressParams) && canBatch;
+  const shouldBatchClassicOrder = !expressParams && !isWrapOrUnwrap && canBatch;
 
   const detectAndSetAvailableMaxLeverage = useDetectAndSetAvailableMaxLeverage({ setToTokenInputValue });
 
@@ -419,35 +449,58 @@ export function useTradeboxButtonState({
     }
 
     if (!isFromTokenGmxAccount && isAllowanceLoaded && tokensToApprove.length) {
-      if (!chainId || isApproving || !tokensToApprove[0]) return;
+      if (isBatchApproving || isAtomicCapabilityLoading) return;
 
-      userAnalytics.pushEvent<TokenApproveClickEvent>({
-        event: "TokenApproveAction",
-        data: { action: "ApproveClick" },
-      });
-      handleApprove({
-        onApproveFail: () =>
-          userAnalytics.pushEvent<TokenApproveResultEvent>({
-            event: "TokenApproveAction",
-            data: { action: "ApproveFail" },
-          }),
-      });
+      if (shouldBatchExpressApprovals) {
+        await submitBatch();
+        return;
+      }
 
-      return;
+      if (!shouldBatchClassicOrder) {
+        if (!chainId || isApproving || !tokensToApprove[0]) return;
+
+        if (isAtomicApprovalCandidate) {
+          if (isAtomicBatchingDisabled) {
+            trackSessionFallback();
+          } else {
+            trackFallback(fallbackReason);
+          }
+        }
+
+        userAnalytics.pushEvent<TokenApproveClickEvent>({
+          event: "TokenApproveAction",
+          data: { action: "ApproveClick" },
+        });
+        handleApprove({
+          onApproveFail: () =>
+            userAnalytics.pushEvent<TokenApproveResultEvent>({
+              event: "TokenApproveAction",
+              data: { action: "ApproveFail" },
+            }),
+        });
+
+        return;
+      }
     }
 
     setStage("processing");
 
     let txnPromise: Promise<any>;
+    const orderSubmitOptions = shouldBatchClassicOrder
+      ? {
+          approvalCalls,
+          approvalAnalytics,
+        }
+      : undefined;
 
     if (isWrapOrUnwrap) {
       txnPromise = onSubmitWrapOrUnwrap();
     } else if (isSwap) {
-      txnPromise = onSubmitSwap();
+      txnPromise = onSubmitSwap(orderSubmitOptions);
     } else if (isIncrease) {
-      txnPromise = Promise.resolve(onSubmitIncreaseOrder());
+      txnPromise = Promise.resolve(onSubmitIncreaseOrder(orderSubmitOptions));
     } else {
-      txnPromise = onSubmitDecreaseOrder();
+      txnPromise = onSubmitDecreaseOrder(orderSubmitOptions);
     }
 
     if (expressParams?.subaccount) {
@@ -468,10 +521,15 @@ export function useTradeboxButtonState({
     account,
     chainId,
     expressParams?.subaccount,
+    fallbackReason,
     fromToken,
     handleApprove,
+    isAtomicApprovalCandidate,
+    isAtomicBatchingDisabled,
     isAllowanceLoaded,
     isApproving,
+    isBatchApproving,
+    isAtomicCapabilityLoading,
     isFromTokenGmxAccount,
     isIncrease,
     isSwap,
@@ -483,12 +541,19 @@ export function useTradeboxButtonState({
     openConnectModal,
     payAmount,
     payTokenSourceChainMappedBalance,
+    approvalAnalytics,
+    approvalCalls,
     setGmxAccountDepositViewTokenAddress,
     setGmxAccountDepositViewTokenInputValue,
     setGmxAccountModalOpen,
     setStage,
     shouldShowDepositButton,
     signer,
+    shouldBatchClassicOrder,
+    shouldBatchExpressApprovals,
+    submitBatch,
+    trackFallback,
+    trackSessionFallback,
     tokensToApprove,
   ]);
 
@@ -573,6 +638,30 @@ export function useTradeboxButtonState({
       };
     }
 
+    if (isAtomicCapabilityLoading) {
+      return {
+        ...commonState,
+        text: (
+          <>
+            {t`Loading...`} <SpinnerIcon className="ml-4 animate-spin" />
+          </>
+        ),
+        disabled: true,
+      };
+    }
+
+    if (isBatchApproving && tokensToApprove.length) {
+      return {
+        ...commonState,
+        text: (
+          <>
+            <Trans>Approve tokens</Trans> <SpinnerIcon className="ml-4 animate-spin" />
+          </>
+        ),
+        disabled: true,
+      };
+    }
+
     if (isApproving && tokensToApprove.length) {
       return {
         ...commonState,
@@ -586,10 +675,14 @@ export function useTradeboxButtonState({
       };
     }
 
-    if (isAllowanceLoaded && tokensToApprove.length) {
+    if (isAllowanceLoaded && tokensToApprove.length && !shouldBatchClassicOrder) {
       return {
         ...commonState,
-        text: t`Allow ${getToken(chainId, tokensToApprove[0]).symbol} to be spent`,
+        text: shouldBatchExpressApprovals ? (
+          <Trans>Approve tokens</Trans>
+        ) : (
+          t`Allow ${getToken(chainId, tokensToApprove[0]).symbol} to be spent`
+        ),
         disabled: false,
       };
     }
@@ -669,8 +762,12 @@ export function useTradeboxButtonState({
     stopLoss.error?.percentage,
     takeProfit.error?.percentage,
     isApproving,
+    isBatchApproving,
+    isAtomicCapabilityLoading,
     tokensToApprove,
     isAllowanceLoaded,
+    shouldBatchClassicOrder,
+    shouldBatchExpressApprovals,
     stage,
     isIncrease,
     sidecarEntries,

--- a/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
+++ b/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
@@ -65,6 +65,7 @@ import {
 } from "lib/metrics/utils";
 import { getByKey } from "lib/objects";
 import { useJsonRpcProvider } from "lib/rpc";
+import type { WalletCall, WalletCallsAnalyticsContext } from "lib/transactions/sendWalletCalls";
 import { getTradeInteractionKey, sendUserAnalyticsOrderConfirmClickEvent, userAnalytics } from "lib/userAnalytics";
 import useWallet from "lib/wallets/useWallet";
 import { BatchOrderTxnParams, getBatchTotalExecutionFee } from "sdk/utils/orderTransactions";
@@ -74,6 +75,11 @@ import { useSidecarOrderPayloads } from "./useSidecarOrderPayloads";
 interface TradeboxTransactionsProps {
   setPendingTxns: (txns: any) => void;
 }
+
+type SubmitOrderOptions = {
+  approvalCalls?: WalletCall[];
+  approvalAnalytics?: WalletCallsAnalyticsContext;
+};
 
 export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactionsProps) {
   const { chainId, srcChainId } = useChainId();
@@ -321,103 +327,109 @@ export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactions
     triggerPrice,
   ]);
 
-  const onSubmitOrder = useCallback(async () => {
-    const fulfilledExpressParams = await expressParamsPromise;
+  const onSubmitOrder = useCallback(
+    async (options?: SubmitOrderOptions) => {
+      const fulfilledExpressParams = await expressParamsPromise;
 
-    const metricData = initOrderMetricData();
+      const metricData = initOrderMetricData();
 
-    sendOrderSubmittedMetric(metricData.metricId);
+      sendOrderSubmittedMetric(metricData.metricId);
 
-    const actionName = isSwap ? "Swap" : isIncrease ? "Open Position" : "Close Position";
-    const collateralSymbol = isSwap ? fromToken?.symbol : collateralToken?.symbol;
+      const actionName = isSwap ? "Swap" : isIncrease ? "Open Position" : "Close Position";
+      const collateralSymbol = isSwap ? fromToken?.symbol : collateralToken?.symbol;
 
-    if (!primaryCreateOrderParams || !signer || !provider || !tokensData || !account || !marketsInfoData) {
-      helperToast.error(t`Order submission failed`, {
-        tradingErrorInfo: { actionName, collateral: collateralSymbol, requestId: metricData.requestId },
-      });
-      sendTxnValidationErrorMetric(metricData.metricId);
-      return Promise.reject();
-    }
+      if (!primaryCreateOrderParams || !signer || !provider || !tokensData || !account || !marketsInfoData) {
+        helperToast.error(t`Order submission failed`, {
+          tradingErrorInfo: { actionName, collateral: collateralSymbol, requestId: metricData.requestId },
+        });
+        sendTxnValidationErrorMetric(metricData.metricId);
+        return Promise.reject();
+      }
 
-    if (
-      reportMultichainExpressSubmitError({
+      if (
+        reportMultichainExpressSubmitError({
+          isGmxAccount: isFromTokenGmxAccount,
+          expressParams: fulfilledExpressParams,
+          tokensData,
+          actionName,
+          collateral: collateralSymbol,
+          requestId: metricData.requestId,
+          metricId: metricData.metricId,
+        })
+      ) {
+        return Promise.reject();
+      }
+
+      sendUserAnalyticsOrderConfirmClickEvent(chainId, metricData.metricId);
+
+      const jitShiftParamsList = marketInfo
+        ? getJitGlvShiftParams(jitLiquidityMap, marketInfo.marketTokenAddress, isLong)
+        : undefined;
+      const nativeReserveLiquidity = marketInfo ? getAvailableUsdLiquidityForPosition(marketInfo, isLong) : undefined;
+      const expressParamsForSubmit = getExpressParamsForSubmit(fulfilledExpressParams);
+      return sendBatchOrderTxn({
+        chainId,
+        signer,
+        provider,
+        batchParams,
         isGmxAccount: isFromTokenGmxAccount,
-        expressParams: fulfilledExpressParams,
-        tokensData,
-        actionName,
-        collateral: collateralSymbol,
-        requestId: metricData.requestId,
-        metricId: metricData.metricId,
-      })
-    ) {
-      return Promise.reject();
-    }
-
-    sendUserAnalyticsOrderConfirmClickEvent(chainId, metricData.metricId);
-
-    const jitShiftParamsList = marketInfo
-      ? getJitGlvShiftParams(jitLiquidityMap, marketInfo.marketTokenAddress, isLong)
-      : undefined;
-    const nativeReserveLiquidity = marketInfo ? getAvailableUsdLiquidityForPosition(marketInfo, isLong) : undefined;
-    return sendBatchOrderTxn({
-      chainId,
-      signer,
-      provider,
-      batchParams,
-      isGmxAccount: isFromTokenGmxAccount,
-      expressParams: getExpressParamsForSubmit(fulfilledExpressParams),
-      simulationParams: shouldDisableValidationForTesting
-        ? undefined
-        : {
-            tokensData,
-            blockTimestampData,
-            jitShiftParamsList,
-            // Excludes JIT — determines whether JIT simulation is needed
-            nativeReserveLiquidity,
+        expressParams: expressParamsForSubmit,
+        approvalCalls: expressParamsForSubmit ? undefined : options?.approvalCalls,
+        approvalAnalytics: expressParamsForSubmit ? undefined : options?.approvalAnalytics,
+        simulationParams: shouldDisableValidationForTesting
+          ? undefined
+          : {
+              tokensData,
+              blockTimestampData,
+              jitShiftParamsList,
+              // Excludes JIT — determines whether JIT simulation is needed
+              nativeReserveLiquidity,
+            },
+        callback: makeOrderTxnCallback({
+          metricId: metricData.metricId,
+          requestId: metricData.requestId,
+          slippageInputId,
+          additionalErrorContent: undefined,
+          actionName,
+          collateralSymbol,
+          onInternalSwapFallback: () => {
+            setShouldFallbackToInternalSwap(true);
+            setShouldForceExternalSwap(false);
           },
-      callback: makeOrderTxnCallback({
-        metricId: metricData.metricId,
-        requestId: metricData.requestId,
-        slippageInputId,
-        additionalErrorContent: undefined,
-        actionName,
-        collateralSymbol,
-        onInternalSwapFallback: () => {
-          setShouldFallbackToInternalSwap(true);
-          setShouldForceExternalSwap(false);
-        },
-        onExternalSwapFallback: () => {
-          setShouldForceExternalSwap(true);
-          setShouldFallbackToInternalSwap(false);
-        },
-      }),
-    });
-  }, [
-    account,
-    batchParams,
-    blockTimestampData,
-    chainId,
-    collateralToken?.symbol,
-    expressParamsPromise,
-    fromToken?.symbol,
-    initOrderMetricData,
-    isFromTokenGmxAccount,
-    isIncrease,
-    isLong,
-    isSwap,
-    jitLiquidityMap,
-    makeOrderTxnCallback,
-    marketInfo,
-    marketsInfoData,
-    primaryCreateOrderParams,
-    provider,
-    setShouldFallbackToInternalSwap,
-    setShouldForceExternalSwap,
-    shouldDisableValidationForTesting,
-    signer,
-    slippageInputId,
-    tokensData,
-  ]);
+          onExternalSwapFallback: () => {
+            setShouldForceExternalSwap(true);
+            setShouldFallbackToInternalSwap(false);
+          },
+        }),
+      });
+    },
+    [
+      account,
+      batchParams,
+      blockTimestampData,
+      chainId,
+      collateralToken?.symbol,
+      expressParamsPromise,
+      fromToken?.symbol,
+      initOrderMetricData,
+      isFromTokenGmxAccount,
+      isIncrease,
+      isLong,
+      isSwap,
+      jitLiquidityMap,
+      makeOrderTxnCallback,
+      marketInfo,
+      marketsInfoData,
+      primaryCreateOrderParams,
+      provider,
+      setShouldFallbackToInternalSwap,
+      setShouldForceExternalSwap,
+      shouldDisableValidationForTesting,
+      signer,
+      slippageInputId,
+      tokensData,
+    ]
+  );
 
   function onSubmitWrapOrUnwrap() {
     if (!account || !swapAmounts || !fromToken || !signer) {

--- a/src/context/PendingTxnsContext/PendingTxnsContext.tsx
+++ b/src/context/PendingTxnsContext/PendingTxnsContext.tsx
@@ -10,6 +10,7 @@ import { helperToast } from "lib/helperToast";
 import { OrderMetricId, sendTxnErrorMetric } from "lib/metrics";
 import { useJsonRpcProvider } from "lib/rpc";
 import { TradingActionName } from "lib/tradingErrorTracker";
+import type { SendWalletCallsResult } from "lib/transactions/sendWalletCalls";
 import { sendUserAnalyticsOrderResultEvent } from "lib/userAnalytics";
 
 import { getInsufficientExecutionFeeToastContent } from "components/Errors/errorToasts";
@@ -20,14 +21,27 @@ export type PendingTransactionData = {
   estimatedExecutionGasLimit: bigint;
 };
 
-export type PendingTransaction = {
-  hash: string;
+type PendingTransactionBase = {
   message: ReactNode | undefined;
   messageDetails?: ReactNode;
   metricId?: OrderMetricId;
   data?: PendingTransactionData;
   actionName?: TradingActionName;
 };
+
+export type PendingTransaction = PendingTransactionBase &
+  (
+    | {
+        type?: "transaction";
+        hash: string;
+      }
+    | {
+        type: "walletCalls";
+        chainId: number;
+        callBundleId: string;
+        getCallsStatus: SendWalletCallsResult["getStatus"];
+      }
+  );
 
 export type SetPendingTransactions = Dispatch<SetStateAction<PendingTransaction[]>>;
 
@@ -45,7 +59,15 @@ export function usePendingTxns() {
   return useContext(PendingTxnsContext);
 }
 
-export function getPendingTxnFailureToastContent({ txUrl }: { txUrl: string }) {
+export function getPendingTxnFailureToastContent({ txUrl }: { txUrl?: string }) {
+  if (!txUrl) {
+    return (
+      <div>
+        <Trans>Transaction failed</Trans>
+      </div>
+    );
+  }
+
   return (
     <div>
       <Trans>
@@ -65,15 +87,19 @@ export function getPendingTxnSuccessToastContent({
 }: {
   message: ReactNode;
   messageDetails?: ReactNode;
-  txUrl: string;
+  txUrl?: string;
 }) {
   return (
     <div className="StatusNotification">
       <div className="StatusNotification-title">{message}</div>
-      <br />
-      <ExternalLink href={txUrl}>
-        <Trans>View</Trans>
-      </ExternalLink>
+      {txUrl && (
+        <>
+          <br />
+          <ExternalLink href={txUrl}>
+            <Trans>View</Trans>
+          </ExternalLink>
+        </>
+      )}
       {messageDetails && (
         <>
           <hr className="my-8 -ml-12 -mr-32 h-[1.5px] border-none bg-[#0f463d]" />
@@ -97,71 +123,99 @@ export function PendingTxnsContextProvider({ children }: { children: ReactNode }
         return;
       }
 
-      const updatedPendingTxns: any[] = [];
+      const updatedPendingTxns: PendingTransaction[] = [];
       for (let i = 0; i < pendingTxns.length; i++) {
         const pendingTxn = pendingTxns[i];
-        const receipt = await provider.getTransactionReceipt(pendingTxn.hash);
-        if (receipt) {
-          if (receipt.status === 0) {
-            const txUrl = getExplorerUrl(chainId) + "tx/" + pendingTxn.hash;
-            const { error: onchainError, txnData } = await getCallStaticError(
-              chainId,
-              provider,
-              undefined,
-              pendingTxn.hash
-            );
-            const errorData = onchainError ? parseError(onchainError as any) : undefined;
+        let hash: string | undefined;
+        let resolvedChainId: number = chainId;
+        let isSuccess = false;
+        let isFailure = false;
 
-            let toastMsg: ReactNode;
+        if (pendingTxn.type === "walletCalls") {
+          try {
+            const callsStatus = await pendingTxn.getCallsStatus();
 
-            if (errorData?.contractError === "InsufficientExecutionFee" && txnData) {
-              const [minExecutionFee, executionFee]: bigint[] = errorData.contractErrorArgs;
-
-              toastMsg = getInsufficientExecutionFeeToastContent({
-                minExecutionFee,
-                executionFee,
-                chainId,
-                executionFeeBufferBps,
-                txUrl,
-                errorMessage: errorData?.errorMessage,
-                shouldOfferExpress: true,
-                setIsSettingsVisible,
-                estimatedExecutionGasLimit: pendingTxn.data?.estimatedExecutionGasLimit ?? 1n,
-              });
-            } else {
-              toastMsg = getPendingTxnFailureToastContent({ txUrl });
+            if (callsStatus.status === "pending" || callsStatus.status === undefined) {
+              updatedPendingTxns.push(pendingTxn);
+              continue;
             }
 
-            helperToast.error(toastMsg, {
-              autoClose: false,
-              tradingErrorInfo: pendingTxn.actionName
-                ? {
-                    actionName: pendingTxn.actionName,
-                    errorData: errorData ?? onchainError,
-                    metricId: pendingTxn.metricId,
-                  }
-                : undefined,
-            });
+            hash = callsStatus.receipts?.at(-1)?.transactionHash;
+            resolvedChainId = callsStatus.chainId ?? pendingTxn.chainId;
+            isSuccess = callsStatus.status === "success" && callsStatus.atomic;
+            isFailure = !isSuccess;
+          } catch {
+            updatedPendingTxns.push(pendingTxn);
+            continue;
+          }
+        } else {
+          const receipt = await provider.getTransactionReceipt(pendingTxn.hash);
 
-            if (pendingTxn.metricId) {
-              sendTxnErrorMetric(pendingTxn.metricId, onchainError, "minting");
-              sendUserAnalyticsOrderResultEvent(chainId, pendingTxn.metricId, false);
-            }
+          if (!receipt) {
+            updatedPendingTxns.push(pendingTxn);
+            continue;
           }
 
-          if (receipt.status === 1 && pendingTxn.message) {
-            const txUrl = getExplorerUrl(chainId) + "tx/" + pendingTxn.hash;
-            helperToast.success(
-              getPendingTxnSuccessToastContent({
-                message: pendingTxn.message,
-                messageDetails: pendingTxn.messageDetails,
-                txUrl,
-              })
-            );
-          }
-          continue;
+          hash = pendingTxn.hash;
+          isSuccess = receipt.status === 1;
+          isFailure = receipt.status === 0;
         }
-        updatedPendingTxns.push(pendingTxn);
+
+        const txUrl = hash ? getExplorerUrl(resolvedChainId) + "tx/" + hash : undefined;
+
+        if (isFailure) {
+          const { error: onchainError, txnData } =
+            pendingTxn.type !== "walletCalls" && hash
+              ? await getCallStaticError(chainId, provider, undefined, hash)
+              : { error: new Error("Wallet call bundle failed"), txnData: undefined };
+          const errorData = onchainError ? parseError(onchainError as any) : undefined;
+
+          let toastMsg: ReactNode;
+
+          if (errorData?.contractError === "InsufficientExecutionFee" && txnData && txUrl) {
+            const [minExecutionFee, executionFee]: bigint[] = errorData.contractErrorArgs;
+
+            toastMsg = getInsufficientExecutionFeeToastContent({
+              minExecutionFee,
+              executionFee,
+              chainId,
+              executionFeeBufferBps,
+              txUrl,
+              errorMessage: errorData?.errorMessage,
+              shouldOfferExpress: true,
+              setIsSettingsVisible,
+              estimatedExecutionGasLimit: pendingTxn.data?.estimatedExecutionGasLimit ?? 1n,
+            });
+          } else {
+            toastMsg = getPendingTxnFailureToastContent({ txUrl });
+          }
+
+          helperToast.error(toastMsg, {
+            autoClose: false,
+            tradingErrorInfo: pendingTxn.actionName
+              ? {
+                  actionName: pendingTxn.actionName,
+                  errorData: errorData ?? onchainError,
+                  metricId: pendingTxn.metricId,
+                }
+              : undefined,
+          });
+
+          if (pendingTxn.metricId) {
+            sendTxnErrorMetric(pendingTxn.metricId, onchainError, "minting");
+            sendUserAnalyticsOrderResultEvent(resolvedChainId, pendingTxn.metricId, false);
+          }
+        }
+
+        if (isSuccess && pendingTxn.message) {
+          helperToast.success(
+            getPendingTxnSuccessToastContent({
+              message: pendingTxn.message,
+              messageDetails: pendingTxn.messageDetails,
+              txUrl,
+            })
+          );
+        }
       }
 
       if (updatedPendingTxns.length !== pendingTxns.length) {

--- a/src/context/SubaccountContext/SubaccountContextProvider.approvalSlots.spec.tsx
+++ b/src/context/SubaccountContext/SubaccountContextProvider.approvalSlots.spec.tsx
@@ -22,6 +22,7 @@ const { mocks, chainState, onchainState, ACCOUNT, CHAIN_ID, SUBACCOUNT_ADDRESS, 
       getInitialSubaccountApproval: vi.fn(),
       signUpdatedSubaccountSettings: vi.fn(),
       refreshSubaccountData: vi.fn(),
+      requestTokenApprovals: vi.fn(),
     },
     chainState: { current: { chainId: 42161, srcChainId: undefined as number | undefined } },
     onchainState: { current: undefined as unknown },
@@ -57,6 +58,13 @@ vi.mock("domain/synthetics/subaccount/useSubaccountOnchainData", () => ({
   useSubaccountOnchainData: () => ({
     subaccountData: onchainState.current,
     refreshSubaccountData: mocks.refreshSubaccountData,
+  }),
+}));
+
+vi.mock("domain/synthetics/subaccount/useOneClickTokenApproval", () => ({
+  useOneClickTokenApproval: () => ({
+    requestTokenApprovals: mocks.requestTokenApprovals,
+    state: { canBatch: false, isApproving: false, pendingTokens: [] },
   }),
 }));
 
@@ -274,6 +282,7 @@ describe("SubaccountContextProvider approval slots", () => {
     expect(readSlot(SOURCE_BSC_MAINNET)?.signatureChainId).toBe(SOURCE_BSC_MAINNET);
     expect(readSlot(SOURCE_BASE_MAINNET)?.signatureChainId).toBe(SOURCE_BASE_MAINNET);
     expect(captured.current.subaccount?.signedApproval.signatureChainId).toBe(SOURCE_BSC_MAINNET);
+    expect(mocks.requestTokenApprovals).toHaveBeenCalledWith("OneClickReauth");
   });
 
   it("ignores stored approvals of another subaccount address", () => {

--- a/src/context/SubaccountContext/SubaccountContextProvider.deactivation.spec.tsx
+++ b/src/context/SubaccountContext/SubaccountContextProvider.deactivation.spec.tsx
@@ -69,6 +69,13 @@ vi.mock("domain/synthetics/subaccount/useSubaccountOnchainData", () => ({
   }),
 }));
 
+vi.mock("domain/synthetics/subaccount/useOneClickTokenApproval", () => ({
+  useOneClickTokenApproval: () => ({
+    requestTokenApprovals: vi.fn(),
+    state: { canBatch: false, isApproving: false, pendingTokens: [] },
+  }),
+}));
+
 vi.mock("domain/synthetics/subaccount/utils", async (importOriginal) => ({
   ...(await importOriginal<object>()),
   getActualApproval: vi.fn(() => ({ signature: "0xsignature" })),

--- a/src/context/SubaccountContext/SubaccountContextProvider.spec.tsx
+++ b/src/context/SubaccountContext/SubaccountContextProvider.spec.tsx
@@ -13,6 +13,7 @@ const { mocks, ACCOUNT, CHAIN_ID, SUBACCOUNT_ADDRESS, OLD_SUBACCOUNT_ADDRESS } =
     getInitialSubaccountApproval: vi.fn(),
     refreshSubaccountData: vi.fn(),
     pushError: vi.fn(),
+    requestTokenApprovals: vi.fn(),
   },
   ACCOUNT: "0x1234567890123456789012345678901234567890",
   CHAIN_ID: 42161,
@@ -45,6 +46,13 @@ vi.mock("domain/synthetics/subaccount/useSubaccountOnchainData", () => ({
   useSubaccountOnchainData: () => ({
     subaccountData: undefined,
     refreshSubaccountData: mocks.refreshSubaccountData,
+  }),
+}));
+
+vi.mock("domain/synthetics/subaccount/useOneClickTokenApproval", () => ({
+  useOneClickTokenApproval: () => ({
+    requestTokenApprovals: mocks.requestTokenApprovals,
+    state: { canBatch: false, isApproving: false, pendingTokens: [] },
   }),
 }));
 
@@ -146,6 +154,7 @@ describe("SubaccountContextProvider.tryEnableSubaccount", () => {
   beforeEach(() => {
     mocks.generateSubaccount.mockResolvedValue(generatedConfig);
     mocks.getInitialSubaccountApproval.mockRejectedValue(new Error("User rejected the request."));
+    mocks.requestTokenApprovals.mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -232,5 +241,29 @@ describe("SubaccountContextProvider.tryEnableSubaccount", () => {
     expect(context.current.subaccountConfig?.address).toBe(SUBACCOUNT_ADDRESS);
     expect(localStorage.getItem(configKey)).toContain(SUBACCOUNT_ADDRESS);
     expect(getStoredValues().some((value) => value.includes("0xsignature"))).toBe(true);
+    expect(mocks.requestTokenApprovals).toHaveBeenCalledOnce();
+    expect(mocks.requestTokenApprovals).toHaveBeenCalledWith("OneClickSetup");
+  });
+
+  it("keeps One-Click enabled if the optional token approval cannot be queued", async () => {
+    mocks.getInitialSubaccountApproval.mockResolvedValue(signedApproval);
+    mocks.requestTokenApprovals.mockImplementationOnce(() => {
+      throw new Error("Optional approval failed");
+    });
+
+    const context = setup();
+
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await context.current.tryEnableSubaccount();
+    });
+
+    expect(result).toBe(true);
+    expect(context.current.subaccountConfig?.address).toBe(SUBACCOUNT_ADDRESS);
+    expect(getStoredValues().some((value) => value.includes("0xsignature"))).toBe(true);
+    expect(mocks.pushError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Optional approval failed" }),
+      "subaccount.requestOneClickTokenApprovals"
+    );
   });
 });

--- a/src/context/SubaccountContext/SubaccountContextProvider.tsx
+++ b/src/context/SubaccountContext/SubaccountContextProvider.tsx
@@ -23,6 +23,10 @@ import {
   serializeSubaccountApproval,
   writeStoredSubaccountApproval,
 } from "domain/synthetics/subaccount/subaccountApprovalStorage";
+import {
+  type OneClickTokenApprovalState,
+  useOneClickTokenApproval,
+} from "domain/synthetics/subaccount/useOneClickTokenApproval";
 import { useSubaccountOnchainData } from "domain/synthetics/subaccount/useSubaccountOnchainData";
 import {
   getActualApproval,
@@ -115,6 +119,7 @@ export type SubaccountState = {
   subaccountActivationError: { message?: string; walletName?: string } | undefined;
   subaccountDeactivationState: SubaccountDeactivationState | undefined;
   subaccountDeactivationFailureReason: SubaccountDeactivationFailureReason | undefined;
+  oneClickTokenApproval?: OneClickTokenApprovalState;
   updateSubaccountSettings: (params: {
     nextRemainigActions?: bigint;
     nextRemainingSeconds?: bigint;
@@ -141,6 +146,8 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
   const signer = useEthersSigner();
   const { account } = useWallet();
   const { provider } = useJsonRpcProvider(chainId);
+  const { requestTokenApprovals: requestOneClickTokenApprovals, state: oneClickTokenApproval } =
+    useOneClickTokenApproval({ chainId, account });
 
   const {
     subaccountConfig,
@@ -215,6 +222,17 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
 
   const calcSelector = useCalcSelector();
 
+  const requestOptionalOneClickTokenApprovals = useCallback(
+    (source: "OneClickSetup" | "OneClickReauth") => {
+      try {
+        requestOneClickTokenApprovals(source);
+      } catch (error) {
+        metrics.pushError(error, "subaccount.requestOneClickTokenApprovals");
+      }
+    },
+    [requestOneClickTokenApprovals]
+  );
+
   const updateSubaccountSettings = useCallback(
     async function updateSubaccountSettings({
       nextRemainigActions,
@@ -254,6 +272,7 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
           </StatusNotification>
         );
         setSignedApproval(signedSubaccountApproval);
+        requestOptionalOneClickTokenApprovals("OneClickReauth");
         return true;
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -268,7 +287,7 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
         return false;
       }
     },
-    [signer, subaccount, provider, calcSelector, chainId, setSignedApproval]
+    [signer, subaccount, provider, calcSelector, chainId, setSignedApproval, requestOptionalOneClickTokenApprovals]
   );
 
   const resetSubaccountApproval = useCallback(() => {
@@ -345,6 +364,8 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
         setSubaccountConfig({ ...config, isNew: true });
       }
 
+      requestOptionalOneClickTokenApprovals("OneClickSetup");
+
       return true;
     } catch (error) {
       if (isConfigGeneratedInCurrentFlow) {
@@ -367,6 +388,7 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
     resetStoredConfig,
     chainId,
     setSignedApproval,
+    requestOptionalOneClickTokenApprovals,
   ]);
 
   const tryDisableSubaccount = useCallback(async (): Promise<boolean> => {
@@ -469,6 +491,7 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
       subaccountActivationError,
       subaccountDeactivationState,
       subaccountDeactivationFailureReason,
+      oneClickTokenApproval,
       updateSubaccountSettings,
       resetSubaccountApproval,
       tryEnableSubaccount,
@@ -482,6 +505,7 @@ export function SubaccountContextProvider({ children }: { children: React.ReactN
     subaccountActivationError,
     subaccountDeactivationState,
     subaccountDeactivationFailureReason,
+    oneClickTokenApproval,
     updateSubaccountSettings,
     resetSubaccountApproval,
     tryEnableSubaccount,

--- a/src/domain/synthetics/orders/__tests__/simulation.spec.ts
+++ b/src/domain/synthetics/orders/__tests__/simulation.spec.ts
@@ -6,9 +6,13 @@ import {
   HttpRequestError,
   InsufficientFundsError,
   InvalidInputRpcError,
+  MethodNotFoundRpcError,
+  RawContractError,
   RpcRequestError,
   TimeoutError,
   WebSocketRequestError,
+  encodeErrorResult,
+  encodeFunctionData,
 } from "viem";
 import type { PublicClient } from "viem";
 import { describe, expect, it, vi } from "vitest";
@@ -16,7 +20,12 @@ import { describe, expect, it, vi } from "vitest";
 import { abis } from "sdk/abis";
 import { encodeSimulationRouterExternalCall } from "sdk/utils/orderTransactions/simulation";
 
-import { isInsufficientFundsError, isTemporaryError, simulateContractWithRetry } from "../simulation";
+import {
+  isEthSimulateV1UnsupportedError,
+  isInsufficientFundsError,
+  isTemporaryError,
+  simulateContractWithRetry,
+} from "../simulation";
 
 describe("simulation", () => {
   it("routes execution simulation through ExchangeRouter.makeExternalCalls", () => {
@@ -45,6 +54,103 @@ describe("simulation", () => {
       })
     ).rejects.toThrow("Execution simulation did not revert with EndOfOracleSimulation.");
     expect(simulateContract).toHaveBeenCalledOnce();
+  });
+
+  describe("pre-call simulation", () => {
+    const account = "0x1111111111111111111111111111111111111111";
+    const preCallTarget = "0x2222222222222222222222222222222222222222";
+    const routerAddress = "0x3333333333333333333333333333333333333333";
+    const endOfOracleSimulationData = encodeErrorResult({
+      abi: abis.CustomErrors,
+      errorName: "EndOfOracleSimulation",
+    });
+
+    function runPreCallSimulation(simulateCalls: ReturnType<typeof vi.fn>) {
+      return simulateContractWithRetry({
+        client: { simulateCalls } as unknown as PublicClient,
+        address: routerAddress,
+        abi: abis.ExchangeRouter,
+        args: [["0x1234"]],
+        value: 5n,
+        account,
+        blockNumber: 123n,
+        isExpress: false,
+        preCalls: [{ data: "0x5678", to: preCallTarget }],
+      });
+    }
+
+    it("simulates pre-calls and the router multicall in order", async () => {
+      const simulateCalls = vi.fn().mockResolvedValue({
+        results: [
+          { status: "success" },
+          {
+            status: "failure",
+            error: new RawContractError({ data: endOfOracleSimulationData }),
+          },
+        ],
+      });
+
+      await expect(runPreCallSimulation(simulateCalls)).resolves.toBeUndefined();
+      expect(simulateCalls).toHaveBeenCalledWith({
+        account,
+        blockNumber: 123n,
+        calls: [
+          { data: "0x5678", to: preCallTarget, value: undefined },
+          {
+            data: encodeFunctionData({
+              abi: abis.ExchangeRouter,
+              functionName: "multicall",
+              args: [["0x1234"]],
+            }),
+            to: routerAddress,
+            value: 5n,
+          },
+        ],
+      });
+    });
+
+    it("does not treat a sentinel-shaped pre-call failure as success", async () => {
+      const sentinelError = new RawContractError({ data: endOfOracleSimulationData });
+      const simulateCalls = vi.fn().mockResolvedValue({
+        results: [
+          { status: "failure", error: sentinelError },
+          { status: "failure", error: sentinelError },
+        ],
+      });
+
+      await expect(runPreCallSimulation(simulateCalls)).rejects.toThrow("EndOfOracleSimulation");
+    });
+
+    it("skips only the remote preflight when eth_simulateV1 is unavailable", async () => {
+      const simulateCalls = vi
+        .fn()
+        .mockRejectedValue(new MethodNotFoundRpcError(new Error("not found"), { method: "eth_simulateV1" }));
+
+      await expect(runPreCallSimulation(simulateCalls)).resolves.toBeUndefined();
+      expect(simulateCalls).toHaveBeenCalledOnce();
+    });
+
+    it("does not swallow other RPC failures", async () => {
+      const simulateCalls = vi.fn().mockRejectedValue(new Error("RPC unavailable"));
+
+      await expect(runPreCallSimulation(simulateCalls)).rejects.toThrow("RPC unavailable");
+    });
+  });
+
+  describe("isEthSimulateV1UnsupportedError", () => {
+    it("recognizes nested method-not-found errors", () => {
+      const error = new MethodNotFoundRpcError(new Error("not found"), { method: "eth_simulateV1" });
+
+      expect(isEthSimulateV1UnsupportedError(error)).toBe(true);
+    });
+
+    it("recognizes provider-specific unsupported messages", () => {
+      expect(isEthSimulateV1UnsupportedError(new Error("eth_simulateV1 is not supported"))).toBe(true);
+    });
+
+    it("does not classify unrelated RPC errors as unsupported", () => {
+      expect(isEthSimulateV1UnsupportedError(new Error("RPC unavailable"))).toBe(false);
+    });
   });
 
   describe("isTemporaryError", () => {

--- a/src/domain/synthetics/orders/sendBatchOrderTxn.ts
+++ b/src/domain/synthetics/orders/sendBatchOrderTxn.ts
@@ -1,5 +1,6 @@
 import { Provider } from "ethers";
 import { withRetry } from "viem";
+import type { Address } from "viem";
 
 import { ContractsChainId } from "config/chains";
 import { getSwapDebugSettings } from "config/externalSwaps";
@@ -9,7 +10,10 @@ import { GlvShiftParam } from "domain/synthetics/jit/utils";
 import { isLimitOrderType, isTriggerDecreaseOrderType } from "domain/synthetics/orders";
 import { TokensData } from "domain/tokens";
 import { extendError } from "lib/errors";
+import { getTenderlyConfig } from "lib/tenderly";
 import { sendExpressTransaction } from "lib/transactions/sendExpressTransaction";
+import { sendWalletCalls } from "lib/transactions/sendWalletCalls";
+import type { WalletCall, WalletCallsAnalyticsContext } from "lib/transactions/sendWalletCalls";
 import { sendWalletTransaction } from "lib/transactions/sendWalletTransaction";
 import { TxnCallback, TxnEventBuilder } from "lib/transactions/types";
 import { BlockTimestampData } from "lib/useBlockTimestampRequest";
@@ -51,6 +55,8 @@ export async function sendBatchOrderTxn({
   batchParams,
   expressParams,
   simulationParams,
+  approvalCalls,
+  approvalAnalytics,
   callback,
 }: {
   chainId: ContractsChainId;
@@ -60,6 +66,8 @@ export async function sendBatchOrderTxn({
   batchParams: BatchOrderTxnParams;
   expressParams: ExpressTxnParams | undefined;
   simulationParams: BatchSimulationParams | undefined;
+  approvalCalls?: WalletCall[];
+  approvalAnalytics?: WalletCallsAnalyticsContext;
   callback: TxnCallback<BatchOrderTxnCtx> | undefined;
 }) {
   const encodedBatchParams = encodeJitBatchOrderMetadata(batchParams, simulationParams);
@@ -76,6 +84,9 @@ export async function sendBatchOrderTxn({
 
     if (isGmxAccount && !provider) {
       throw new Error("provider is required for multichain txns");
+    }
+    if (expressParams && approvalCalls?.length) {
+      throw new Error("Approval calls cannot be included in an Express order");
     }
     callback?.(eventBuilder.Submitted());
 
@@ -94,6 +105,7 @@ export async function sendBatchOrderTxn({
           isGmxAccount,
           jitShiftParamsList: simulationParams.jitShiftParamsList,
           nativeReserveLiquidity: simulationParams.nativeReserveLiquidity,
+          approvalCalls,
         });
       };
     }
@@ -154,6 +166,51 @@ export async function sendBatchOrderTxn({
 
     const { callData, value } = getBatchOrderMulticallPayload({ params: encodedBatchParams });
 
+    if (approvalCalls?.length) {
+      await runSimulation().then(() => callback?.(eventBuilder.Simulated()));
+
+      if (getTenderlyConfig()) {
+        return {
+          transactionHash: undefined,
+          wait: async () => ({
+            transactionHash: undefined,
+            blockNumber: undefined,
+            status: "success" as const,
+          }),
+        };
+      }
+
+      callback?.(eventBuilder.Sending());
+
+      const result = await sendWalletCalls({
+        chainId,
+        account: signer.address as Address,
+        calls: [
+          ...approvalCalls,
+          {
+            to: getContract(chainId, "ExchangeRouter") as Address,
+            data: callData as `0x${string}`,
+            value,
+          },
+        ],
+        analytics: approvalAnalytics,
+      }).catch((error) => {
+        throw extendError(error, {
+          errorContext: "sending",
+        });
+      });
+
+      callback?.(
+        eventBuilder.Sent({
+          type: "walletCalls",
+          callBundleId: result.id,
+          getCallsStatus: result.getStatus,
+        })
+      );
+
+      return result;
+    }
+
     return sendWalletTransaction({
       chainId,
       signer,
@@ -183,6 +240,7 @@ const makeBatchOrderSimulation = async ({
   expressParams,
   jitShiftParamsList,
   nativeReserveLiquidity,
+  approvalCalls,
 }: {
   chainId: ContractsChainId;
   signer: WalletSigner;
@@ -194,6 +252,7 @@ const makeBatchOrderSimulation = async ({
   expressParams: ExpressTxnParams | undefined;
   jitShiftParamsList?: GlvShiftParam[];
   nativeReserveLiquidity?: bigint;
+  approvalCalls?: WalletCall[];
 }): Promise<void> => {
   let simulationMethod: "simulateExecuteLatestOrder" | "simulateExecuteLatestJitOrder" | undefined;
 
@@ -323,6 +382,7 @@ const makeBatchOrderSimulation = async ({
           isExpress: Boolean(expressParams),
           method: simulationMethod,
           jitShiftParamsList: needsJit ? jitShiftParamsList : undefined,
+          preCalls: approvalCalls,
         });
       } catch (error) {
         if (needsJit && isJitShiftError(error)) {

--- a/src/domain/synthetics/orders/simulation.ts
+++ b/src/domain/synthetics/orders/simulation.ts
@@ -10,6 +10,7 @@ import {
   encodeFunctionData,
   withRetry,
 } from "viem";
+import type { Address } from "viem";
 
 import { getContract, tryGetContract } from "config/contracts";
 import { isDevelopment } from "config/env";
@@ -18,6 +19,7 @@ import { TokenPrices, TokensData, convertToContractPrice, getTokenData } from "d
 import { SignedTokenPermit } from "domain/tokens";
 import { decodeSimulationErrorFromViemError } from "lib/errors";
 import { getTenderlyConfig, simulateTxWithTenderly } from "lib/tenderly";
+import type { WalletCall } from "lib/transactions/sendWalletCalls";
 import { BlockTimestampData, adjustBlockTimestamp } from "lib/useBlockTimestampRequest";
 import { getPublicClientWithRpc } from "lib/wallets/walletConfig";
 import { abis } from "sdk/abis";
@@ -48,6 +50,7 @@ export type SimulateExecuteParams = {
   swapPricingType?: SwapPricingType;
   blockTimestampData: BlockTimestampData | undefined;
   jitShiftParamsList?: GlvShiftParam[];
+  preCalls?: WalletCall[];
 };
 
 export function isInsufficientFundsError(error: any): boolean {
@@ -309,7 +312,7 @@ export async function simulateExecution(chainId: ContractsChainId, p: SimulateEx
     const routerAddress = getContract(chainId, "GlvRouter");
     const routerAbi = abis.GlvRouter;
 
-    if (tenderlyConfig) {
+    if (tenderlyConfig && !p.preCalls?.length) {
       await simulateTxWithTenderly({
         chainId,
         address: routerAddress,
@@ -331,12 +334,13 @@ export async function simulateExecution(chainId: ContractsChainId, p: SimulateEx
       account: p.account,
       blockNumber,
       isExpress: p.isExpress,
+      preCalls: p.preCalls,
     });
   } else if (simulationRouterAddress) {
     simulationPayloadData.push(encodeSimulationRouterExternalCall(simulationRouterAddress, simulateExecuteData));
     const exchangeRouterAddress = getContract(chainId, "ExchangeRouter");
 
-    if (tenderlyConfig) {
+    if (tenderlyConfig && !p.preCalls?.length) {
       await simulateTxWithTenderly({
         chainId,
         address: exchangeRouterAddress,
@@ -358,13 +362,14 @@ export async function simulateExecution(chainId: ContractsChainId, p: SimulateEx
       account: p.account,
       blockNumber,
       isExpress: p.isExpress,
+      preCalls: p.preCalls,
     });
   } else {
     simulationPayloadData.push(simulateExecuteData);
     const routerAddress = getContract(chainId, "ExchangeRouter");
     const routerAbi = abis.ExchangeRouter;
 
-    if (tenderlyConfig) {
+    if (tenderlyConfig && !p.preCalls?.length) {
       await simulateTxWithTenderly({
         chainId,
         address: routerAddress,
@@ -386,6 +391,7 @@ export async function simulateExecution(chainId: ContractsChainId, p: SimulateEx
       account: p.account,
       blockNumber,
       isExpress: p.isExpress,
+      preCalls: p.preCalls,
     });
   }
 }
@@ -399,6 +405,7 @@ export async function simulateContractWithRetry({
   account,
   blockNumber,
   isExpress,
+  preCalls,
 }: {
   client: PublicClient;
   address: string;
@@ -408,7 +415,23 @@ export async function simulateContractWithRetry({
   account: string;
   blockNumber: bigint | undefined;
   isExpress: boolean;
+  preCalls?: WalletCall[];
 }) {
+  if (preCalls?.length) {
+    await simulateContractWithPreCalls({
+      client,
+      address,
+      abi,
+      args,
+      value,
+      account,
+      blockNumber,
+      isExpress,
+      preCalls,
+    });
+    return;
+  }
+
   try {
     await withRetry(
       () => {
@@ -431,34 +454,145 @@ export async function simulateContractWithRetry({
       }
     );
   } catch (txnError) {
-    const decodedError = decodeSimulationErrorFromViemError(txnError);
-
-    const isPassed = decodedError?.name === CustomErrorName.EndOfOracleSimulation;
-
-    const isInsufficientFunds = isInsufficientFundsError(txnError);
-    const shouldIgnoreExpressNativeTokenBalance = isInsufficientFunds && isExpress;
-
-    if (isPassed || shouldIgnoreExpressNativeTokenBalance) {
-      return;
-    } else {
-      throw extendError(
-        decodedError
-          ? new CustomError({
-              name: decodedError.name,
-              message: JSON.stringify(decodedError, null, 2),
-              args: decodedError.args,
-            })
-          : txnError,
-        {
-          errorContext: "simulation",
-        }
-      );
-    }
+    handleSimulationError(txnError, { isExpress });
+    return;
   }
 
   throw extendError(new Error("Execution simulation did not revert with EndOfOracleSimulation."), {
     errorContext: "simulation",
   });
+}
+
+async function simulateContractWithPreCalls({
+  client,
+  address,
+  abi,
+  args,
+  value,
+  account,
+  blockNumber,
+  isExpress,
+  preCalls,
+}: {
+  client: PublicClient;
+  address: string;
+  abi: readonly any[];
+  args: [string[]];
+  value: bigint;
+  account: string;
+  blockNumber: bigint | undefined;
+  isExpress: boolean;
+  preCalls: WalletCall[];
+}) {
+  let results;
+
+  try {
+    ({ results } = await withRetry(
+      () =>
+        client.simulateCalls({
+          account: account as Address,
+          blockNumber,
+          calls: [
+            ...preCalls,
+            {
+              data: encodeFunctionData({
+                abi,
+                functionName: "multicall",
+                args,
+              }),
+              to: address as Address,
+              value,
+            },
+          ],
+        }),
+      {
+        retryCount: 2,
+        delay: 200,
+        shouldRetry: ({ error }) => isTemporaryError(error),
+      }
+    ));
+  } catch (error) {
+    if (isEthSimulateV1UnsupportedError(error)) {
+      return;
+    }
+
+    handleSimulationError(error, { isExpress });
+    return;
+  }
+
+  const failedPreCall = results.slice(0, preCalls.length).find((result) => result.status === "failure");
+  if (failedPreCall) {
+    handleSimulationError(failedPreCall.error ?? new Error("Pre-call simulation failed"), {
+      acceptEndOfOracleSimulation: false,
+      isExpress: false,
+    });
+    return;
+  }
+
+  const simulationResult = results[preCalls.length];
+  if (simulationResult?.status === "failure") {
+    handleSimulationError(simulationResult.error ?? new Error("Execution simulation failed"), { isExpress });
+    return;
+  }
+
+  throw extendError(new Error("Execution simulation did not revert with EndOfOracleSimulation."), {
+    errorContext: "simulation",
+  });
+}
+
+function handleSimulationError(
+  txnError: any,
+  { acceptEndOfOracleSimulation = true, isExpress }: { acceptEndOfOracleSimulation?: boolean; isExpress: boolean }
+) {
+  const decodedError = decodeSimulationErrorFromViemError(txnError);
+  const isPassed = acceptEndOfOracleSimulation && decodedError?.name === CustomErrorName.EndOfOracleSimulation;
+  const shouldIgnoreExpressNativeTokenBalance = isInsufficientFundsError(txnError) && isExpress;
+
+  if (isPassed || shouldIgnoreExpressNativeTokenBalance) {
+    return;
+  }
+
+  throw extendError(
+    decodedError
+      ? new CustomError({
+          name: decodedError.name,
+          message: JSON.stringify(decodedError, null, 2),
+          args: decodedError.args,
+        })
+      : txnError,
+    {
+      errorContext: "simulation",
+    }
+  );
+}
+
+export function isEthSimulateV1UnsupportedError(error: any): boolean {
+  let current = error;
+
+  for (let index = 0; index < 10 && current && typeof current === "object"; index++) {
+    if (current.code === -32601) {
+      return true;
+    }
+
+    const errorText = [current.details, current.shortMessage, current.message]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ")
+      .toLowerCase();
+
+    if (
+      errorText.includes("eth_simulatev1") &&
+      (errorText.includes("method not found") ||
+        errorText.includes("does not exist") ||
+        errorText.includes("not available") ||
+        errorText.includes("not supported"))
+    ) {
+      return true;
+    }
+
+    current = current.cause;
+  }
+
+  return false;
 }
 
 export function getOrdersTriggerPriceOverrides(createOrderPayloads: CreateOrderTxnParams<any>[]) {

--- a/src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
+++ b/src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
@@ -280,7 +280,7 @@ export function useOrderTxnCallbacks() {
               key: expressParams ? getExpressParamsKey(expressParams) : undefined,
               taskId: e.data.relayTaskId,
             });
-          } else if (e.data.type === "wallet") {
+          } else {
             const totalExecutionFee = tokensData
               ? getBatchTotalExecutionFee({
                   batchParams: e.data.batchParams,
@@ -289,8 +289,7 @@ export function useOrderTxnCallbacks() {
                 })
               : undefined;
 
-            const pendingTxn: PendingTransaction = {
-              hash: e.data.transactionHash,
+            const pendingTxnBase = {
               message: getOperationMessage(mainActionType, "success", actionsCount, undefined, setIsSettingsVisible),
               metricId: ctx.metricId,
               actionName: ctx.actionName,
@@ -301,6 +300,19 @@ export function useOrderTxnCallbacks() {
                   }
                 : undefined,
             };
+            const pendingTxn: PendingTransaction =
+              e.data.type === "wallet"
+                ? {
+                    ...pendingTxnBase,
+                    hash: e.data.transactionHash,
+                  }
+                : {
+                    ...pendingTxnBase,
+                    type: "walletCalls",
+                    chainId,
+                    callBundleId: e.data.callBundleId,
+                    getCallsStatus: e.data.getCallsStatus,
+                  };
 
             setPendingTxns((txns) => [...txns, pendingTxn]);
           }

--- a/src/domain/synthetics/subaccount/useOneClickTokenApproval.spec.ts
+++ b/src/domain/synthetics/subaccount/useOneClickTokenApproval.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { MaxUint256 } from "sdk/utils/numbers";
+
+import { getPendingOneClickTokenApprovals } from "./useOneClickTokenApproval";
+
+describe("getPendingOneClickTokenApprovals", () => {
+  it("selects only tokens without an unlimited allowance and preserves address casing", () => {
+    const tokenAddresses = [
+      "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+      "0xBbbBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbbBBbB",
+      "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+    ];
+
+    expect(getPendingOneClickTokenApprovals(tokenAddresses, [0n, MaxUint256, MaxUint256 - 1n])).toEqual([
+      { tokenAddress: tokenAddresses[0], amount: MaxUint256 },
+      { tokenAddress: tokenAddresses[2], amount: MaxUint256 },
+    ]);
+  });
+
+  it("does not guess approval state before every configured allowance is loaded", () => {
+    expect(getPendingOneClickTokenApprovals(["0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"], undefined)).toEqual([]);
+    expect(
+      getPendingOneClickTokenApprovals(
+        ["0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa", "0xBbbBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbbBBbB"],
+        [0n]
+      )
+    ).toEqual([]);
+  });
+});

--- a/src/domain/synthetics/subaccount/useOneClickTokenApproval.ts
+++ b/src/domain/synthetics/subaccount/useOneClickTokenApproval.ts
@@ -1,0 +1,200 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Address } from "viem";
+
+import type { ContractsChainId } from "config/chains";
+import type { PendingTokenApproval } from "domain/tokens/tokenApproval";
+import { useAtomicTokenApproval } from "domain/tokens/useAtomicTokenApproval";
+import type { TokenApproveBatchSource } from "lib/userAnalytics/types";
+import { getPublicClientWithRpc } from "lib/wallets/walletConfig";
+import TokenAbi from "sdk/abis/Token";
+import { getContract } from "sdk/configs/contracts";
+import { getGasPaymentTokens } from "sdk/configs/express";
+import { getToken } from "sdk/configs/tokens";
+import { MaxUint256 } from "sdk/utils/numbers";
+
+type OneClickTokenApprovalSource = Extract<TokenApproveBatchSource, "OneClickSetup" | "OneClickReauth">;
+
+export type OneClickTokenApprovalState = {
+  canBatch: boolean;
+  isApproving: boolean;
+  pendingTokens: { address: string; symbol: string }[];
+};
+
+export function getPendingOneClickTokenApprovals(
+  tokenAddresses: string[],
+  allowances: bigint[] | undefined
+): PendingTokenApproval[] {
+  if (!allowances || allowances.length !== tokenAddresses.length) {
+    return [];
+  }
+
+  return tokenAddresses.flatMap((tokenAddress, index) =>
+    allowances[index] < MaxUint256 ? [{ tokenAddress, amount: MaxUint256 }] : []
+  );
+}
+
+export function useOneClickTokenApproval({
+  chainId,
+  account,
+}: {
+  chainId: ContractsChainId;
+  account: string | undefined;
+}) {
+  const queryClient = useQueryClient();
+  const spenderAddress = getContract(chainId, "SyntheticsRouter");
+  const tokenAddresses = useMemo(() => getGasPaymentTokens(chainId), [chainId]);
+  const allowancesQueryKey = useMemo(
+    () => ["oneClickTokenAllowances", chainId, account, spenderAddress, tokenAddresses] as const,
+    [account, chainId, spenderAddress, tokenAddresses]
+  );
+
+  const allowancesQuery = useQuery({
+    queryKey: allowancesQueryKey,
+    queryFn: async () => {
+      if (!account) {
+        return [];
+      }
+
+      const client = getPublicClientWithRpc(chainId);
+
+      const allowances = await client.multicall({
+        allowFailure: false,
+        contracts: tokenAddresses.map((tokenAddress) => ({
+          address: tokenAddress as Address,
+          abi: TokenAbi,
+          functionName: "allowance",
+          args: [account as Address, spenderAddress as Address],
+        })),
+      });
+
+      return allowances as bigint[];
+    },
+    enabled: Boolean(account && tokenAddresses.length),
+    retry: false,
+  });
+
+  const pendingTokenApprovals = useMemo(
+    () => getPendingOneClickTokenApprovals(tokenAddresses, allowancesQuery.data),
+    [allowancesQuery.data, tokenAddresses]
+  );
+
+  const isAtomicCapabilityEnabled = allowancesQuery.isSuccess && pendingTokenApprovals.length > 0;
+
+  const setupApproval = useAtomicTokenApproval({
+    chainId,
+    spenderAddress,
+    pendingTokenApprovals,
+    source: "OneClickSetup",
+    enabled: isAtomicCapabilityEnabled,
+    minApprovalCount: 1,
+  });
+  const reauthApproval = useAtomicTokenApproval({
+    chainId,
+    spenderAddress,
+    pendingTokenApprovals,
+    source: "OneClickReauth",
+    enabled: isAtomicCapabilityEnabled,
+    minApprovalCount: 1,
+  });
+
+  const [requestedSource, setRequestedSource] = useState<
+    { id: number; source: OneClickTokenApprovalSource } | undefined
+  >();
+  const nextRequestId = useRef(0);
+  const processingRequestId = useRef<number>();
+  const wasBatchApproving = useRef(false);
+
+  const requestTokenApprovals = useCallback((source: OneClickTokenApprovalSource) => {
+    nextRequestId.current += 1;
+    setRequestedSource({ id: nextRequestId.current, source });
+  }, []);
+
+  useEffect(
+    function processRequestedApprovals() {
+      if (!requestedSource || processingRequestId.current === requestedSource.id) {
+        return;
+      }
+
+      if (allowancesQuery.isPending) {
+        return;
+      }
+
+      if (allowancesQuery.isError || pendingTokenApprovals.length === 0) {
+        processingRequestId.current = requestedSource.id;
+        setRequestedSource(undefined);
+        return;
+      }
+
+      const approval = requestedSource.source === "OneClickSetup" ? setupApproval : reauthApproval;
+
+      if (approval.isCapabilityLoading) {
+        return;
+      }
+
+      processingRequestId.current = requestedSource.id;
+      setRequestedSource(undefined);
+
+      if (approval.isAtomicBatchingDisabled) {
+        return;
+      }
+
+      if (!approval.canBatch) {
+        approval.trackFallback(approval.fallbackReason);
+        return;
+      }
+
+      void approval
+        .submitBatch()
+        .then((success) => {
+          if (success) {
+            queryClient.setQueryData(
+              allowancesQueryKey,
+              tokenAddresses.map(() => MaxUint256)
+            );
+          }
+        })
+        .catch(() => undefined);
+    },
+    [
+      allowancesQuery,
+      allowancesQueryKey,
+      pendingTokenApprovals.length,
+      queryClient,
+      reauthApproval,
+      requestedSource,
+      setupApproval,
+      tokenAddresses,
+    ]
+  );
+
+  const isBatchApproving = setupApproval.isBatchApproving || reauthApproval.isBatchApproving;
+
+  useEffect(
+    function refreshAllowancesAfterBatchSettles() {
+      if (wasBatchApproving.current && !isBatchApproving) {
+        void allowancesQuery.refetch();
+      }
+
+      wasBatchApproving.current = isBatchApproving;
+    },
+    [allowancesQuery, isBatchApproving]
+  );
+
+  const state = useMemo<OneClickTokenApprovalState>(
+    () => ({
+      canBatch: setupApproval.canBatch,
+      isApproving: isBatchApproving,
+      pendingTokens: pendingTokenApprovals.map(({ tokenAddress }) => ({
+        address: tokenAddress,
+        symbol: getToken(chainId, tokenAddress).symbol,
+      })),
+    }),
+    [pendingTokenApprovals, chainId, isBatchApproving, setupApproval.canBatch]
+  );
+
+  return {
+    requestTokenApprovals,
+    state,
+  };
+}

--- a/src/domain/tokens/approveTokens.tsx
+++ b/src/domain/tokens/approveTokens.tsx
@@ -18,6 +18,8 @@ import { InfoTokens, Token, TokenInfo } from "sdk/utils/tokens/types";
 import ExternalLink from "components/ExternalLink/ExternalLink";
 import { ToastifyDebug } from "components/ToastifyDebug/ToastifyDebug";
 
+import { buildTokenApprovalCall } from "./tokenApproval";
+
 type Params = {
   setIsApproving: (val: boolean) => void;
   signer: Signer | undefined;
@@ -147,13 +149,18 @@ export async function approveTokens({
   const networkName = getChainName(chainId);
 
   const finalApproveAmount = approveAmount ?? maxUint256;
+  const approvalCall = buildTokenApprovalCall({
+    tokenAddress,
+    spender,
+    amount: finalApproveAmount,
+  });
 
   try {
     const gasLimit = await estimateGasLimit(getProvider(undefined, chainId), {
-      to: tokenAddress,
-      data: contract.interface.encodeFunctionData("approve", [spender, finalApproveAmount]),
+      to: approvalCall.to,
+      data: approvalCall.data,
       from: await signer!.getAddress(),
-      value: undefined,
+      value: approvalCall.value,
     });
 
     const res = await contract.approve(spender, finalApproveAmount, { gasLimit });

--- a/src/domain/tokens/tokenApproval.spec.ts
+++ b/src/domain/tokens/tokenApproval.spec.ts
@@ -1,0 +1,68 @@
+import { decodeFunctionData, maxUint256 } from "viem";
+import { describe, expect, it } from "vitest";
+
+import TokenAbi from "sdk/abis/Token";
+
+import { buildTokenApprovalCall, mergeTokenApprovals } from "./tokenApproval";
+
+describe("mergeTokenApprovals", () => {
+  it("merges duplicate token amounts while preserving their address casing and order", () => {
+    expect(
+      mergeTokenApprovals([
+        { tokenAddress: "0xAbC", amount: 2n },
+        { tokenAddress: "0xDef", amount: 3n },
+        { tokenAddress: "0xAbC", amount: 5n },
+      ])
+    ).toEqual([
+      { tokenAddress: "0xAbC", amount: 7n },
+      { tokenAddress: "0xDef", amount: 3n },
+    ]);
+  });
+
+  it("does not lowercase addresses when identifying duplicates", () => {
+    expect(
+      mergeTokenApprovals([
+        { tokenAddress: "0xAbC", amount: 2n },
+        { tokenAddress: "0xabc", amount: 5n },
+      ])
+    ).toEqual([
+      { tokenAddress: "0xAbC", amount: 2n },
+      { tokenAddress: "0xabc", amount: 5n },
+    ]);
+  });
+
+  it("ignores empty addresses and treats missing amounts as zero", () => {
+    expect(
+      mergeTokenApprovals([
+        { tokenAddress: "", amount: 10n },
+        { tokenAddress: "0xAbC", amount: undefined },
+        { tokenAddress: "0xAbC", amount: 4n },
+      ])
+    ).toEqual([{ tokenAddress: "0xAbC", amount: 4n }]);
+  });
+});
+
+describe("buildTokenApprovalCall", () => {
+  const tokenAddress = "0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+  const spender = "0x111111125421cA6dc452d289314280a0f8842A65";
+
+  it("encodes an unlimited ERC20 approval by default", () => {
+    const call = buildTokenApprovalCall({ tokenAddress, spender });
+
+    expect(call.to).toBe(tokenAddress);
+    expect(call.value).toBe(0n);
+    expect(decodeFunctionData({ abi: TokenAbi, data: call.data })).toEqual({
+      functionName: "approve",
+      args: [spender, maxUint256],
+    });
+  });
+
+  it("encodes an explicitly requested approval amount", () => {
+    const call = buildTokenApprovalCall({ tokenAddress, spender, amount: 123n });
+
+    expect(decodeFunctionData({ abi: TokenAbi, data: call.data })).toEqual({
+      functionName: "approve",
+      args: [spender, 123n],
+    });
+  });
+});

--- a/src/domain/tokens/tokenApproval.ts
+++ b/src/domain/tokens/tokenApproval.ts
@@ -1,0 +1,50 @@
+import type { Address, Hex } from "viem";
+
+import { buildErc20ApproveTxn } from "sdk/utils/balances/api";
+
+export type TokenToApprove = {
+  tokenAddress: string;
+  amount: bigint | undefined;
+};
+
+export type PendingTokenApproval = {
+  tokenAddress: string;
+  amount: bigint;
+};
+
+export type TokenApprovalCall = {
+  to: Address;
+  data: Hex;
+  value: bigint;
+};
+
+export function mergeTokenApprovals(tokens: TokenToApprove[]): PendingTokenApproval[] {
+  const tokenAmounts = new Map<string, bigint>();
+
+  for (const token of tokens) {
+    if (!token.tokenAddress) continue;
+
+    const previousAmount = tokenAmounts.get(token.tokenAddress) ?? 0n;
+    tokenAmounts.set(token.tokenAddress, previousAmount + (token.amount ?? 0n));
+  }
+
+  return Array.from(tokenAmounts, ([tokenAddress, amount]) => ({ tokenAddress, amount }));
+}
+
+export function buildTokenApprovalCall({
+  tokenAddress,
+  spender,
+  amount,
+}: {
+  tokenAddress: string;
+  spender: string;
+  amount?: bigint;
+}): TokenApprovalCall {
+  const call = buildErc20ApproveTxn({ tokenAddress, spender, amount });
+
+  return {
+    to: call.to as Address,
+    data: call.data as Hex,
+    value: call.value,
+  };
+}

--- a/src/domain/tokens/useAtomicTokenApproval.ts
+++ b/src/domain/tokens/useAtomicTokenApproval.ts
@@ -1,0 +1,153 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { Address } from "viem";
+
+import { sendWalletCalls } from "lib/transactions/sendWalletCalls";
+import type { WalletCallsAnalyticsContext } from "lib/transactions/sendWalletCalls";
+import { pushBatchApprovalAnalyticsEvent } from "lib/userAnalytics/batchApprovalAnalytics";
+import type { TokenApproveBatchReason, TokenApproveBatchSource } from "lib/userAnalytics/types";
+import { useAtomicCapability } from "lib/wallets/useAtomicCapability";
+import useWallet from "lib/wallets/useWallet";
+
+import { buildTokenApprovalCall } from "./tokenApproval";
+import type { PendingTokenApproval } from "./tokenApproval";
+
+export function useAtomicTokenApproval({
+  chainId,
+  spenderAddress,
+  pendingTokenApprovals,
+  source,
+  enabled = true,
+  minApprovalCount = 2,
+}: {
+  chainId: number | undefined;
+  spenderAddress: string | undefined;
+  pendingTokenApprovals: PendingTokenApproval[];
+  source: TokenApproveBatchSource;
+  enabled?: boolean;
+  minApprovalCount?: number;
+}) {
+  const { account } = useWallet();
+  const [isBatchApproving, setIsBatchApproving] = useState(false);
+  const isBatchApprovingRef = useRef(false);
+  const atomicCapability = useAtomicCapability({
+    chainId: chainId ?? 0,
+    enabled: enabled && chainId !== undefined,
+  });
+
+  const approvalCalls = useMemo(
+    () =>
+      spenderAddress
+        ? pendingTokenApprovals.map(({ tokenAddress }) =>
+            buildTokenApprovalCall({
+              tokenAddress,
+              spender: spenderAddress,
+            })
+          )
+        : [],
+    [pendingTokenApprovals, spenderAddress]
+  );
+
+  const analyticsContext = useMemo<WalletCallsAnalyticsContext | undefined>(
+    () =>
+      chainId !== undefined
+        ? {
+            source,
+            chainId,
+            capabilityStatus: atomicCapability.atomicCapabilityStatus,
+            tokenCount: approvalCalls.length,
+            walletProvider: atomicCapability.walletProvider,
+          }
+        : undefined,
+    [approvalCalls.length, atomicCapability.atomicCapabilityStatus, atomicCapability.walletProvider, chainId, source]
+  );
+
+  const trackFallback = useCallback(
+    (reason: TokenApproveBatchReason) => {
+      if (!analyticsContext) return;
+
+      void pushBatchApprovalAnalyticsEvent({
+        ...analyticsContext,
+        action: "BatchApproveFallback",
+        reason,
+      });
+    },
+    [analyticsContext]
+  );
+  const trackSessionFallback = useCallback(() => {
+    const reason = atomicCapability.consumeAtomicBatchingFallbackReason();
+
+    if (reason) {
+      trackFallback(reason);
+    }
+  }, [atomicCapability, trackFallback]);
+
+  const submitBatch = useCallback(async () => {
+    if (
+      isBatchApprovingRef.current ||
+      !account ||
+      !chainId ||
+      !analyticsContext ||
+      approvalCalls.length < minApprovalCount
+    ) {
+      return false;
+    }
+
+    isBatchApprovingRef.current = true;
+    setIsBatchApproving(true);
+
+    let result: Awaited<ReturnType<typeof sendWalletCalls>> | undefined;
+    let isWaitingInBackground = false;
+
+    try {
+      result = await sendWalletCalls({
+        chainId,
+        account: account as Address,
+        calls: approvalCalls,
+        analytics: analyticsContext,
+      });
+
+      const status = await result.wait();
+      return status.status === "success" && status.atomic;
+    } catch (error) {
+      if ((error as { name?: string }).name === "WaitForCallsStatusTimeoutError" && result) {
+        isWaitingInBackground = true;
+        void result
+          .wait(0)
+          .catch(() => undefined)
+          .finally(() => {
+            isBatchApprovingRef.current = false;
+            setIsBatchApproving(false);
+          });
+        return false;
+      }
+
+      return false;
+    } finally {
+      if (!isWaitingInBackground) {
+        isBatchApprovingRef.current = false;
+        setIsBatchApproving(false);
+      }
+    }
+  }, [account, analyticsContext, approvalCalls, chainId, minApprovalCount]);
+
+  const fallbackReason: TokenApproveBatchReason =
+    atomicCapability.atomicCapabilityStatus === "unsupported" ? "CapabilityUnsupported" : "CapabilityQueryFailed";
+
+  return {
+    approvalCalls,
+    analyticsContext,
+    atomicCapabilityStatus: atomicCapability.atomicCapabilityStatus,
+    canBatch:
+      enabled &&
+      atomicCapability.isAtomicBatchSupported &&
+      approvalCalls.length >= minApprovalCount &&
+      Boolean(account && chainId),
+    fallbackReason,
+    isBatchApproving,
+    isCapabilityLoading: atomicCapability.isPending,
+    isAtomicBatchingDisabled: atomicCapability.isAtomicBatchingDisabled,
+    submitBatch,
+    trackFallback,
+    trackSessionFallback,
+  };
+}

--- a/src/domain/tokens/useTokenApproval.ts
+++ b/src/domain/tokens/useTokenApproval.ts
@@ -11,11 +11,8 @@ import type { AnyChainId } from "sdk/configs/chains";
 import { wrapChainAction } from "components/GmxAccountModal/wrapChainAction";
 
 import { approveTokens } from "./approveTokens";
-
-interface TokenToApprove {
-  tokenAddress: string;
-  amount: bigint | undefined;
-}
+import { mergeTokenApprovals } from "./tokenApproval";
+import type { PendingTokenApproval, TokenToApprove } from "./tokenApproval";
 
 interface UseTokenApprovalParams {
   chainId: AnyChainId | undefined;
@@ -32,6 +29,7 @@ export interface HandleApproveOptions {
 
 interface UseTokenApprovalReturn {
   tokensToApprove: string[];
+  pendingTokenApprovals: PendingTokenApproval[];
   needsApproval: boolean;
   isAllowanceLoading: boolean;
   isAllowanceLoaded: boolean;
@@ -51,15 +49,7 @@ export function useTokenApproval({
   const { tokenPermits, addTokenPermit, isPermitsDisabled, setIsPermitsDisabled } = useTokenPermitsContext();
   const [, setSettlementChainId] = useGmxAccountSettlementChainId();
 
-  const mergedTokens = useMemo(() => {
-    const map = new Map<string, bigint>();
-    for (const token of tokens) {
-      if (!token.tokenAddress) continue;
-      const prev = map.get(token.tokenAddress) ?? 0n;
-      map.set(token.tokenAddress, prev + (token.amount ?? 0n));
-    }
-    return Array.from(map, ([tokenAddress, amount]) => ({ tokenAddress, amount }));
-  }, [tokens]);
+  const mergedTokens = useMemo(() => mergeTokenApprovals(tokens), [tokens]);
 
   const tokenAddresses = useMemo(() => mergedTokens.map((t) => t.tokenAddress), [mergedTokens]);
 
@@ -80,16 +70,19 @@ export function useTokenApproval({
 
   const permitsOrEmpty = allowPermit && !isPermitsDisabled && tokenPermits ? tokenPermits : EMPTY_ARRAY;
 
-  const tokensToApprove = useMemo(
+  const pendingTokenApprovals = useMemo<PendingTokenApproval[]>(
     () =>
       skip
         ? EMPTY_ARRAY
-        : mergedTokens
-            .filter((token) =>
-              getNeedTokenApprove(tokensAllowanceData, token.tokenAddress, token.amount, permitsOrEmpty)
-            )
-            .map((token) => token.tokenAddress),
+        : mergedTokens.filter((token) =>
+            getNeedTokenApprove(tokensAllowanceData, token.tokenAddress, token.amount, permitsOrEmpty)
+          ),
     [skip, mergedTokens, tokensAllowanceData, permitsOrEmpty]
+  );
+
+  const tokensToApprove = useMemo(
+    () => pendingTokenApprovals.map((token) => token.tokenAddress),
+    [pendingTokenApprovals]
   );
 
   const needsApproval = tokensToApprove.length > 0;
@@ -148,6 +141,7 @@ export function useTokenApproval({
 
   return {
     tokensToApprove,
+    pendingTokenApprovals,
     needsApproval,
     isAllowanceLoading,
     isAllowanceLoaded,

--- a/src/lib/transactions/sendWalletCalls.spec.ts
+++ b/src/lib/transactions/sendWalletCalls.spec.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  consumeAtomicBatchingFallbackReason,
+  isAtomicBatchingDisabledForSession,
+  resetAtomicBatchingSessionOverride,
+} from "lib/wallets/eip5792";
+
+import { sendWalletCalls } from "./sendWalletCalls";
+
+const { mocks, ACCOUNT, CONNECTOR, CHAIN_ID } = vi.hoisted(() => ({
+  mocks: {
+    getAccount: vi.fn(),
+    getCallsStatus: vi.fn(),
+    sendCalls: vi.fn(),
+    waitForCallsStatus: vi.fn(),
+    pushBatchApprovalAnalyticsEvent: vi.fn(),
+  },
+  ACCOUNT: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as const,
+  CONNECTOR: { uid: "connector-1", name: "Test Wallet" },
+  CHAIN_ID: 42161,
+}));
+
+vi.mock("@wagmi/core", () => ({
+  getAccount: mocks.getAccount,
+  getCallsStatus: mocks.getCallsStatus,
+  sendCalls: mocks.sendCalls,
+  waitForCallsStatus: mocks.waitForCallsStatus,
+}));
+
+vi.mock("lib/wallets/walletConfig", () => ({
+  getWagmiConfig: () => ({ chains: [{ id: CHAIN_ID }] }),
+}));
+
+vi.mock("lib/userAnalytics/batchApprovalAnalytics", () => ({
+  pushBatchApprovalAnalyticsEvent: mocks.pushBatchApprovalAnalyticsEvent,
+}));
+
+const analytics = {
+  source: "Classic" as const,
+  chainId: CHAIN_ID,
+  capabilityStatus: "supported" as const,
+  tokenCount: 1,
+  walletProvider: CONNECTOR.name,
+};
+
+const calls = [
+  {
+    to: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as const,
+    data: "0x1234" as const,
+    value: 0n,
+  },
+];
+
+const sessionKey = {
+  connectorUid: CONNECTOR.uid,
+  account: ACCOUNT,
+  chainId: CHAIN_ID,
+};
+
+describe("sendWalletCalls", () => {
+  beforeEach(() => {
+    mocks.getAccount.mockReturnValue({ address: ACCOUNT, connector: CONNECTOR });
+    mocks.sendCalls.mockResolvedValue({ id: "bundle-1" });
+    mocks.pushBatchApprovalAnalyticsEvent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    resetAtomicBatchingSessionOverride();
+    vi.clearAllMocks();
+  });
+
+  it("requests an atomic batch and records submission and success", async () => {
+    mocks.waitForCallsStatus.mockResolvedValue({
+      id: "bundle-1",
+      atomic: true,
+      status: "success",
+      statusCode: 200,
+      receipts: [],
+    });
+
+    const result = await sendWalletCalls({
+      chainId: CHAIN_ID,
+      account: ACCOUNT,
+      calls,
+      analytics,
+    });
+
+    expect(mocks.sendCalls).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        account: ACCOUNT,
+        calls,
+        chainId: CHAIN_ID,
+        connector: CONNECTOR,
+        forceAtomic: true,
+      })
+    );
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ action: "BatchApproveAttempt" })
+    );
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ action: "BatchApproveSubmitted" })
+    );
+
+    await result.wait();
+
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ action: "BatchApproveSuccess" })
+    );
+  });
+
+  it("records a rejected request and disables batching for the session", async () => {
+    mocks.sendCalls.mockRejectedValue(Object.assign(new Error("Rejected"), { code: 4001 }));
+
+    await expect(
+      sendWalletCalls({
+        chainId: CHAIN_ID,
+        account: ACCOUNT,
+        calls,
+        analytics,
+      })
+    ).rejects.toThrow("Rejected");
+
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "BatchApproveFail",
+        reason: "UserRejected",
+      })
+    );
+    expect(mocks.pushBatchApprovalAnalyticsEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "BatchApproveFallback" })
+    );
+    expect(isAtomicBatchingDisabledForSession(sessionKey)).toBe(true);
+    expect(consumeAtomicBatchingFallbackReason(sessionKey)).toBe("UserRejected");
+  });
+
+  it.each([
+    [5750, "UpgradeRejected"],
+    [5760, "AtomicUnsupported"],
+    [4200, "AtomicUnsupported"],
+    [-32601, "AtomicUnsupported"],
+  ] as const)("classifies provider error code %s", async (code, reason) => {
+    mocks.sendCalls.mockRejectedValue(Object.assign(new Error("Provider error"), { code }));
+
+    await expect(
+      sendWalletCalls({
+        chainId: CHAIN_ID,
+        account: ACCOUNT,
+        calls,
+        analytics,
+      })
+    ).rejects.toThrow("Provider error");
+
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "BatchApproveFail",
+        reason,
+      })
+    );
+  });
+
+  it("classifies nested provider errors", async () => {
+    mocks.sendCalls.mockRejectedValue(
+      Object.assign(new Error("Wrapped error"), {
+        cause: Object.assign(new Error("Upgrade rejected"), { code: 5750 }),
+      })
+    );
+
+    await expect(
+      sendWalletCalls({
+        chainId: CHAIN_ID,
+        account: ACCOUNT,
+        calls,
+        analytics,
+      })
+    ).rejects.toThrow("Wrapped error");
+
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "BatchApproveFail",
+        reason: "UpgradeRejected",
+      })
+    );
+  });
+
+  it("keeps an unresolved status separate from a failure", async () => {
+    mocks.waitForCallsStatus.mockRejectedValue(
+      Object.assign(new Error("Timed out"), { name: "WaitForCallsStatusTimeoutError" })
+    );
+
+    const result = await sendWalletCalls({
+      chainId: CHAIN_ID,
+      account: ACCOUNT,
+      calls,
+      analytics,
+    });
+
+    await expect(result.wait()).rejects.toThrow("Timed out");
+
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "BatchApproveStatusUnknown",
+        reason: "StatusTimeout",
+      })
+    );
+    expect(isAtomicBatchingDisabledForSession(sessionKey)).toBe(false);
+  });
+
+  it("rejects a successful result that was not atomic", async () => {
+    mocks.getCallsStatus.mockResolvedValue({
+      id: "bundle-1",
+      atomic: false,
+      status: "success",
+      statusCode: 200,
+      receipts: [],
+    });
+
+    const result = await sendWalletCalls({
+      chainId: CHAIN_ID,
+      account: ACCOUNT,
+      calls,
+      analytics,
+    });
+
+    await expect(result.getStatus()).resolves.toMatchObject({ atomic: false, status: "success" });
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "BatchApproveFail",
+        reason: "AtomicUnsupported",
+      })
+    );
+    expect(mocks.pushBatchApprovalAnalyticsEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "BatchApproveFallback" })
+    );
+    expect(isAtomicBatchingDisabledForSession(sessionKey)).toBe(true);
+  });
+
+  it("records a terminal bundle failure and disables batching", async () => {
+    mocks.waitForCallsStatus.mockResolvedValue({
+      id: "bundle-1",
+      atomic: true,
+      status: "failure",
+      statusCode: 500,
+      receipts: [],
+    });
+
+    const result = await sendWalletCalls({
+      chainId: CHAIN_ID,
+      account: ACCOUNT,
+      calls,
+      analytics,
+    });
+
+    await expect(result.wait()).resolves.toMatchObject({ status: "failure" });
+    expect(mocks.pushBatchApprovalAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "BatchApproveFail",
+        reason: "BundleFailed",
+      })
+    );
+    expect(mocks.pushBatchApprovalAnalyticsEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "BatchApproveFallback" })
+    );
+    expect(isAtomicBatchingDisabledForSession(sessionKey)).toBe(true);
+  });
+
+  it("rejects a non-atomic success when waiting for an approval bundle", async () => {
+    mocks.waitForCallsStatus.mockResolvedValue({
+      id: "bundle-1",
+      atomic: false,
+      status: "success",
+      statusCode: 200,
+      receipts: [],
+    });
+
+    const result = await sendWalletCalls({
+      chainId: CHAIN_ID,
+      account: ACCOUNT,
+      calls,
+      analytics,
+    });
+
+    await expect(result.wait()).rejects.toThrow("not executed atomically");
+    expect(isAtomicBatchingDisabledForSession(sessionKey)).toBe(true);
+  });
+});

--- a/src/lib/transactions/sendWalletCalls.ts
+++ b/src/lib/transactions/sendWalletCalls.ts
@@ -1,0 +1,189 @@
+import { getAccount, getCallsStatus, sendCalls, waitForCallsStatus } from "@wagmi/core";
+import type { Address, Hex } from "viem";
+
+import { parseError } from "lib/errors";
+import { pushBatchApprovalAnalyticsEvent } from "lib/userAnalytics/batchApprovalAnalytics";
+import type { BatchApprovalAnalyticsEventParams } from "lib/userAnalytics/batchApprovalAnalytics";
+import type { TokenApproveBatchReason } from "lib/userAnalytics/types";
+import { disableAtomicBatchingForSession } from "lib/wallets/eip5792";
+import { getWagmiConfig } from "lib/wallets/walletConfig";
+
+export type WalletCall = {
+  to: Address;
+  data?: Hex;
+  value?: bigint;
+};
+
+export type WalletCallsStatus = Awaited<ReturnType<typeof getCallsStatus>>;
+
+export type WalletCallsAnalyticsContext = Omit<BatchApprovalAnalyticsEventParams, "action" | "reason">;
+
+export type SendWalletCallsResult = {
+  id: string;
+  getStatus: () => Promise<WalletCallsStatus>;
+  wait: (timeout?: number) => Promise<WalletCallsStatus>;
+};
+
+export class AtomicWalletCallsRequiredError extends Error {
+  constructor() {
+    super("Wallet call bundle was not executed atomically");
+    this.name = "AtomicWalletCallsRequiredError";
+  }
+}
+
+function getBatchApprovalFailureReason(error: unknown): TokenApproveBatchReason {
+  let currentError = error;
+
+  for (let index = 0; index < 10 && currentError && typeof currentError === "object"; index++) {
+    const errorName = (currentError as { name?: string }).name;
+    const errorCode = (currentError as { code?: number }).code;
+
+    if (errorName === "AtomicReadyWalletRejectedUpgradeError" || errorCode === 5750) {
+      return "UpgradeRejected";
+    }
+
+    if (
+      errorName === "AtomicityNotSupportedError" ||
+      errorName === "MethodNotFoundRpcError" ||
+      errorName === "MethodNotSupportedRpcError" ||
+      errorName === "UnsupportedProviderMethodError" ||
+      errorCode === 5760 ||
+      errorCode === 4200 ||
+      errorCode === -32601
+    ) {
+      return "AtomicUnsupported";
+    }
+
+    if (errorCode === 4001) {
+      return "UserRejected";
+    }
+
+    currentError = (currentError as { cause?: unknown }).cause;
+  }
+
+  if (parseError(error as Error)?.isUserRejectedError) {
+    return "UserRejected";
+  }
+
+  return "SendFailed";
+}
+
+export async function sendWalletCalls({
+  chainId,
+  account,
+  calls,
+  analytics,
+}: {
+  chainId: number;
+  account: Address;
+  calls: WalletCall[];
+  analytics?: WalletCallsAnalyticsContext;
+}): Promise<SendWalletCallsResult> {
+  const config = getWagmiConfig();
+  const connector = getAccount(config).connector;
+  const sessionKey = connector
+    ? {
+        connectorUid: connector.uid,
+        account,
+        chainId,
+      }
+    : undefined;
+
+  const pushAnalytics = (action: BatchApprovalAnalyticsEventParams["action"], reason?: TokenApproveBatchReason) => {
+    if (!analytics) return;
+
+    void pushBatchApprovalAnalyticsEvent({
+      ...analytics,
+      action,
+      reason,
+    });
+  };
+
+  pushAnalytics("BatchApproveAttempt");
+
+  let id: string;
+
+  try {
+    const result = await sendCalls(config, {
+      account,
+      calls,
+      chainId: chainId as (typeof config.chains)[number]["id"],
+      connector,
+      forceAtomic: true,
+    });
+    id = result.id;
+  } catch (error) {
+    const reason = getBatchApprovalFailureReason(error);
+    pushAnalytics("BatchApproveFail", reason);
+
+    if (sessionKey) {
+      disableAtomicBatchingForSession(sessionKey, reason);
+    }
+
+    throw error;
+  }
+
+  pushAnalytics("BatchApproveSubmitted");
+
+  let isTerminalStatusTracked = false;
+  let isUnknownStatusTracked = false;
+
+  const trackStatus = (status: WalletCallsStatus) => {
+    if (isTerminalStatusTracked || status.status === "pending" || status.status === undefined) {
+      return;
+    }
+
+    isTerminalStatusTracked = true;
+
+    if (status.status === "success" && status.atomic) {
+      pushAnalytics("BatchApproveSuccess");
+      return;
+    }
+
+    const reason = status.status === "success" ? "AtomicUnsupported" : "BundleFailed";
+    pushAnalytics("BatchApproveFail", reason);
+
+    if (sessionKey) {
+      disableAtomicBatchingForSession(sessionKey, reason);
+    }
+  };
+
+  const assertAtomicStatus = (status: WalletCallsStatus) => {
+    if (status.status === "success" && !status.atomic) {
+      throw new AtomicWalletCallsRequiredError();
+    }
+
+    return status;
+  };
+
+  const getStatus = async () => {
+    const status = await getCallsStatus(config, { id, connector });
+    trackStatus(status);
+    return status;
+  };
+
+  const wait = async (timeout = 60_000) => {
+    try {
+      const status = await waitForCallsStatus(config, {
+        id,
+        connector,
+        timeout,
+      });
+      trackStatus(status);
+      return assertAtomicStatus(status);
+    } catch (error) {
+      if ((error as { name?: string }).name === "WaitForCallsStatusTimeoutError" && !isUnknownStatusTracked) {
+        isUnknownStatusTracked = true;
+        pushAnalytics("BatchApproveStatusUnknown", "StatusTimeout");
+      }
+
+      throw error;
+    }
+  };
+
+  return {
+    id,
+    getStatus,
+    wait,
+  };
+}

--- a/src/lib/transactions/types.ts
+++ b/src/lib/transactions/types.ts
@@ -1,6 +1,8 @@
 import { ErrorLike } from "lib/errors";
 import { StatusCode } from "sdk/utils/gelatoRelay";
 
+import type { SendWalletCallsResult } from "./sendWalletCalls";
+
 export type TransactionWaiterResult = {
   relayStatus?:
     | {
@@ -64,7 +66,12 @@ export class TxnEventBuilder<TParams> {
     return this._build(TxnEventName.Sending, {});
   }
 
-  Sent(params: { type: "wallet"; transactionHash: string } | { type: "relay"; relayTaskId: string }) {
+  Sent(
+    params:
+      | { type: "wallet"; transactionHash: string }
+      | { type: "walletCalls"; callBundleId: string; getCallsStatus: SendWalletCallsResult["getStatus"] }
+      | { type: "relay"; relayTaskId: string }
+  ) {
     return this._build(TxnEventName.Sent, params);
   }
 }

--- a/src/lib/userAnalytics/batchApprovalAnalytics.spec.ts
+++ b/src/lib/userAnalytics/batchApprovalAnalytics.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ARBITRUM, getChainName } from "config/chains";
+
+import { pushBatchApprovalAnalyticsEvent } from "./batchApprovalAnalytics";
+import { userAnalytics } from "./UserAnalytics";
+
+vi.mock("./UserAnalytics", () => ({
+  userAnalytics: {
+    pushEvent: vi.fn(),
+  },
+}));
+
+describe("pushBatchApprovalAnalyticsEvent", () => {
+  beforeEach(() => {
+    vi.mocked(userAnalytics.pushEvent).mockClear();
+  });
+
+  it("emits a bundle-level token approval event", () => {
+    pushBatchApprovalAnalyticsEvent({
+      action: "BatchApproveSubmitted",
+      source: "Classic",
+      chainId: ARBITRUM,
+      capabilityStatus: "ready",
+      tokenCount: 2,
+      walletProvider: "MetaMask",
+    });
+
+    expect(userAnalytics.pushEvent).toHaveBeenCalledWith({
+      event: "TokenApproveAction",
+      data: {
+        action: "BatchApproveSubmitted",
+        source: "Classic",
+        chain: getChainName(ARBITRUM),
+        capability: "Ready",
+        tokenCount: 2,
+        walletProvider: "MetaMask",
+        reason: undefined,
+      },
+    });
+  });
+
+  it("includes a controlled fallback reason", () => {
+    pushBatchApprovalAnalyticsEvent({
+      action: "BatchApproveFallback",
+      source: "OneClickReauth",
+      chainId: ARBITRUM,
+      capabilityStatus: "unsupported",
+      tokenCount: 3,
+      reason: "CapabilityUnsupported",
+    });
+
+    expect(userAnalytics.pushEvent).toHaveBeenCalledWith({
+      event: "TokenApproveAction",
+      data: expect.objectContaining({
+        action: "BatchApproveFallback",
+        source: "OneClickReauth",
+        capability: "Unsupported",
+        tokenCount: 3,
+        reason: "CapabilityUnsupported",
+      }),
+    });
+  });
+});

--- a/src/lib/userAnalytics/batchApprovalAnalytics.ts
+++ b/src/lib/userAnalytics/batchApprovalAnalytics.ts
@@ -1,0 +1,51 @@
+import { getChainName } from "config/chains";
+import type { AtomicCapabilityStatus } from "lib/wallets/eip5792";
+
+import type {
+  TokenApproveBatchAction,
+  TokenApproveBatchCapability,
+  TokenApproveBatchEvent,
+  TokenApproveBatchReason,
+  TokenApproveBatchSource,
+} from "./types";
+import { userAnalytics } from "./UserAnalytics";
+
+const ANALYTICS_CAPABILITY_BY_STATUS: Record<AtomicCapabilityStatus, TokenApproveBatchCapability> = {
+  supported: "Supported",
+  ready: "Ready",
+  unsupported: "Unsupported",
+  unknown: "Unknown",
+};
+
+export type BatchApprovalAnalyticsEventParams = {
+  action: TokenApproveBatchAction;
+  source: TokenApproveBatchSource;
+  chainId: number;
+  capabilityStatus: AtomicCapabilityStatus;
+  tokenCount: number;
+  walletProvider?: string;
+  reason?: TokenApproveBatchReason;
+};
+
+export function pushBatchApprovalAnalyticsEvent({
+  action,
+  source,
+  chainId,
+  capabilityStatus,
+  tokenCount,
+  walletProvider,
+  reason,
+}: BatchApprovalAnalyticsEventParams) {
+  return userAnalytics.pushEvent<TokenApproveBatchEvent>({
+    event: "TokenApproveAction",
+    data: {
+      action,
+      source,
+      chain: getChainName(chainId),
+      capability: ANALYTICS_CAPABILITY_BY_STATUS[capabilityStatus],
+      tokenCount,
+      walletProvider,
+      reason,
+    },
+  });
+}

--- a/src/lib/userAnalytics/types.ts
+++ b/src/lib/userAnalytics/types.ts
@@ -120,6 +120,42 @@ export type TokenApproveResultEvent = {
   };
 };
 
+export type TokenApproveBatchAction =
+  | "BatchApproveAttempt"
+  | "BatchApproveSubmitted"
+  | "BatchApproveSuccess"
+  | "BatchApproveFail"
+  | "BatchApproveStatusUnknown"
+  | "BatchApproveFallback";
+
+export type TokenApproveBatchSource = "Classic" | "Express" | "OneClickSetup" | "OneClickReauth";
+
+export type TokenApproveBatchCapability = "Supported" | "Ready" | "Unsupported" | "Unknown";
+
+export type TokenApproveBatchReason =
+  | "CapabilityUnsupported"
+  | "CapabilityQueryFailed"
+  | "UserRejected"
+  | "UpgradeRejected"
+  | "AtomicUnsupported"
+  | "SendFailed"
+  | "BundleFailed"
+  | "StatusTimeout"
+  | "UserSkipped";
+
+export type TokenApproveBatchEvent = {
+  event: "TokenApproveAction";
+  data: {
+    action: TokenApproveBatchAction;
+    source: TokenApproveBatchSource;
+    chain: ChainName;
+    capability: TokenApproveBatchCapability;
+    tokenCount: number;
+    walletProvider?: string;
+    reason?: TokenApproveBatchReason;
+  };
+};
+
 export type TradeBoxConfirmClickEvent = {
   event: "TradeBoxAction";
   data: {

--- a/src/lib/wallets/eip5792.spec.ts
+++ b/src/lib/wallets/eip5792.spec.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  consumeAtomicBatchingFallbackReason,
+  disableAtomicBatchingForSession,
+  getAtomicCapabilityQueryKey,
+  getAtomicCapabilityStatus,
+  isAtomicBatchingDisabledForSession,
+  resetAtomicBatchingSessionOverride,
+  subscribeToAtomicBatchingSessionOverrides,
+} from "./eip5792";
+
+afterEach(() => {
+  resetAtomicBatchingSessionOverride();
+});
+
+describe("getAtomicCapabilityStatus", () => {
+  it.each(["supported", "ready", "unsupported"] as const)("returns the current chain %s status", (status) => {
+    expect(
+      getAtomicCapabilityStatus(
+        {
+          42161: { atomic: { status } },
+          0: { atomic: { status: "unsupported" } },
+        },
+        42161
+      )
+    ).toBe(status);
+  });
+
+  it("falls back to the global capability", () => {
+    expect(getAtomicCapabilityStatus({ 0: { atomic: { status: "ready" } } }, 42161)).toBe("ready");
+  });
+
+  it("resolves the atomic capability globally when the current chain only declares other capabilities", () => {
+    expect(
+      getAtomicCapabilityStatus(
+        {
+          42161: {},
+          0: { atomic: { status: "supported" } },
+        },
+        42161
+      )
+    ).toBe("supported");
+  });
+
+  it("prefers a chain-specific atomic capability over the global capability", () => {
+    expect(
+      getAtomicCapabilityStatus(
+        {
+          42161: { atomic: { status: "unsupported" } },
+          0: { atomic: { status: "supported" } },
+        },
+        42161
+      )
+    ).toBe("unsupported");
+  });
+
+  it("treats a completed response without the atomic capability as unsupported", () => {
+    expect(getAtomicCapabilityStatus({}, 42161)).toBe("unsupported");
+    expect(getAtomicCapabilityStatus({ 42161: {} }, 42161)).toBe("unsupported");
+  });
+
+  it("returns unknown before a response or for an unrecognized status", () => {
+    expect(getAtomicCapabilityStatus(undefined, 42161)).toBe("unknown");
+    expect(getAtomicCapabilityStatus({ 42161: { atomic: { status: "invalid" } } }, 42161)).toBe("unknown");
+  });
+});
+
+describe("getAtomicCapabilityQueryKey", () => {
+  it("is scoped to connector, account, and chain without changing address casing", () => {
+    expect(
+      getAtomicCapabilityQueryKey({
+        connectorUid: "metamask-1",
+        account: "0xAbCd",
+        chainId: 42161,
+      })
+    ).toEqual(["eip5792AtomicCapability", "metamask-1", "0xAbCd", 42161]);
+  });
+});
+
+describe("atomic batching session override", () => {
+  const key = {
+    connectorUid: "metamask-1",
+    account: "0xAbCd",
+    chainId: 42161,
+  };
+
+  it("disables batching only for the matching connector, account, and chain", () => {
+    disableAtomicBatchingForSession(key);
+
+    expect(isAtomicBatchingDisabledForSession(key)).toBe(true);
+    expect(isAtomicBatchingDisabledForSession({ ...key, connectorUid: "rabby-1" })).toBe(false);
+    expect(isAtomicBatchingDisabledForSession({ ...key, account: "0xDcBa" })).toBe(false);
+    expect(isAtomicBatchingDisabledForSession({ ...key, chainId: 43114 })).toBe(false);
+  });
+
+  it("can reset one override without affecting another", () => {
+    const secondKey = { ...key, chainId: 43114 };
+    disableAtomicBatchingForSession(key);
+    disableAtomicBatchingForSession(secondKey);
+
+    resetAtomicBatchingSessionOverride(key);
+
+    expect(isAtomicBatchingDisabledForSession(key)).toBe(false);
+    expect(isAtomicBatchingDisabledForSession(secondKey)).toBe(true);
+  });
+
+  it("exposes a fallback reason only for the next explicit fallback", () => {
+    disableAtomicBatchingForSession(key, "UserRejected");
+
+    expect(consumeAtomicBatchingFallbackReason(key)).toBe("UserRejected");
+    expect(consumeAtomicBatchingFallbackReason(key)).toBeUndefined();
+    expect(isAtomicBatchingDisabledForSession(key)).toBe(true);
+  });
+
+  it("notifies subscribers only when an override changes", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToAtomicBatchingSessionOverrides(listener);
+
+    disableAtomicBatchingForSession(key);
+    disableAtomicBatchingForSession(key);
+    resetAtomicBatchingSessionOverride(key);
+    resetAtomicBatchingSessionOverride(key);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+});

--- a/src/lib/wallets/eip5792.ts
+++ b/src/lib/wallets/eip5792.ts
@@ -1,0 +1,105 @@
+import type { TokenApproveBatchReason } from "lib/userAnalytics/types";
+
+export type AtomicCapabilityStatus = "supported" | "ready" | "unsupported" | "unknown";
+
+export type Eip5792Capabilities = Record<
+  number,
+  | {
+      atomic?: {
+        status?: string;
+      };
+    }
+  | undefined
+>;
+
+export type AtomicCapabilitySessionKey = {
+  connectorUid: string;
+  account: string;
+  chainId: number;
+};
+
+const disabledAtomicBatchingReasons = new Map<string, TokenApproveBatchReason | undefined>();
+const atomicBatchingOverrideListeners = new Set<() => void>();
+
+export function getAtomicCapabilityStatus(
+  capabilities: Eip5792Capabilities | undefined,
+  chainId: number
+): AtomicCapabilityStatus {
+  if (!capabilities) {
+    return "unknown";
+  }
+
+  const atomicStatus = (capabilities[chainId]?.atomic ?? capabilities[0]?.atomic)?.status;
+
+  if (!atomicStatus) {
+    return "unsupported";
+  }
+
+  if (atomicStatus === "supported" || atomicStatus === "ready" || atomicStatus === "unsupported") {
+    return atomicStatus;
+  }
+
+  return "unknown";
+}
+
+export function getAtomicCapabilityQueryKey({
+  connectorUid,
+  account,
+  chainId,
+}: {
+  connectorUid: string | undefined;
+  account: string | undefined;
+  chainId: number;
+}) {
+  return ["eip5792AtomicCapability", connectorUid, account, chainId] as const;
+}
+
+function serializeAtomicCapabilitySessionKey({ connectorUid, account, chainId }: AtomicCapabilitySessionKey) {
+  return JSON.stringify([connectorUid, account, chainId]);
+}
+
+export function isAtomicBatchingDisabledForSession(key: AtomicCapabilitySessionKey) {
+  return disabledAtomicBatchingReasons.has(serializeAtomicCapabilitySessionKey(key));
+}
+
+export function disableAtomicBatchingForSession(key: AtomicCapabilitySessionKey, reason?: TokenApproveBatchReason) {
+  const serializedKey = serializeAtomicCapabilitySessionKey(key);
+
+  if (disabledAtomicBatchingReasons.has(serializedKey)) {
+    return;
+  }
+
+  disabledAtomicBatchingReasons.set(serializedKey, reason);
+  atomicBatchingOverrideListeners.forEach((listener) => listener());
+}
+
+export function consumeAtomicBatchingFallbackReason(key: AtomicCapabilitySessionKey) {
+  const serializedKey = serializeAtomicCapabilitySessionKey(key);
+  const reason = disabledAtomicBatchingReasons.get(serializedKey);
+
+  if (reason) {
+    disabledAtomicBatchingReasons.set(serializedKey, undefined);
+  }
+
+  return reason;
+}
+
+export function resetAtomicBatchingSessionOverride(key?: AtomicCapabilitySessionKey) {
+  const didChange = key
+    ? disabledAtomicBatchingReasons.delete(serializeAtomicCapabilitySessionKey(key))
+    : disabledAtomicBatchingReasons.size > 0;
+
+  if (!key) {
+    disabledAtomicBatchingReasons.clear();
+  }
+
+  if (didChange) {
+    atomicBatchingOverrideListeners.forEach((listener) => listener());
+  }
+}
+
+export function subscribeToAtomicBatchingSessionOverrides(listener: () => void) {
+  atomicBatchingOverrideListeners.add(listener);
+
+  return () => atomicBatchingOverrideListeners.delete(listener);
+}

--- a/src/lib/wallets/useAtomicCapability.ts
+++ b/src/lib/wallets/useAtomicCapability.ts
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCapabilities } from "@wagmi/core";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useAccount, useConfig } from "wagmi";
+
+import {
+  consumeAtomicBatchingFallbackReason,
+  disableAtomicBatchingForSession,
+  getAtomicCapabilityQueryKey,
+  getAtomicCapabilityStatus,
+  isAtomicBatchingDisabledForSession,
+  resetAtomicBatchingSessionOverride,
+  subscribeToAtomicBatchingSessionOverrides,
+} from "./eip5792";
+import type { AtomicCapabilitySessionKey, AtomicCapabilityStatus, Eip5792Capabilities } from "./eip5792";
+
+export function useAtomicCapability({ chainId, enabled = true }: { chainId: number; enabled?: boolean }) {
+  const config = useConfig();
+  const { address: account, connector } = useAccount();
+  const sessionKey = useMemo<AtomicCapabilitySessionKey | undefined>(
+    () =>
+      account && connector
+        ? {
+            connectorUid: connector.uid,
+            account,
+            chainId,
+          }
+        : undefined,
+    [account, chainId, connector]
+  );
+
+  const query = useQuery({
+    queryKey: getAtomicCapabilityQueryKey({
+      connectorUid: connector?.uid,
+      account,
+      chainId,
+    }),
+    queryFn: () => getCapabilities(config, { account, connector }),
+    enabled: enabled && Boolean(account && connector),
+    retry: false,
+  });
+
+  const atomicCapabilityStatus: AtomicCapabilityStatus = query.error
+    ? "unknown"
+    : getAtomicCapabilityStatus(query.data as Eip5792Capabilities | undefined, chainId);
+
+  const getIsAtomicBatchingDisabled = useCallback(
+    () => Boolean(sessionKey && isAtomicBatchingDisabledForSession(sessionKey)),
+    [sessionKey]
+  );
+  const isAtomicBatchingDisabled = useSyncExternalStore(
+    subscribeToAtomicBatchingSessionOverrides,
+    getIsAtomicBatchingDisabled,
+    getIsAtomicBatchingDisabled
+  );
+  const disableAtomicBatching = useCallback(() => {
+    if (sessionKey) {
+      disableAtomicBatchingForSession(sessionKey);
+    }
+  }, [sessionKey]);
+  const resetAtomicBatching = useCallback(() => {
+    if (sessionKey) {
+      resetAtomicBatchingSessionOverride(sessionKey);
+    }
+  }, [sessionKey]);
+  const consumeAtomicBatchingFallback = useCallback(
+    () => (sessionKey ? consumeAtomicBatchingFallbackReason(sessionKey) : undefined),
+    [sessionKey]
+  );
+
+  return {
+    ...query,
+    atomicCapabilityStatus,
+    isAtomicBatchSupported:
+      !isAtomicBatchingDisabled && (atomicCapabilityStatus === "supported" || atomicCapabilityStatus === "ready"),
+    isAtomicBatchingDisabled,
+    disableAtomicBatching,
+    resetAtomicBatching,
+    consumeAtomicBatchingFallbackReason: consumeAtomicBatchingFallback,
+    walletProvider: connector?.name,
+  };
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>Kaufe</0> {wrappedNativeTokenSymbol}."
 msgid "Annualized buy pressure:"
 msgstr "Annualisierter Kaufdruck:"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "Unbegrenzt"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "Auf Wallet erhalten"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "Bestätige die optionale Genehmigung in deiner Wallet"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "Das Überspringen dieser Anfrage unterbricht die One-Click-Einrichtung nicht."
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Herunterladen der Handelsverlauf-CSV fehlgeschlagen"
@@ -9103,6 +9117,10 @@ msgstr "Verkaufsauftrag gesendet"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "Auszahlungsfehler"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "Optionale Token-Genehmigungen"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "Kontoereignisse"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "Transaktion fehlgeschlagen"
 
@@ -11003,6 +11022,10 @@ msgstr "Reduzieren Sie die Abhebung auf das Maximum. <0>Mehr erfahren</0>.<1/><2
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "Genehmige One-Click-Gaszahlungstoken mit einer einzigen Wallet-Bestätigung."
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} abgebrochen"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "Limit"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "Tokens genehmigen"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgid "Annualized buy pressure:"
 msgstr "Annualized buy pressure:"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "Unlimited"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "Wallet received"
 msgid "Set SL price above mark price"
 msgstr "Set SL price above mark price"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "Confirm the optional approval in your wallet"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr "ParaSwap"
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr "ParaSwap"
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr "Set short Stop Market @ {0}"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "Skipping this request won't interrupt One-Click setup."
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Failed to download trade history CSV"
@@ -9103,6 +9117,10 @@ msgstr "Sell request sent"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "Withdrawal error"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "Optional token approvals"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "Account events"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "Transaction failed"
 
@@ -11003,6 +11022,10 @@ msgstr "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "Approve One-Click gas payment tokens in one wallet confirmation."
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} canceled"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "Limit"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "Approve tokens"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>Comprar</0> {wrappedNativeTokenSymbol}."
 msgid "Annualized buy pressure:"
 msgstr "Presión de compra anualizada:"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "Ilimitado"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "Recibido en la billetera"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "Confirma la aprobación opcional en tu billetera"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "Omitir esta solicitud no interrumpirá la configuración de One-Click."
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Error al descargar el CSV del historial de operaciones"
@@ -9103,6 +9117,10 @@ msgstr "Solicitud de venta enviada"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "Error de retirada"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "Aprobaciones de tokens opcionales"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "Eventos de la cuenta"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "Transacción fallida"
 
@@ -11003,6 +11022,10 @@ msgstr "Reduzca la retirada para ajustarse al máximo. <0>Más información</0>.
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "Aprueba los tokens de pago de gas de One-Click con una sola confirmación de la billetera."
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} canceladas"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "Límite"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "Aprobar tokens"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>Acheter</0> {wrappedNativeTokenSymbol}."
 msgid "Annualized buy pressure:"
 msgstr "Pression d'achat annualisée :"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "Illimité"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "Reçu sur le portefeuille"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "Confirmez l’autorisation facultative dans votre portefeuille"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "Ignorer cette demande n’interrompra pas la configuration de One-Click."
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Échec du téléchargement du CSV de l'historique des transactions"
@@ -9103,6 +9117,10 @@ msgstr "Demande de vente envoyée"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "Erreur de retrait"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "Autorisations de jetons facultatives"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "Événements du compte"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "Transaction échouée"
 
@@ -11003,6 +11022,10 @@ msgstr "Réduisez le retrait pour correspondre au maximum. <0>En savoir plus</0>
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "Autorisez les jetons de paiement des frais de One-Click en une seule confirmation du portefeuille."
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} annulé(s)"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "Limite"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "Approuver les jetons"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>{wrappedNativeTokenSymbol}を購入</0>。"
 msgid "Annualized buy pressure:"
 msgstr "年間購入圧力："
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "無制限"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "ウォレット受取額"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "ウォレットで任意の承認を確認してください"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "このリクエストをスキップしても、One-Click の設定は中断されません。"
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "取引履歴CSVのダウンロードに失敗しました"
@@ -9103,6 +9117,10 @@ msgstr "売却リクエストが送信されました"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "出金エラー"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "任意のトークン承認"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "アカウントイベント"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "取引失敗"
 
@@ -11003,6 +11022,10 @@ msgstr "最大値に合わせて出金額を減らしてください。<0>詳細
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "One-Click のガス支払いトークンを、ウォレットで一度に承認します。"
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText}がキャンセルされました"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "リミット"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "トークンを承認"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>{wrappedNativeTokenSymbol} 구매</0>."
 msgid "Annualized buy pressure:"
 msgstr "연간 매수 압력:"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "무제한"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "지갑 수령액"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "지갑에서 선택적 승인을 확인하세요"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "이 요청을 건너뛰어도 One-Click 설정은 중단되지 않습니다."
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "거래 내역 CSV 다운로드에 실패했습니다"
@@ -9103,6 +9117,10 @@ msgstr "판매 요청이 전송되었습니다"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "출금 오류"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "선택적 토큰 승인"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "계정 이벤트"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "트랜잭션 실패"
 
@@ -11003,6 +11022,10 @@ msgstr "최대값에 맞게 출금을 줄이십시오. <0>자세히 보기</0>.<
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "한 번의 지갑 확인으로 One-Click 가스 결제 토큰을 승인하세요."
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} 취소됨"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "지정가"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "토큰 승인"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4799,6 +4799,10 @@ msgstr ""
 msgid "Annualized buy pressure:"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr ""
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr ""
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr ""
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr ""
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr ""
@@ -9102,6 +9116,10 @@ msgstr ""
 #: src/domain/synthetics/markets/createGlvWithdrawalTxn.ts
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
+msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
@@ -10891,6 +10909,7 @@ msgstr ""
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr ""
 
@@ -11002,6 +11021,10 @@ msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
+msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
 msgstr ""
 
 #: src/components/GmList/GmList.tsx
@@ -11643,6 +11666,13 @@ msgstr ""
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
+msgstr ""
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
 msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>Купить</0> {wrappedNativeTokenSymbol}."
 msgid "Annualized buy pressure:"
 msgstr "Годовое давление на покупку:"
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "Без ограничений"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "Получено на кошелёк"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "Подтвердите необязательное разрешение в кошельке"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "Пропуск этого запроса не прервёт настройку One-Click."
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Не удалось скачать CSV истории сделок"
@@ -9103,6 +9117,10 @@ msgstr "Запрос на продажу отправлен"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "Ошибка вывода"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "Необязательные разрешения токенов"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "События аккаунта"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "Транзакция не удалась"
 
@@ -11003,6 +11022,10 @@ msgstr "Уменьшите вывод до максимума. <0>Подробн
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "Разрешите использование токенов для оплаты газа One-Click одним подтверждением в кошельке."
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} отменён"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "Лимит"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "Одобрить токены"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>買入</0> {wrappedNativeTokenSymbol}。"
 msgid "Annualized buy pressure:"
 msgstr "年化買入壓力："
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "無限"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "錢包收到金額"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "在錢包中確認選用授權"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "略過此請求不會中斷 One-Click 設定。"
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "交易歷史 CSV 下載失敗"
@@ -9103,6 +9117,10 @@ msgstr "賣出請求已發送"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "提取錯誤"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "選用代幣授權"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "帳戶事件"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "交易失敗"
 
@@ -11003,6 +11022,10 @@ msgstr "減少提取金額以符合上限。<0>了解更多</0>。<1/><2/><3>設
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "只需一次錢包確認即可授權 One-Click Gas 支付代幣。"
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} 已取消"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "限價"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "授權代幣"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4799,6 +4799,10 @@ msgstr "<0>购买</0> {wrappedNativeTokenSymbol}。"
 msgid "Annualized buy pressure:"
 msgstr "年化买入压力："
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Unlimited"
+msgstr "无限"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -6436,6 +6440,10 @@ msgstr "钱包收到金额"
 msgid "Set SL price above mark price"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Confirm the optional approval in your wallet"
+msgstr "在钱包中确认可选授权"
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 #: src/components/Referrals/distributions/table/RebatesDistributionTable.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -6880,6 +6888,7 @@ msgstr ""
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
 #: src/components/PositionSeller/PositionSeller.tsx
 #: src/components/Referrals/affiliates/createCode/AddAffiliateCode.tsx
 #: src/components/Referrals/shared/charts/TraderReferralChartContainer.tsx
@@ -6888,6 +6897,7 @@ msgstr ""
 #: src/components/Referrals/traders/joinCode/getReferralCodeButtonState.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 #: src/components/ShareModal/CreateReferralCode.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
 #: src/domain/multichain/useWithdrawBlockedError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -8799,6 +8809,10 @@ msgstr "Jones DAO"
 msgid "Set short Stop Market @ {0}"
 msgstr ""
 
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Skipping this request won't interrupt One-Click setup."
+msgstr "跳过此请求不会中断 One-Click 设置。"
+
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "交易历史 CSV 下载失败"
@@ -9103,6 +9117,10 @@ msgstr "卖出请求已发送"
 #: src/domain/synthetics/markets/createWithdrawalTxn.ts
 msgid "Withdrawal error"
 msgstr "提取错误"
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Optional token approvals"
+msgstr "可选代币授权"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Decentralised permissionless on-chain exchange with deep liquidity and low costs, live since 2021"
@@ -10891,6 +10909,7 @@ msgstr "账户事件"
 
 #: src/components/Errors/errorToasts.tsx
 #: src/components/Errors/errorToasts.tsx
+#: src/context/PendingTxnsContext/PendingTxnsContext.tsx
 msgid "Transaction failed"
 msgstr "交易失败"
 
@@ -11003,6 +11022,10 @@ msgstr "减少提取量以匹配上限。<0>了解更多</0>。<1/><2/><3>设置
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing {indexTokenText} Long: -{sizeDeltaUsdText}"
 msgstr ""
+
+#: src/components/OneClickAdvancedSettings/OneClickTokenApprovalPreview.tsx
+msgid "Approve One-Click gas payment tokens in one wallet confirmation."
+msgstr "一次钱包确认即可授权 One-Click Gas 支付代币。"
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11644,6 +11667,13 @@ msgstr "{ordersText} 已取消"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Limit"
 msgstr "限价"
+
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/PositionEditor/usePositionEditorButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Approve tokens"
+msgstr "授权代币"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"


### PR DESCRIPTION
## Summary

- batch Classic token approvals and trade submission into one atomic EIP-5792 wallet confirmation
- batch multiple Express approvals and add optional One-Click gas-token preapprovals with an Unlimited preview
- add capability and session fallback handling, ordered simulation, pending wallet-call tracking, analytics, tests, and translations

## Validation

- `yarn test:ci`
- `yarn test:ct`
- `cd sdk && yarn test:ci`
- `yarn tscheck:ci`
- ESLint, Prettier, and Lingui extraction/compilation

Linear: https://linear.app/gmx-io/issue/FEDEV-4153/phase-7-batch-approve-trade-into-one-confirmation-with-eip-5792
