### PR TITLE
Grant the USDC allowance the funded e2e suite needs

### DIFF
--- a/sdk/src/clients/v2/__tests__/setupAllowance.ts
+++ b/sdk/src/clients/v2/__tests__/setupAllowance.ts
@@ -1,0 +1,42 @@
+import { createPublicClient, erc20Abi, http } from "viem";
+import { beforeAll } from "vitest";
+
+import { getViemChain } from "configs/chains";
+import { getContract } from "configs/contracts";
+
+import { getTestSdk, getTestSigner, TEST_CHAIN_ID } from "./testUtil";
+
+const USDC_ARBITRUM = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+
+/**
+ * The funded suite pays collateral in USDC, which the routers pull through SyntheticsRouter.
+ * A freshly funded wallet has no allowance, and every submit then reverts with
+ * "ERC20: transfer amount exceeds allowance" — so grant it once before the tests run.
+ */
+beforeAll(async () => {
+  const signer = getTestSigner();
+  // eslint-disable-next-line no-restricted-globals
+  const rpcUrl = process.env.GMX_TEST_RPC_URL;
+
+  if (!signer || !rpcUrl) return;
+
+  const spender = getContract(TEST_CHAIN_ID, "SyntheticsRouter") as `0x${string}`;
+  const owner = signer.address as `0x${string}`;
+  const client = createPublicClient({ chain: getViemChain(TEST_CHAIN_ID), transport: http(rpcUrl) });
+
+  const current = (await client.readContract({
+    address: USDC_ARBITRUM,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: [owner, spender],
+  })) as bigint;
+
+  if (current > 0n) return;
+
+  const txHash = await getTestSdk().executeErc20Approve(signer, {
+    tokenAddress: USDC_ARBITRUM,
+    spender,
+  });
+
+  await client.waitForTransactionReceipt({ hash: txHash as `0x${string}` });
+}, 120000);

--- a/sdk/vitest.v2.config.ts
+++ b/sdk/vitest.v2.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     maxConcurrency: 1,
     include: ["src/clients/v2/__tests__/**/*.spec.ts"],
     exclude: ["**/build/**", "**/node_modules/**"],
+    setupFiles: ["src/clients/v2/__tests__/setupAllowance.ts"],
     // eslint-disable-next-line no-restricted-globals
     env: loadEnv("test", process.cwd(), ""),
   },


### PR DESCRIPTION
Follow-up to #2699 / #2709.

The funded suite now fails on every submit against the new test wallet:

```
execution reverted: ERC20: transfer amount exceeds allowance
HTTP 400: Gelato relay failed: Transaction reverted on simulation.
```

Collateral is pulled through `SyntheticsRouter` (`0x7452c558d45f8afC8c83dAe62C3f8A5BE19c71f6` — the same spender the frontend approves), and a freshly funded wallet has none. Verified on-chain: every USDC allowance for `0xBef7…dC34` is currently 0.

Rather than approving by hand — which breaks again the next time the wallet rotates — the suite provisions itself: a setup file on the funded config grants the allowance once when it is missing. This mirrors `ensureSourceErc20Allowance`, which already does the same for Stargate on the Base side, so the pattern is not new to this suite.

Only `vitest.v2.config.ts` loads it. The public tier must never broadcast anything, and the guard additionally no-ops when there is no signer or no `GMX_TEST_RPC_URL`.

Verified: `tscheck:ci` and `lint:ci` clean, `test:v2:public` still 50 passed / 2 skipped against production (unchanged, as it does not load the setup).

The approval transaction itself will run inside CI, signed by the test wallet from the `sdk_e2e` environment secret.