### PR TITLE
Carry the funded e2e fixes into release, sweep the wallet, and skip on high gas

### DIFF
--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -12,6 +12,10 @@ on:
         description: "Also run bridge tests that move funds cross-chain (sets GMX_TEST_SEND=1)"
         type: boolean
         default: false
+      run_twap:
+        description: "Also run live TWAP flows, which fan out into one paid sub-order per part"
+        type: boolean
+        default: false
 
 concurrency:
   group: sdk-e2e
@@ -29,6 +33,7 @@ jobs:
       GMX_TEST_SOURCE_RPC_URL: ${{ secrets.GMX_TEST_SOURCE_RPC_URL }}
       GMX_TEST_API_URL: ${{ vars.GMX_TEST_API_URL }}
       GMX_TEST_SEND: ${{ inputs.run_bridges && '1' || '' }}
+      GMX_TEST_TWAP: ${{ inputs.run_twap && '1' || '' }}
     steps:
       - name: Check secrets
         run: |

--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -37,19 +37,47 @@ jobs:
             exit 1
           fi
 
+      # Nearly all of a run's cost is the per-order execution fee, which scales with gas.
+      # A congested chain turns a routine run into an expensive one, so sit it out instead.
+      - name: Check gas price
+        id: gas
+        run: |
+          max_gwei="${{ vars.GMX_TEST_MAX_GAS_GWEI || '0.1' }}"
+
+          hex=$(curl -sS --max-time 20 -X POST "$GMX_TEST_RPC_URL" \
+            -H 'content-type: application/json' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"eth_gasPrice","params":[]}' \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"])')
+
+          wei=$((hex))
+          max_wei=$(python3 -c "print(int(float('$max_gwei') * 10**9))")
+          gwei=$(python3 -c "print(f'{$wei / 10**9:.6f}')")
+
+          if [ "$wei" -gt "$max_wei" ]; then
+            echo "::warning::Skipped: Arbitrum gas is $gwei gwei, above the $max_gwei gwei limit"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Arbitrum gas $gwei gwei, limit $max_gwei gwei"
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
+        if: steps.gas.outputs.ok == 'true'
         uses: actions/checkout@v3
 
       - name: Setup Node.js
+        if: steps.gas.outputs.ok == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: "22"
           cache: "yarn"
 
       - name: Install dependencies
+        if: steps.gas.outputs.ok == 'true'
         run: yarn install --frozen-lockfile
 
       - name: Run SDK e2e tests
+        if: steps.gas.outputs.ok == 'true'
         run: |
           cd sdk
           yarn test:v2

--- a/sdk/src/clients/v2/__tests__/decrease.spec.ts
+++ b/sdk/src/clients/v2/__tests__/decrease.spec.ts
@@ -11,6 +11,7 @@ import {
   waitForPositionUpdate,
   activateTestSubaccount,
   hasRpcUrl,
+  shouldRunTwap,
   TEST_SYMBOL,
   TEST_SIZE_USD,
 } from "./testUtil";
@@ -265,7 +266,7 @@ describe("decrease orders", () => {
     });
   });
 
