### PR TITLE
Fix the funded e2e assertions the first full run exposed

### DIFF
--- a/sdk/src/clients/v2/__tests__/decrease.spec.ts
+++ b/sdk/src/clients/v2/__tests__/decrease.spec.ts
@@ -5,6 +5,8 @@ import {
   requireSigner,
   expressFlow,
   waitForOrderStatus,
+  waitForOrderPlaced,
+  PLACED_OK_STATUSES,
   waitForOrdersUpdate,
   waitForPositionUpdate,
   activateTestSubaccount,
@@ -413,8 +415,8 @@ describe("decrease orders", () => {
 
       expect(submitted.status).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
+      expect(PLACED_OK_STATUSES).toContain(status.status);
 
       const orders = await waitForOrdersUpdate(sdk, account, (o) => o.length > 0, 30000);
       expect(orders.length).toBeGreaterThan(0);
@@ -444,8 +446,8 @@ describe("decrease orders", () => {
 
       expect(submitted.status).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
+      expect(PLACED_OK_STATUSES).toContain(status.status);
 
       const orders = await waitForOrdersUpdate(sdk, account, (o) => o.length > 0, 30000);
       expect(orders.length).toBeGreaterThan(0);

--- a/sdk/src/clients/v2/__tests__/editCancel.spec.ts
+++ b/sdk/src/clients/v2/__tests__/editCancel.spec.ts
@@ -3,7 +3,8 @@ import { describe, expect, it, afterAll } from "vitest";
 import {
   getTestSdk,
   requireSigner,
-  waitForOrderStatus,
+  waitForOrderPlaced,
+  PLACED_OK_STATUSES,
   waitForOrdersUpdate,
   activateTestSubaccount,
   TEST_SYMBOL,
@@ -50,8 +51,8 @@ async function createLimitOrder(sdkInstance: ReturnType<typeof getTestSdk>, trig
     signer
   );
 
-  const status = await waitForOrderStatus(sdkInstance, result.requestId);
-  expect(status.status).toBe("executed");
+  const status = await waitForOrderPlaced(sdkInstance, result.requestId);
+  expect(PLACED_OK_STATUSES).toContain(status.status);
   return result;
 }
 
@@ -110,8 +111,8 @@ describe("edit & cancel orders", () => {
       const submitted = await signAndSubmit(sdk, prepared);
       expect(submitted.status).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
+      expect(PLACED_OK_STATUSES).toContain(status.status);
 
       const ordersAfter = await waitForOrdersUpdate(
         sdk,
@@ -144,8 +145,8 @@ describe("edit & cancel orders", () => {
       const submitted = await signAndSubmit(sdk, prepared);
       expect(submitted.status).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
+      expect(PLACED_OK_STATUSES).toContain(status.status);
 
       const ordersAfter = await waitForOrdersUpdate(
         sdk,
@@ -183,8 +184,8 @@ describe("edit & cancel orders", () => {
       const submitted = await signAndSubmit(sdk, prepared);
       expect(submitted.status).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
+      expect(PLACED_OK_STATUSES).toContain(status.status);
     });
   });
 
@@ -240,8 +241,8 @@ describe("edit & cancel orders", () => {
 
       expect(submitted.requestId).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
+      expect(PLACED_OK_STATUSES).toContain(status.status);
 
       const updatedOrders = await waitForOrdersUpdate(
         sdk,
@@ -294,8 +295,8 @@ describe("edit & cancel orders", () => {
 
       expect(submitted.requestId).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
-      expect(status.status).toBe("executed");
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
+      expect(PLACED_OK_STATUSES).toContain(status.status);
 
       const updatedOrders = await waitForOrdersUpdate(
         sdk,

--- a/sdk/src/clients/v2/__tests__/increase.spec.ts
+++ b/sdk/src/clients/v2/__tests__/increase.spec.ts
@@ -5,6 +5,8 @@ import {
   requireSigner,
   expressFlow,
   waitForOrderStatus,
+  waitForOrderPlaced,
+  PLACED_OK_STATUSES,
   waitForOrdersUpdate,
   waitForPositionUpdate,
   activateTestSubaccount,
@@ -38,6 +40,15 @@ async function cancelAllOrders() {
   } catch {
     /* cleanup best-effort */
   }
+}
+
+/**
+ * Two prepares are priced moments apart, so oracle drift moves the fee in the last digits.
+ * Assert they agree well within a basis point rather than bit-for-bit.
+ */
+function expectFeesEqual(a: bigint, b: bigint): void {
+  const diff = a > b ? a - b : b - a;
+  expect(diff * 10_000n).toBeLessThanOrEqual(a);
 }
 
 describe("increase orders", () => {
@@ -143,7 +154,7 @@ describe("increase orders", () => {
       ]);
 
       // Same size → same position fee regardless of collateral amount
-      expect(small.estimates!.positionFeeUsd).toBe(large.estimates!.positionFeeUsd);
+      expectFeesEqual(small.estimates!.positionFeeUsd, large.estimates!.positionFeeUsd);
       expect(small.estimates!.sizeDeltaUsd).toBe(large.estimates!.sizeDeltaUsd);
     });
   });
@@ -157,7 +168,7 @@ describe("increase orders", () => {
         orderType: "market",
         size: TEST_SIZE_USD,
         collateralToken: "USDC",
-        collateralToPay: { amount: 1_000_000n, token: "USDC" },
+        collateralToPay: TEST_COLLATERAL,
         mode: "express",
         from: account,
       });
@@ -180,7 +191,7 @@ describe("increase orders", () => {
         direction: "long",
         orderType: "market",
         size: TEST_SIZE_USD,
-        collateralToPay: { amount: 1_000_000n, token: "USDC" },
+        collateralToPay: TEST_COLLATERAL,
         mode: "express",
         from: account,
       });
@@ -200,7 +211,7 @@ describe("increase orders", () => {
           orderType: "market",
           size: TEST_SIZE_USD,
           collateralToken: "USDC",
-          collateralToPay: { amount: 1_000_000n, token: "USDC" },
+          collateralToPay: TEST_COLLATERAL,
           mode: "express",
           from: account,
         }),
@@ -210,7 +221,7 @@ describe("increase orders", () => {
           direction: "long",
           orderType: "market",
           size: TEST_SIZE_USD,
-          collateralToPay: { amount: 1_000_000n, token: "USDC" },
+          collateralToPay: TEST_COLLATERAL,
           mode: "express",
           from: account,
         }),
@@ -236,7 +247,7 @@ describe("increase orders", () => {
           direction: "long",
           orderType: "market",
           size: TEST_SIZE_USD,
-          collateralToPay: { amount: 1_000_000n, token: "USDC" },
+          collateralToPay: TEST_COLLATERAL,
           mode: "express",
           from: account,
         }),
@@ -246,7 +257,7 @@ describe("increase orders", () => {
           direction: "long",
           orderType: "market",
           size: TEST_SIZE_USD,
-          collateralToPay: { amount: 1_000_000n, token: "USDC" },
+          collateralToPay: TEST_COLLATERAL,
           manualSwapPath: [ETH_USD_MARKET_ADDRESS],
           mode: "express",
           from: account,
@@ -586,9 +597,9 @@ describe("increase orders", () => {
 
       expect(submitted.status).toBeDefined();
 
-      const status = await waitForOrderStatus(sdk, submitted.requestId);
+      const status = await waitForOrderPlaced(sdk, submitted.requestId);
       expect(status.requestId).toBe(submitted.requestId);
-      expect(status.status).toBe("executed");
+      expect(PLACED_OK_STATUSES).toContain(status.status);
 
       const orders = await waitForOrdersUpdate(sdk, account, (o) => o.length > 0, 30000);
       expect(orders.length).toBeGreaterThan(0);
@@ -635,7 +646,7 @@ describe("increase orders", () => {
       ]);
 
       expect(prepared30.estimates!.sizeDeltaUsd).toBe(prepared300.estimates!.sizeDeltaUsd);
-      expect(prepared30.estimates!.positionFeeUsd).toBe(prepared300.estimates!.positionFeeUsd);
+      expectFeesEqual(prepared30.estimates!.positionFeeUsd, prepared300.estimates!.positionFeeUsd);
     });
   });
 

--- a/sdk/src/clients/v2/__tests__/testUtil.ts
+++ b/sdk/src/clients/v2/__tests__/testUtil.ts
@@ -28,6 +28,10 @@ export const TEST_SIZE_USD = 10n * 10n ** 30n; // $10
 export const TEST_COLLATERAL = { amount: 3000000n, token: "USDC" }; // 3 USDC
 
 const TERMINAL_STATUSES = new Set(["executed", "cancelled", "relay_failed", "relay_reverted"]);
+// A limit or conditional order rests at "created" until its trigger is hit, so that is
+// where waiting should stop for them — "executed" would only arrive if the market moved.
+const PLACED_STATUSES = new Set([...TERMINAL_STATUSES, "created"]);
+export const PLACED_OK_STATUSES = ["created", "executed"];
 const ORDER_PREPARE_PATHS = new Set([
   "/v1/orders/txns/prepare",
   "/v1/orders/txns/edit/prepare",
@@ -184,18 +188,28 @@ export function hasRpcUrl(): boolean {
   return !!process.env.GMX_TEST_RPC_URL;
 }
 
-export async function waitForOrderStatus(
+/** For limit and conditional orders: resolves as soon as the order is on the book. */
+export function waitForOrderPlaced(
   sdk: GmxApiSdk,
   requestId: string,
   timeoutMs = 60000
+): Promise<OrderStatusResponse> {
+  return waitForOrderStatus(sdk, requestId, timeoutMs, PLACED_STATUSES);
+}
+
+export async function waitForOrderStatus(
+  sdk: GmxApiSdk,
+  requestId: string,
+  timeoutMs = 60000,
+  stopStatuses: ReadonlySet<string> = TERMINAL_STATUSES
 ): Promise<OrderStatusResponse> {
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {
     const status = await sdk.fetchOrderStatus({ requestId });
 
-    if (TERMINAL_STATUSES.has(status.status)) {
-      if (status.status !== "executed") {
+    if (stopStatuses.has(status.status)) {
+      if (!PLACED_OK_STATUSES.includes(status.status)) {
         logOrderFailure(status);
       }
       return status;


### PR DESCRIPTION
The funded suite finally reached its own logic on `release-121-1`: **186 passed, 14 failed**. All 14 are defects in the tests, not the product — they had never run end to end before, so nothing had ever checked them.

## Limit and conditional orders assert the wrong status (9 tests)

A limit or conditional order rests at `created` until its trigger is hit. These tests asserted `executed`, which could only pass if the market happened to move through the trigger during the run. Worse, `created` is not in `TERMINAL_STATUSES`, so each test also burned the full 60s wait before failing — about nine minutes of the run spent waiting for something that was never going to happen.

Added `waitForOrderPlaced`, which stops as soon as the order is on the book, and assert against `created | executed`. Edit and cancel actions behave the same way — no keeper execution follows them — so those call sites move too, including the two in the 1CT block that this run never reached.

## Collateral below the on-chain minimum (3 tests)

Three prepare-only tests still paid 1 USDC while defaulting the collateral token to WETH, so there was no existing position to add to and gmx-io/gmx-api#120 rejected them at prepare — correctly. Switched every remaining hardcoded fixture to `TEST_COLLATERAL`.

That includes `same collateral — no swap`, which passed this run only because an earlier test had left a USDC-collateral position open. It would fail on a fresh wallet, so it is fixed too rather than left as a trap.

## Fee compared bit-for-bit across concurrent prepares (2 tests)

`slippage does not affect size/fee estimates` compared `positionFeeUsd` from two concurrent prepares with `toBe`. The oracle moves between them:

```
- 5999999999999999796291748530n
+ 5999999999999998885114546401n
```

A 1.5e-16 relative difference. The intent — slippage must not change the fee — survives a tolerance, so compare within a basis point. Applied to `larger collateral: position fee scales with size not collateral` as well, which has the same shape and passed this run by luck.

## Verification

`tscheck:ci` and `lint:ci` clean; `test:v2:public` still 50 passed / 2 skipped against production. The funded suite itself needs a `release-*` push to run — worth doing once this lands to confirm the remaining 14 go green.