### PR TITLE
Apply the fee tolerance to the decrease slippage test too

### DIFF
--- a/sdk/src/clients/v2/__tests__/decrease.spec.ts
+++ b/sdk/src/clients/v2/__tests__/decrease.spec.ts
@@ -12,6 +12,7 @@ import {
   activateTestSubaccount,
   hasRpcUrl,
   shouldRunTwap,
+  expectFeesEqual,
   TEST_SYMBOL,
   TEST_SIZE_USD,
 } from "./testUtil";
@@ -366,7 +367,7 @@ describe("decrease orders", () => {
 
       // Size and fees unchanged between slippage variants
       expect(prepared30.estimates!.sizeDeltaUsd).toBe(prepared300.estimates!.sizeDeltaUsd);
-      expect(prepared30.estimates!.positionFeeUsd).toBe(prepared300.estimates!.positionFeeUsd);
+      expectFeesEqual(prepared30.estimates!.positionFeeUsd, prepared300.estimates!.positionFeeUsd);
     });
   });
 

--- a/sdk/src/clients/v2/__tests__/increase.spec.ts
+++ b/sdk/src/clients/v2/__tests__/increase.spec.ts
@@ -12,6 +12,7 @@ import {
   activateTestSubaccount,
   hasRpcUrl,
   shouldRunTwap,
+  expectFeesEqual,
   TEST_SYMBOL,
   TEST_SIZE_USD,
   TEST_COLLATERAL,
@@ -41,15 +42,6 @@ async function cancelAllOrders() {
   } catch {
     /* cleanup best-effort */
   }
-}
-
-/**
- * Two prepares are priced moments apart, so oracle drift moves the fee in the last digits.
- * Assert they agree well within a basis point rather than bit-for-bit.
- */
-function expectFeesEqual(a: bigint, b: bigint): void {
-  const diff = a > b ? a - b : b - a;
-  expect(diff * 10_000n).toBeLessThanOrEqual(a);
 }
 
 describe("increase orders", () => {

--- a/sdk/src/clients/v2/__tests__/testUtil.ts
+++ b/sdk/src/clients/v2/__tests__/testUtil.ts
@@ -1,4 +1,5 @@
 import { generatePrivateKey } from "viem/accounts";
+import { expect } from "vitest";
 
 import { ARBITRUM, getViemChain } from "configs/chains";
 import { sleep } from "utils/common";
@@ -190,6 +191,15 @@ export function getOrCreateTestSigner(): PrivateKeySigner {
 export function shouldRunTwap(): boolean {
   // eslint-disable-next-line no-restricted-globals
   return process.env.GMX_TEST_TWAP === "1";
+}
+
+/**
+ * Two prepares are priced moments apart, so oracle drift moves the fee in the last digits.
+ * Assert they agree well within a basis point rather than bit-for-bit.
+ */
+export function expectFeesEqual(a: bigint, b: bigint): void {
+  const diff = a > b ? a - b : b - a;
+  expect(diff * 10_000n).toBeLessThanOrEqual(a);
 }
 
 export function hasRpcUrl(): boolean {


### PR DESCRIPTION
The run after #2730 came back **197 passed, 1 failed** — down from 14. The one left is the same defect I already fixed twice in `increase.spec`, missed in `decrease.spec`.

`different slippage values accepted for decrease` issues two concurrent prepares and compares `positionFeeUsd` with `toBe`. The oracle moves between them:

```
- 3999154348651250600000000000n
+ 3999154349339439800000000000n
```

1.7e-10 relative, far inside a basis point. Same tolerance as the other two.

The helper is now used from two files, so it moves into `testUtil` instead of living as a second copy.

## Everything else from that run behaved

- `[cleanup:before]` picked up the two positions the previous run stranded, `[cleanup:after]` cancelled a resting order and closed behind itself
- TWAP skipped as intended
- limit and conditional orders no longer sit out their 60s timeouts, so the run went from 884s to **346s**

Verified: `tscheck:ci` and `lint:ci` clean, `test:v2:public` 50 passed / 2 skipped.