### PR TITLE
Keep vitest out of globalSetup

### DIFF
--- a/sdk/src/clients/v2/__tests__/assertions.ts
+++ b/sdk/src/clients/v2/__tests__/assertions.ts
@@ -1,0 +1,13 @@
+import { expect } from "vitest";
+
+/**
+ * Two prepares are priced moments apart, so oracle drift moves the fee in the last digits.
+ * Assert they agree well within a basis point rather than bit-for-bit.
+ *
+ * Lives outside testUtil because globalSetup imports that file, and importing vitest from
+ * globalSetup breaks the run before any test is collected.
+ */
+export function expectFeesEqual(a: bigint, b: bigint): void {
+  const diff = a > b ? a - b : b - a;
+  expect(diff * 10_000n).toBeLessThanOrEqual(a);
+}

--- a/sdk/src/clients/v2/__tests__/decrease.spec.ts
+++ b/sdk/src/clients/v2/__tests__/decrease.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
 
+import { expectFeesEqual } from "./assertions";
 import {
   getTestSdk,
   requireSigner,
@@ -12,7 +13,6 @@ import {
   activateTestSubaccount,
   hasRpcUrl,
   shouldRunTwap,
-  expectFeesEqual,
   TEST_SYMBOL,
   TEST_SIZE_USD,
 } from "./testUtil";

--- a/sdk/src/clients/v2/__tests__/increase.spec.ts
+++ b/sdk/src/clients/v2/__tests__/increase.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
 
+import { expectFeesEqual } from "./assertions";
 import {
   getTestSdk,
   requireSigner,
@@ -12,7 +13,6 @@ import {
   activateTestSubaccount,
   hasRpcUrl,
   shouldRunTwap,
-  expectFeesEqual,
   TEST_SYMBOL,
   TEST_SIZE_USD,
   TEST_COLLATERAL,

--- a/sdk/src/clients/v2/__tests__/testUtil.ts
+++ b/sdk/src/clients/v2/__tests__/testUtil.ts
@@ -1,5 +1,4 @@
 import { generatePrivateKey } from "viem/accounts";
-import { expect } from "vitest";
 
 import { ARBITRUM, getViemChain } from "configs/chains";
 import { sleep } from "utils/common";
@@ -191,15 +190,6 @@ export function getOrCreateTestSigner(): PrivateKeySigner {
 export function shouldRunTwap(): boolean {
   // eslint-disable-next-line no-restricted-globals
   return process.env.GMX_TEST_TWAP === "1";
-}
-
-/**
- * Two prepares are priced moments apart, so oracle drift moves the fee in the last digits.
- * Assert they agree well within a basis point rather than bit-for-bit.
- */
-export function expectFeesEqual(a: bigint, b: bigint): void {
-  const diff = a > b ? a - b : b - a;
-  expect(diff * 10_000n).toBeLessThanOrEqual(a);
 }
 
 export function hasRpcUrl(): boolean {


### PR DESCRIPTION
My regression from #2731, and the run is red before a single test collects:

```
No test files found, exiting with code 1
Error: Vitest failed to access its internal state.
- "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead,
  because "globalSetup" runs in a different context)
```

#2731 moved `expectFeesEqual` into `testUtil` so two specs could share it, which dragged an `import { expect } from "vitest"` into a module that `globalCleanup` — the `globalSetup` entry — imports. Vitest bails in that context, so nothing was collected at all.

The helper now lives in its own `assertions.ts` that only specs import, and `testUtil` is free of vitest again.

## Verified

Ran the funded config with the credentials blanked, so `globalSetup` loads and its sweep no-ops. The internal-state error is gone and files collect — `multichain.spec` runs its 7 tests — with only the expected `GMX_TEST_PRIVATE_KEY env var is required` throws from the specs that need a signer.

`tscheck:ci` and `lint:ci` clean, `test:v2:public` 50 passed / 2 skipped.