### PR TITLE
Name the source chain in the low gas payment token balance warning FEDEV-4166

### DIFF
--- a/src/domain/tokens/useMaxAvailableAmount.ts
+++ b/src/domain/tokens/useMaxAvailableAmount.ts
@@ -244,7 +244,7 @@ export function useMaxAvailableAmount({
     })
   ) {
     gasPaymentTokenWarningContent = getLowGasPaymentTokenBalanceWarning({
-      chainId,
+      chainId: srcChainId ?? chainId,
       isGmxAccount,
       symbol: gasPaymentToken.symbol,
     });


### PR DESCRIPTION
The warning always used the settlement chain id from useChainId, so paying from a source chain wallet read "on Arbitrum" while the balance being checked and held back was on Base or Ethereum. Use srcChainId when present.

FEDEV-4166