-  describe("TWAP decrease", () => {
+  describe.skipIf(!shouldRunTwap())("TWAP decrease", () => {
     afterAll(async () => {
       try {
         const prepared = await sdk.prepareCancelOrder({ all: true, mode: "express", from: account });

--- a/sdk/src/clients/v2/__tests__/globalCleanup.ts
+++ b/sdk/src/clients/v2/__tests__/globalCleanup.ts
@@ -1,0 +1,87 @@
+import { expressFlow, getTestSdk, getTestSigner, waitForOrderStatus } from "./testUtil";
+
+/**
+ * The funded suite trades a shared wallet, so anything a failed run leaves behind — resting
+ * orders and open positions — locks collateral and skews the next run's starting state.
+ * Sweep before the run so it starts flat, and again after so nothing is left holding funds.
+ */
+async function sweep(label: string): Promise<void> {
+  const signer = getTestSigner();
+  if (!signer) return;
+
+  const sdk = getTestSdk();
+  const account = signer.address;
+
+  try {
+    const orders = await sdk.fetchOrders({ address: account });
+
+    if (orders.length > 0) {
+      const prepared = await sdk.prepareCancelOrder({ all: true, mode: "express", from: account });
+      const signature = await sdk.signOrder(prepared, signer);
+      await sdk.submitOrder({
+        mode: prepared.mode,
+        requestId: prepared.requestId,
+        signature,
+        from: account,
+        idempotencyKey: prepared.idempotencyKey,
+        eip712Data: {
+          batchParams: prepared.payload.batchParams,
+          relayParams: prepared.payload.relayParams,
+        },
+      });
+      // eslint-disable-next-line no-console
+      console.log(`[cleanup:${label}] cancelled ${orders.length} resting order(s)`);
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(`[cleanup:${label}] cancel-all failed:`, (error as Error).message);
+  }
+
+  // Positions can reappear while a close settles, so re-read rather than trusting one snapshot.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    let positions: any[];
+
+    try {
+      positions = await sdk.fetchPositionsInfo({ address: account });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn(`[cleanup:${label}] fetchPositions failed:`, (error as Error).message);
+      return;
+    }
+
+    const open = positions.filter((p) => BigInt(p.sizeInUsd) > 0n);
+    if (open.length === 0) return;
+
+    for (const position of open) {
+      try {
+        const { submitted } = await expressFlow(sdk, signer, {
+          kind: "decrease",
+          symbol: position.marketAddress,
+          direction: position.isLong ? "long" : "short",
+          orderType: "market",
+          size: BigInt(position.sizeInUsd),
+          collateralToken: position.collateralTokenAddress,
+          // Settle back into USDC, otherwise the wallet slowly drains into the index token.
+          receiveToken: "USDC",
+          mode: "express",
+          from: account,
+        });
+
+        await waitForOrderStatus(sdk, submitted.requestId);
+        // eslint-disable-next-line no-console
+        console.log(`[cleanup:${label}] closed position on ${position.marketAddress}`);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(`[cleanup:${label}] close failed for ${position.marketAddress}:`, (error as Error).message);
+      }
+    }
+  }
+}
+
+export default async function setup() {
+  await sweep("before");
+
+  return async () => {
+    await sweep("after");
+  };
+}

--- a/sdk/src/clients/v2/__tests__/increase.spec.ts
+++ b/sdk/src/clients/v2/__tests__/increase.spec.ts
@@ -11,6 +11,7 @@ import {
   waitForPositionUpdate,
   activateTestSubaccount,
   hasRpcUrl,
+  shouldRunTwap,
   TEST_SYMBOL,
   TEST_SIZE_USD,
   TEST_COLLATERAL,
@@ -478,7 +479,7 @@ describe("increase orders", () => {
     });
   });
 
-  describe("TWAP increase", () => {
+  describe.skipIf(!shouldRunTwap())("TWAP increase", () => {
     afterAll(cancelAllOrders);
 
     it("TWAP market increase — creates sub-orders", async () => {

--- a/sdk/src/clients/v2/__tests__/testUtil.ts
+++ b/sdk/src/clients/v2/__tests__/testUtil.ts
@@ -183,6 +183,15 @@ export function getOrCreateTestSigner(): PrivateKeySigner {
   return ephemeralSigner;
 }
 
+/**
+ * TWAP submits fan out into one sub-order per part, each paying its own execution fee,
+ * so the live TWAP flows are opt-in. The TWAP validation cases never submit and always run.
+ */
+export function shouldRunTwap(): boolean {
+  // eslint-disable-next-line no-restricted-globals
+  return process.env.GMX_TEST_TWAP === "1";
+}
+
 export function hasRpcUrl(): boolean {
   // eslint-disable-next-line no-restricted-globals
   return !!process.env.GMX_TEST_RPC_URL;

--- a/sdk/vitest.v2.config.ts
+++ b/sdk/vitest.v2.config.ts
@@ -3,6 +3,16 @@ import path from "path";
 import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
 
+// eslint-disable-next-line no-restricted-globals
+const testEnv = loadEnv("test", process.cwd(), "");
+
+// globalSetup runs outside the test environment, so it only sees process.env. Backfill the
+// dotenv values there too, without shadowing what CI already provides.
+for (const [key, value] of Object.entries(testEnv)) {
+  // eslint-disable-next-line no-restricted-globals
+  if (process.env[key] === undefined) process.env[key] = value;
+}
+
 export default defineConfig({
   test: {
     environment: "node",
@@ -12,8 +22,8 @@ export default defineConfig({
     include: ["src/clients/v2/__tests__/**/*.spec.ts"],
     exclude: ["**/build/**", "**/node_modules/**"],
     setupFiles: ["src/clients/v2/__tests__/setupAllowance.ts"],
-    // eslint-disable-next-line no-restricted-globals
-    env: loadEnv("test", process.cwd(), ""),
+    globalSetup: ["src/clients/v2/__tests__/globalCleanup.ts"],
+    env: testEnv,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Three things, all from the first full funded run on `release-121-1`.

## The assertion fixes never reached release

#2726 was merged into `release-121-1`, not `release` — the base was changed after I opened it. So the 14 fixes live only on that throwaway branch: `release` still has `waitForOrderStatus` without the resting-order variant and six `1_000_000n` collateral fixtures, and the next branch cut from it reproduces all 14 failures. That commit is cherry-picked here unchanged.

## Nothing cleans the wallet between runs

The run ended with **29.94 USDC locked in two positions** that aborted tests never closed. Nothing ever sweeps, so each failed run strands a bit more.

Added a `globalSetup` on the funded config that cancels resting orders and closes open positions before the suite starts, and again on teardown. Closes settle into USDC on purpose — the swap tests and the `receiveToken: "ETH"` decrease had turned roughly $33 of USDC into ETH, which looks like the wallet draining when it is only changing denomination.

`globalSetup` runs outside the test environment and sees only `process.env`, so the config backfills the dotenv values there without shadowing CI — otherwise the sweep would silently no-op locally.

## High gas now skips the run

Cost per order at the $10 test size:

| | |
|---|---|
| position fee | $0.0060 |
| borrowing | $0.0002 |
| price impact | −$0.0034 |
| **execution fee** | **0.00017 ETH ≈ $0.33** |

The execution fee is ~97% of it and is **fixed per order regardless of size**, so smaller positions save nothing — only fewer orders do. It scales with gas, though, so a congested chain silently turns a routine run into an expensive one.

The workflow now reads `eth_gasPrice` before checking anything out and skips the remaining steps past a limit — default 0.1 gwei, five times the current 0.02, overridable with the `GMX_TEST_MAX_GAS_GWEI` repo variable. It skips with a warning annotation rather than failing, so it is visible without going red.

## Verification

`tscheck:ci` and `lint:ci` clean; `test:v2:public` 50 passed / 2 skipped against production. The gas comparison was exercised against 0.02 / 0.1 / 0.5 / 2 gwei and flips where it should. The funded suite itself needs a `release-*` push to confirm the 14 go green.