### PR TITLE
Align the subaccount signing test with the shared collateral fixture

### DIFF
--- a/sdk/src/clients/v2/__tests__/subaccount.spec.ts
+++ b/sdk/src/clients/v2/__tests__/subaccount.spec.ts
@@ -297,11 +297,11 @@ describe("GmxApiSdk — subaccount (1CT)", () => {
 
     const prepared = await sdk.prepareOrder({
       kind: "increase",
-      symbol: "ETH/USD [WETH-USDC]",
+      symbol: TEST_SYMBOL,
       direction: "long",
       orderType: "market",
-      size: 100n * 10n ** 30n,
-      collateralToPay: { amount: 1000000n, token: "USDC" },
+      size: TEST_SIZE_USD,
+      collateralToPay: TEST_COLLATERAL,
       mode: "express",
       from: signer.address,
       subaccountAddress: sdk.subaccountAddress,


### PR DESCRIPTION
Follow-up to #2699.

That test carried its own hardcoded `1 USDC` collateral instead of `TEST_COLLATERAL`, so the bump to 3 USDC in #2699 missed it. Now that gmx-io/gmx-api#120 is live, `prepareOrder` rejects it at prepare time:

```
HTTP 400: Collateral after fees is below the $1.00 minimum required to open the position
```

Which is the API behaving correctly — the fixture is what is wrong. It was asking for a $100 position on 1 USDC, i.e. 100x leverage, which would have been cancelled on-chain as immediately liquidatable.

Switched to the shared `TEST_SYMBOL` / `TEST_SIZE_USD` / `TEST_COLLATERAL` constants, so it now matches every other spec in the suite and the incidental leverage goes away.

Verified against production: `yarn test:v2:public` → 50 passed / 2 skipped, all 4 files green. `tscheck:ci` and `lint:ci` clean.