### PR TITLE
Stop comparing oracle-derived estimates exactly

### DIFF
--- a/sdk/src/clients/v2/__tests__/decrease.spec.ts
+++ b/sdk/src/clients/v2/__tests__/decrease.spec.ts
@@ -12,7 +12,7 @@ import {
   activateTestSubaccount,
   hasRpcUrl,
   shouldRunTwap,
-  feesMatch,
+  withinOneBp,
   TEST_SYMBOL,
   TEST_SIZE_USD,
 } from "./testUtil";
@@ -367,7 +367,7 @@ describe("decrease orders", () => {
 
       // Size and fees unchanged between slippage variants
       expect(prepared30.estimates!.sizeDeltaUsd).toBe(prepared300.estimates!.sizeDeltaUsd);
-      expect(feesMatch(prepared30.estimates!.positionFeeUsd, prepared300.estimates!.positionFeeUsd)).toBe(true);
+      expect(withinOneBp(prepared30.estimates!.positionFeeUsd, prepared300.estimates!.positionFeeUsd)).toBe(true);
     });
   });
 

--- a/sdk/src/clients/v2/__tests__/increase.spec.ts
+++ b/sdk/src/clients/v2/__tests__/increase.spec.ts
@@ -12,7 +12,7 @@ import {
   activateTestSubaccount,
   hasRpcUrl,
   shouldRunTwap,
-  feesMatch,
+  withinOneBp,
   TEST_SYMBOL,
   TEST_SIZE_USD,
   TEST_COLLATERAL,
@@ -147,7 +147,7 @@ describe("increase orders", () => {
       ]);
 
       // Same size → same position fee regardless of collateral amount
-      expect(feesMatch(small.estimates!.positionFeeUsd, large.estimates!.positionFeeUsd)).toBe(true);
+      expect(withinOneBp(small.estimates!.positionFeeUsd, large.estimates!.positionFeeUsd)).toBe(true);
       expect(small.estimates!.sizeDeltaUsd).toBe(large.estimates!.sizeDeltaUsd);
     });
   });
@@ -639,7 +639,7 @@ describe("increase orders", () => {
       ]);
 
       expect(prepared30.estimates!.sizeDeltaUsd).toBe(prepared300.estimates!.sizeDeltaUsd);
-      expect(feesMatch(prepared30.estimates!.positionFeeUsd, prepared300.estimates!.positionFeeUsd)).toBe(true);
+      expect(withinOneBp(prepared30.estimates!.positionFeeUsd, prepared300.estimates!.positionFeeUsd)).toBe(true);
     });
   });
 
@@ -671,8 +671,8 @@ describe("increase orders", () => {
       ]);
 
       expect(prepared0.estimates!.sizeDeltaUsd).toBe(prepared5000.estimates!.sizeDeltaUsd);
-      expect(prepared0.estimates!.positionFeeUsd).toBe(prepared5000.estimates!.positionFeeUsd);
-      expect(prepared0.estimates!.acceptablePrice).toBe(prepared5000.estimates!.acceptablePrice);
+      expect(withinOneBp(prepared0.estimates!.positionFeeUsd, prepared5000.estimates!.positionFeeUsd)).toBe(true);
+      expect(withinOneBp(prepared0.estimates!.acceptablePrice, prepared5000.estimates!.acceptablePrice)).toBe(true);
     });
   });
 

--- a/sdk/src/clients/v2/__tests__/testUtil.ts
+++ b/sdk/src/clients/v2/__tests__/testUtil.ts
@@ -187,8 +187,8 @@ export function shouldRunTwap(): boolean {
   return process.env.GMX_TEST_TWAP === "1";
 }
 
-// Concurrent prepares are priced moments apart, so fees drift in the last digits.
-export function feesMatch(a: bigint, b: bigint): boolean {
+// Concurrent prepares are priced moments apart, so oracle-derived values drift in the last digits.
+export function withinOneBp(a: bigint, b: bigint): boolean {
   const diff = a > b ? a - b : b - a;
   return diff * 10_000n <= a;
 }


### PR DESCRIPTION
Fourth failure of the same kind, so this sweeps the class rather than patching one more call site.

```
FAIL increase.spec.ts > executionFeeBufferBps > buffer does not affect other estimates
- 5999999999999999313418160756n
+ 5999999999999999283070015443n
```

5e-18 relative. Any two concurrent prepares are priced moments apart, so every oracle-derived estimate drifts in the last digits — comparing them with `toBe` is a coin flip.

I grepped every cross-prepare comparison in the suite. Two were still exact:

- `positionFeeUsd` in `executionFeeBufferBps` — the one that failed
- `acceptablePrice` on the line below it — same flaw, passed only by luck

Both use the tolerance now. `sizeDeltaUsd` comparisons stay exact on purpose: that value is the requested size, not an oracle read, and it does not drift.

Renamed the predicate `feesMatch` → `withinOneBp`, since it now covers prices as well as fees.

Verified: `tscheck:ci` and `lint:ci` clean, `test:v2:public` 50 passed / 2 skipped.