### PR TITLE
Force UI update: bump uiVersion to 1.8

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,3 +1,3 @@
 {
-  "uiVersion": 1.7
+  "uiVersion": 1.8
 }


### PR DESCRIPTION
Bumps `uiVersion` in `public/config.json` from 1.7 to 1.8 to force clients onto a fresh bundle.

`UI_VERSION` is derived from this same file at build time (`src/config/env.ts`), so this single value covers both sides of the check: clients running an older bundle fetch `https://app.gmx.io/config.json` at runtime, see 1.8 > their baked-in 1.7, and `useHasOutdatedUi` disables submit actions with "Page outdated. Refresh".

Takes effect only once a build carrying this file is deployed to app.gmx.io, so this needs the usual master -> release promotion.