### PR TITLE
Reduce Datadog log volume from the UI (iteration 2) FEDEV-4190

### DIFF
--- a/src/lib/FallbackTracker/FallbackTracker.ts
+++ b/src/lib/FallbackTracker/FallbackTracker.ts
@@ -313,6 +313,12 @@ export class FallbackTracker<TCheckStats> {
       return;
     }
 
+    // Failures keep coming in while the endpoint is degraded, but the ban is already applied:
+    // re-banning only duplicates the metric event and re-runs the selection for nothing.
+    if (endpointState.banned) {
+      return;
+    }
+
     endpointState.banned = {
       timestamp: Date.now(),
       reason,

--- a/src/lib/FallbackTracker/__tests__/FallbackTracker.banning.spec.ts
+++ b/src/lib/FallbackTracker/__tests__/FallbackTracker.banning.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { suppressConsole } from "lib/__testUtils__/_utils";
 
+import { addFallbackTrackerListener } from "../events";
 import { FallbackTracker } from "../FallbackTracker";
 import { createMockConfig, testEndpoints } from "./_utils";
 
@@ -231,6 +232,26 @@ describe("FallbackTracker - endpoint banning", () => {
       // Banning unused endpoint
       tracker2.banEndpoint(testEndpoints.fallback, "Test ban");
       expect(selectSpy2).toHaveBeenCalledWith({ keepPrimary: true });
+    });
+
+    it("should ignore repeated bans of an already banned endpoint", () => {
+      const config = createMockConfig();
+      const tracker = new FallbackTracker(config);
+      const bannedListener = vi.fn();
+      const cleanup = addFallbackTrackerListener("endpointBanned", config.trackerKey, bannedListener);
+
+      tracker.banEndpoint(config.primary, "First ban");
+
+      const selectSpy = vi.spyOn(tracker, "selectBestEndpoints");
+
+      tracker.banEndpoint(config.primary, "Second ban");
+      tracker.banEndpoint(config.primary, "Third ban");
+
+      expect(bannedListener).toHaveBeenCalledTimes(1);
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(tracker.state.endpointsState[config.primary].banned?.reason).toBe("First ban");
+
+      cleanup();
     });
 
     // Error handling

--- a/src/lib/metrics/oracleTrackerMetrics.ts
+++ b/src/lib/metrics/oracleTrackerMetrics.ts
@@ -2,9 +2,16 @@ import { getChainName, getProviderNameFromUrl } from "config/rpc";
 import { addFallbackTrackerListener } from "lib/FallbackTracker/events";
 import { OracleKeeperFallbackTracker } from "lib/oracleKeeperFetcher/OracleFallbackTracker";
 
-import { metrics, OracleKeeperEndpointBannedEvent, OracleKeeperUpdateEndpointsEvent } from ".";
+import {
+  metrics,
+  OracleKeeperEndpointBannedEvent,
+  OracleKeeperFallbacksUpdatedCounter,
+  OracleKeeperUpdateEndpointsEvent,
+} from ".";
 
 export function subscribeForOracleTrackerMetrics(tracker: OracleKeeperFallbackTracker) {
+  let reportedPrimary: string | undefined;
+
   const cleanupBannedSubscription = addFallbackTrackerListener(
     "endpointBanned",
     tracker.trackerKey,
@@ -28,6 +35,16 @@ export function subscribeForOracleTrackerMetrics(tracker: OracleKeeperFallbackTr
     (p) => {
       const { primary, fallbacks } = p;
       const secondary = fallbacks[0];
+
+      // Same as in the RPC tracker: only a primary switch carries new information.
+      if (primary === reportedPrimary) {
+        metrics.pushCounter<OracleKeeperFallbacksUpdatedCounter>("oracleKeeper.endpoint.fallbacksUpdated", {
+          chainId: tracker.params.chainId,
+        });
+        return;
+      }
+
+      reportedPrimary = primary;
 
       metrics.pushEvent<OracleKeeperUpdateEndpointsEvent>({
         event: "oracleKeeper.endpoint.updated",

--- a/src/lib/metrics/rpcTrackerMetrics.ts
+++ b/src/lib/metrics/rpcTrackerMetrics.ts
@@ -9,10 +9,13 @@ import {
   RpcTrackerEndpointBannedEvent,
   RpcTrackerEndpointBlockGapTiming,
   RpcTrackerEndpointTiming,
+  RpcTrackerFallbacksUpdatedCounter,
   RpcTrackerUpdateEndpointsEvent,
 } from ".";
 
 export function subscribeForRpcTrackerMetrics(tracker: RpcTracker) {
+  let reportedPrimary: string | undefined;
+
   const cleanupBannedSubscription = addFallbackTrackerListener(
     "endpointBanned",
     tracker.trackerKey,
@@ -35,6 +38,17 @@ export function subscribeForRpcTrackerMetrics(tracker: RpcTracker) {
     tracker.trackerKey,
     (p) => {
       const { primary, fallbacks, endpointsStats } = p;
+
+      // The fallbacks list is re-ranked on every tracking cycle, so most updates carry
+      // no new information about which endpoint actually serves the user.
+      if (primary === reportedPrimary) {
+        metrics.pushCounter<RpcTrackerFallbacksUpdatedCounter>("rpcTracker.endpoint.fallbacksUpdated", {
+          chainId: tracker.params.chainId,
+        });
+        return;
+      }
+
+      reportedPrimary = primary;
 
       const bestBlock = getBestBlock(endpointsStats);
 

--- a/src/lib/metrics/types.ts
+++ b/src/lib/metrics/types.ts
@@ -287,6 +287,18 @@ export type RpcTrackerUpdateEndpointsEvent = {
   };
 };
 
+/**
+ * Emitted instead of `rpcTracker.endpoint.updated` when only the fallbacks order changed.
+ * The fallbacks list is re-ranked on every tracking cycle, so as an event it produced
+ * the bulk of the UI log volume.
+ */
+export type RpcTrackerFallbacksUpdatedCounter = {
+  event: "rpcTracker.endpoint.fallbacksUpdated";
+  data: {
+    chainId: number;
+  };
+};
+
 export type RpcTrackerEndpointTiming = {
   event: "rpcTracker.endpoint.timing";
   data: {
@@ -311,6 +323,16 @@ export type OracleKeeperUpdateEndpointsEvent = {
     chainName: string;
     primary: string;
     secondary: string;
+  };
+};
+
+/**
+ * See `RpcTrackerFallbacksUpdatedCounter`.
+ */
+export type OracleKeeperFallbacksUpdatedCounter = {
+  event: "oracleKeeper.endpoint.fallbacksUpdated";
+  data: {
+    chainId: number;
   };
 };
 
@@ -636,6 +658,19 @@ export type MulticallRequestCounter = {
     requestType: string;
     rpcProvider: string;
     isLargeAccount: boolean;
+  };
+};
+
+/**
+ * A worker job failure always falls back to the main thread, which reports the outcome itself
+ * (`multicall.error` / `multicall.timeout` once all endpoints are exhausted). Counting the
+ * fallbacks keeps the rate visible without logging the same failure twice.
+ */
+export type WorkerMulticallErrorCounter = {
+  event: "worker.multicall.error";
+  data: {
+    chainId: number;
+    errorName: string;
   };
 };
 

--- a/src/lib/multicall/executeMulticallWorker.ts
+++ b/src/lib/multicall/executeMulticallWorker.ts
@@ -7,7 +7,7 @@ import { type AnyChainId } from "config/chains";
 import { PRODUCTION_PREVIEW_KEY } from "config/localStorage";
 import { getIsLargeAccount } from "domain/stats/isLargeAccount";
 import { emitReportEndpointFailure } from "lib/FallbackTracker/events";
-import { MetricEventParams, MulticallTimeoutEvent } from "lib/metrics";
+import { MetricEventParams, MulticallTimeoutEvent, WorkerMulticallErrorCounter } from "lib/metrics";
 import { emitMetricCounter, emitMetricEvent, emitMetricTiming } from "lib/metrics/emitMetricEvent";
 import { CurrentRpcEndpoints } from "lib/rpc/RpcTracker";
 import { getCurrentRpcUrls } from "lib/rpc/useRpcUrls";
@@ -158,15 +158,13 @@ export async function executeMulticallWorker(
         request
       );
     } else {
-      emitMetricEvent({
+      // The main thread fallback below reports the failure itself once every endpoint is
+      // exhausted, so only the fallback rate is tracked here.
+      emitMetricCounter<WorkerMulticallErrorCounter>({
         event: "worker.multicall.error",
-        isError: true,
         data: {
-          isInMainThread: false,
+          chainId,
           errorName: error.name,
-          errorGroup: "Worker multicall error",
-          errorMessage: error.message,
-          errorStack: error.stack,
         },
       });
 


### PR DESCRIPTION
Follow-up to FEDEV-3993 (#2652). Targets the three top UI log producers listed in [FEDEV-4190](https://linear.app/gmx-io/issue/FEDEV-4190/reduce-datadog-log-volume-from-the-ui-iteration-2), which together are ~63% of the `service:api @ns:routes.ui` stream.

### `rpcTracker.endpoint.banned` (14.0%)

`FallbackTracker.banEndpoint` did not check whether the endpoint was already banned. `handleFailure` throttles at 2s but never clears `failureTimestamps` after a ban, so while an endpoint is degraded every subsequent failure crossed the threshold again — rewriting `banned`, re-emitting the event and re-running `selectBestEndpoints`. That is roughly one event per 2s per endpoint instead of one per session. Added an early return.

Side effects: removes the redundant re-selection churn (which itself fed `endpoint.updated`), and covers `oracleKeeper.endpoint.banned` through the same shared code.

### `rpcTracker.endpoint.updated` (46.2%) and `oracleKeeper.endpoint.updated` (4.9%)

The event is now pushed only when the **primary** actually changes. `selectNextFallbacks` returns a fully re-ranked list of every valid endpoint and filters it by block-number equality with the primary, so the `fallbacks` array changes on nearly every 10s tracking cycle and `setCurrentEndpoints` treated that as an update. Tail reshuffles now go to the new counters `rpcTracker.endpoint.fallbacksUpdated` / `oracleKeeper.endpoint.fallbacksUpdated` (tagged with `chainId`), so the rate stays observable.

Block gaps are unaffected — `rpcTracker.endpoint.blockGap` is a timing pushed on every tracking cycle independently.

### `worker.multicall.error` (2.4%)

Downgraded to a counter carrying `chainId` + `errorName`. The main-thread fallback still reports the full error once all endpoints are exhausted (`multicall.error` / `multicall.timeout`), so the event only duplicated it — exactly the double-logging described in the issue.

### Dashboard impact

As in the previous iteration, this is an intentional break of existing panels:

- panels counting `*.endpoint.updated` as "reselection rate" should move to the `*.endpoint.fallbacksUpdated` counters; the event now means strictly "primary switched"
- `*.endpoint.banned` now means "endpoint banned for the first time this session", not "another failure on an already banned endpoint"
- `worker.multicall.error` moves from logs to a counter

### Checks

- `vitest run src/lib/FallbackTracker src/lib/rpc` — 200 passed, incl. a new case for the ban dedupe
- `yarn tscheck` — clean
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9jsAMCMdkFbeiK9xNktMF