### PR TITLE
Fix long TP/SL percentage display FEDEV-4047

### DIFF
--- a/sdk/src/utils/__tests__/numbers.spec.ts
+++ b/sdk/src/utils/__tests__/numbers.spec.ts
@@ -23,6 +23,8 @@ import {
   PERCENT_PRECISION_DECIMALS,
   PRECISION,
   PRECISION_DECIMALS,
+  parseValue,
+  removeTrailingZeros,
   trimZeroDecimals,
   roundWithDecimals,
   roundUpMagnitudeDivision,
@@ -144,6 +146,22 @@ describe("trimZeroDecimals", () => {
 
   it("leading zeros with trailing zero decimals trims to int", () => {
     expect(trimZeroDecimals("0000123.000")).toBe("123");
+  });
+});
+
+describe("removeTrailingZeros", () => {
+  it("keeps large values in plain decimal notation", () => {
+    expect(removeTrailingZeros("9659861417460889000000.00")).toBe("9659861417460889000000");
+  });
+
+  it("removes trailing fractional zeros without converting the value to a number", () => {
+    expect(removeTrailingZeros("123.4500")).toBe("123.45");
+  });
+});
+
+describe("parseValue", () => {
+  it("returns undefined instead of throwing for scientific notation", () => {
+    expect(parseValue("9.659861417460889e+21", USD_DECIMALS)).toBeUndefined();
   });
 });
 

--- a/sdk/src/utils/numbers/utils.ts
+++ b/sdk/src/utils/numbers/utils.ts
@@ -776,8 +776,13 @@ export const parseValue = (value: string, tokenDecimals: number) => {
     return undefined;
   }
 
-  value = limitDecimals(value, tokenDecimals);
-  const amount = parseUnits(value, tokenDecimals);
+  let amount: bigint;
+  try {
+    value = limitDecimals(value, tokenDecimals);
+    amount = parseUnits(value, tokenDecimals);
+  } catch {
+    return undefined;
+  }
 
   // Cap at a safe maximum to prevent downstream BigInt overflow errors
   const MAX_ALLOWED = expandDecimals(1, 62);
@@ -823,9 +828,11 @@ export function maxbigint(...args: bigint[]) {
 }
 
 export function removeTrailingZeros(amount: string | number) {
-  const amountWithoutZeros = Number(amount);
-  if (!amountWithoutZeros) return amount;
-  return amountWithoutZeros;
+  if (typeof amount === "number" || !amount.includes(".") || amount.includes(",") || /^[-+]?0*\.0*$/.test(amount)) {
+    return amount;
+  }
+
+  return amount.replace(/0+$/, "").replace(/\.$/, "");
 }
 
 type SerializedBigIntsInObject<T> = {

--- a/src/components/OrdersModal/TPSLInputRow.spec.tsx
+++ b/src/components/OrdersModal/TPSLInputRow.spec.tsx
@@ -1,0 +1,65 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { expandDecimals } from "lib/numbers";
+
+import { TPSLInputRow } from "./TPSLInputRow";
+
+beforeAll(() => {
+  i18n.load("en", {});
+  i18n.activate("en");
+});
+
+afterEach(cleanup);
+
+const positionData = {
+  sizeInTokens: expandDecimals(1, 18),
+  collateralUsd: expandDecimals(10, 30),
+  entryPrice: expandDecimals(100, 30),
+  referencePrice: expandDecimals(100, 30),
+  isLong: true,
+  indexTokenDecimals: 18,
+};
+
+describe("TPSLInputRow", () => {
+  it("keeps long derived percentages unchanged and contained within the PnL row", () => {
+    const view = render(
+      <I18nProvider i18n={i18n}>
+        <TPSLInputRow
+          type="takeProfit"
+          priceValue="100000000000000000000"
+          onPriceChange={vi.fn()}
+          positionData={positionData}
+        />
+      </I18nProvider>
+    );
+
+    const inputs = view.getAllByRole("textbox") as HTMLInputElement[];
+
+    expect(inputs[0].value).toBe("100000000000000000000");
+    expect(inputs[1].value).toMatch(/^\d+(?:\.\d+)?$/);
+    expect(inputs[1].value.length).toBeGreaterThan(6);
+    expect(inputs[1].value).not.toBe("199.99");
+
+    const estimatedPnlValue = view.getByText("Est. PnL").nextElementSibling;
+    expect(estimatedPnlValue?.classList.contains("truncate")).toBe(true);
+  });
+
+  it("keeps prices calculated from long percentage inputs in plain decimal notation", () => {
+    const onPriceChange = vi.fn();
+    const view = render(
+      <I18nProvider i18n={i18n}>
+        <TPSLInputRow type="takeProfit" priceValue="100" onPriceChange={onPriceChange} positionData={positionData} />
+      </I18nProvider>
+    );
+
+    const inputs = view.getAllByRole("textbox") as HTMLInputElement[];
+    fireEvent.change(inputs[1], { target: { value: "9659861417460889000000" } });
+
+    const calculatedPrice = onPriceChange.mock.calls[onPriceChange.mock.calls.length - 1][0];
+    expect(calculatedPrice).toMatch(/^\d+(?:\.\d+)?$/);
+    expect(calculatedPrice).not.toMatch(/[eE]/);
+  });
+});

--- a/src/components/OrdersModal/TPSLInputRow.tsx
+++ b/src/components/OrdersModal/TPSLInputRow.tsx
@@ -399,12 +399,12 @@ export function TPSLInputRow({
   }, [referencePrice, formatPrice, onPriceChange]);
 
   const estimatedPnlRow = (
-    <div className="text-body-small flex justify-end">
-      <span className="text-typography-secondary">
+    <div className="text-body-small flex min-w-0 justify-end">
+      <span className="shrink-0 text-typography-secondary">
         <Trans>Est. PnL</Trans>
       </span>
       <span
-        className={cx("ml-4 numbers", {
+        className={cx("ml-4 min-w-0 truncate numbers", {
           "text-green-500": estimatedPnl && estimatedPnl.pnlUsd > 0n,
           "text-red-500": estimatedPnl && estimatedPnl.pnlUsd < 0n,
         })}


### PR DESCRIPTION
## Summary

Fix long values in TP/SL inputs so the real calculated percentage is preserved without breaking the Est. PnL layout.

Linear: https://linear.app/gmx-io/issue/FEDEV-4047/long-number-entered-in-tpsl-fields-displayed-fully-in-long-percent

## What changed

- Keep the calculated TP/SL percentage unchanged and truncate overflowing Est. PnL text within its row.
- Preserve large decimal values in plain notation when removing trailing zeros.
- Return an invalid parse result instead of throwing when a decimal parser receives unsupported scientific notation.
- Add regression tests for long TP/SL values and numeric parsing.

## Root cause

Large decimal strings were converted through JavaScript `Number`, which could produce scientific notation. The downstream decimal parser rejects exponent notation, and the long calculated Est. PnL text had no overflow containment.

## Validation

- Pre-commit SDK build, locale preparation, lint-staged checks, and typechecks passed.
- Application Vitest: 1,165 passed, 14 skipped.
- SDK Vitest: 575 passed.
- Component Playwright: 186 passed; one unrelated existing FEDEV-2133 test failed because the expected `Deactivated` text did not appear. The isolated retry reproduced the same timeout. This PR remains draft pending a green quality gate.
