### PR TITLE
Cap per-position pnl against positive-only pool pnl FEDEV-4001

### DIFF
--- a/sdk/src/utils/__tests__/markets.spec.ts
+++ b/sdk/src/utils/__tests__/markets.spec.ts
@@ -19,6 +19,7 @@ import {
   getMarketPnl,
   getOpenInterestUsd,
   getOpenInterestInTokens,
+  getPositiveMarketPnl,
   getPriceForPnl,
 } from "utils/markets";
 import { MarketInfo } from "utils/markets/types";
@@ -455,6 +456,78 @@ describe("getMarketPnl", () => {
     } as MarketInfo;
     // maximize = false => use minPrice for long
     expect(getMarketPnl(marketInfo, true, true)).toBe(0n); // openInterestValue(1000n) - openInterestUsd(1000n) = 0
+  });
+});
+
+describe("getPositiveMarketPnl", () => {
+  const price = expandDecimals(1000, 18);
+
+  function makeMarket(overrides: Partial<MarketInfo>) {
+    return {
+      indexToken: { decimals: 18, prices: { minPrice: price, maxPrice: price } },
+      ...overrides,
+    } as MarketInfo;
+  }
+
+  it("falls back to net pnl when the per-collateral open interest is missing", () => {
+    const marketInfo = makeMarket({ longInterestUsd: 500n, longInterestInTokens: 1n });
+
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(500n);
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(getMarketPnl(marketInfo, true, true));
+  });
+
+  it("drops the losing collateral bucket for longs", () => {
+    const marketInfo = makeMarket({
+      longInterestUsd: 6000n,
+      longInterestInTokens: 5n,
+      longInterestUsdUsingLongToken: 1000n,
+      longInterestInTokensUsingLongToken: 3n,
+      longInterestUsdUsingShortToken: 5000n,
+      longInterestInTokensUsingShortToken: 2n,
+    });
+
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(2000n);
+    expect(getMarketPnl(marketInfo, true, true)).toBe(-1000n);
+  });
+
+  it("drops the losing collateral bucket for shorts", () => {
+    const marketInfo = makeMarket({
+      shortInterestUsd: 6000n,
+      shortInterestInTokens: 5n,
+      shortInterestUsdUsingLongToken: 5000n,
+      shortInterestInTokensUsingLongToken: 2n,
+      shortInterestUsdUsingShortToken: 1000n,
+      shortInterestInTokensUsingShortToken: 3n,
+    });
+
+    expect(getPositiveMarketPnl(marketInfo, false, true)).toBe(3000n);
+    expect(getMarketPnl(marketInfo, false, true)).toBe(1000n);
+  });
+
+  it("treats an empty collateral bucket as zero pnl", () => {
+    const marketInfo = makeMarket({
+      longInterestUsd: 1000n,
+      longInterestInTokens: 3n,
+      longInterestUsdUsingLongToken: 0n,
+      longInterestInTokensUsingLongToken: 0n,
+      longInterestUsdUsingShortToken: 1000n,
+      longInterestInTokensUsingShortToken: 3n,
+    });
+
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(2000n);
+  });
+
+  it("returns zero pnl for a bucket that has usd open interest but no tokens", () => {
+    const marketInfo = makeMarket({
+      longInterestUsd: 1000n,
+      longInterestInTokens: 0n,
+      longInterestUsdUsingLongToken: 1000n,
+      longInterestInTokensUsingLongToken: 0n,
+      longInterestUsdUsingShortToken: 0n,
+      longInterestInTokensUsingShortToken: 0n,
+    });
+
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(0n);
   });
 });
 

--- a/sdk/src/utils/__tests__/positionPnlCap.spec.ts
+++ b/sdk/src/utils/__tests__/positionPnlCap.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { USD_DECIMALS } from "configs/factors";
+import { mockMarketsInfoData, mockTokensData } from "test/mock";
+import { getMarketPnl, getPositiveMarketPnl } from "utils/markets";
+import type { MarketInfo } from "utils/markets/types";
+import { expandDecimals } from "utils/numbers";
+import { getPositionPnlUsd } from "utils/positions";
+
+const MARKET_KEY = "ETH-ETH-USDC";
+
+function usd(amount: number) {
+  return expandDecimals(amount, USD_DECIMALS);
+}
+
+function eth(amount: number) {
+  return expandDecimals(amount, 18);
+}
+
+const ETH_PRICE = usd(2000);
+
+/**
+ * Long side splits into an eth collateral bucket worth +$1,000,000 and a usdc collateral bucket worth
+ * -$500,000, so net pnl is $500,000 and positive-only pnl is $1,000,000. The long pool is $1,000,000
+ * with a 90% trader pnl factor, so the cap binds on the positive-only figure only.
+ */
+function createMarketInfo(overrides: Partial<MarketInfo> = {}): MarketInfo {
+  const tokensData = mockTokensData({ ETH: { prices: { minPrice: ETH_PRICE, maxPrice: ETH_PRICE } } });
+
+  return mockMarketsInfoData(tokensData, [MARKET_KEY], {
+    [MARKET_KEY]: {
+      longPoolAmount: eth(500),
+      maxPnlFactorForTradersLong: expandDecimals(9, 29),
+
+      longInterestUsd: usd(2_000_000),
+      longInterestInTokens: eth(1250),
+
+      longInterestUsdUsingLongToken: usd(1_000_000),
+      longInterestInTokensUsingLongToken: eth(1000),
+      longInterestUsdUsingShortToken: usd(1_000_000),
+      longInterestInTokensUsingShortToken: eth(250),
+
+      ...overrides,
+    },
+  })[MARKET_KEY];
+}
+
+function getLongPositionPnl(marketInfo: MarketInfo) {
+  return getPositionPnlUsd({
+    marketInfo,
+    sizeInUsd: usd(100_000),
+    sizeInTokens: eth(100),
+    markPrice: ETH_PRICE,
+    isLong: true,
+  });
+}
+
+describe("per-position pnl cap (v2.2c parity)", () => {
+  it("caps against the positive-only pool pnl", () => {
+    const marketInfo = createMarketInfo();
+
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(usd(1_000_000));
+
+    expect(getLongPositionPnl(marketInfo)).toBe(usd(90_000));
+  });
+
+  it("leaves the net pool pnl used by gm pool value untouched", () => {
+    const marketInfo = createMarketInfo();
+
+    expect(getMarketPnl(marketInfo, true, true)).toBe(usd(500_000));
+  });
+
+  it("keeps the net behaviour when the data source has no per-collateral open interest", () => {
+    const marketInfo = createMarketInfo({
+      longInterestUsdUsingLongToken: undefined,
+      longInterestInTokensUsingLongToken: undefined,
+      longInterestUsdUsingShortToken: undefined,
+      longInterestInTokensUsingShortToken: undefined,
+    });
+
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(usd(500_000));
+    expect(getLongPositionPnl(marketInfo)).toBe(usd(100_000));
+  });
+
+  it("matches the net pool pnl when both collateral buckets are winning", () => {
+    const marketInfo = createMarketInfo({
+      longInterestUsdUsingShortToken: usd(1_000_000),
+      longInterestInTokensUsingShortToken: eth(600),
+      longInterestUsd: usd(2_000_000),
+      longInterestInTokens: eth(1600),
+    });
+
+    expect(getPositiveMarketPnl(marketInfo, true, true)).toBe(usd(1_200_000));
+    expect(getMarketPnl(marketInfo, true, true)).toBe(usd(1_200_000));
+    expect(getLongPositionPnl(marketInfo)).toBe(usd(75_000));
+  });
+});

--- a/sdk/src/utils/__tests__/positions.spec.ts
+++ b/sdk/src/utils/__tests__/positions.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach, Mock } from "vitest";
 
 import { bigMath } from "utils/bigmath";
 import { getPositionFee, getPriceImpactForPosition } from "utils/fees";
-import { getCappedPoolPnl, getMarketPnl, getPoolUsdWithoutPnl } from "utils/markets";
+import { getCappedPoolPnl, getPoolUsdWithoutPnl, getPositiveMarketPnl } from "utils/markets";
 import { MarketInfo } from "utils/markets/types";
 import { expandDecimals, USD_DECIMALS } from "utils/numbers";
 import {
@@ -25,7 +25,7 @@ import { Token } from "utils/tokens/types";
 
 vi.mock("../markets", () => ({
   ...vi.importActual("../markets"),
-  getMarketPnl: vi.fn(),
+  getPositiveMarketPnl: vi.fn(),
   getPoolUsdWithoutPnl: vi.fn(),
   getCappedPoolPnl: vi.fn(),
 }));
@@ -86,9 +86,9 @@ describe("getPositionPnlUsd", () => {
   const marketInfo = { indexToken: {}, maxPositionImpactFactorForLiquidations: 2n } as MarketInfo;
 
   beforeEach(() => {
-    (getMarketPnl as Mock).mockReturnValue(1000n);
-    (getPoolUsdWithoutPnl as Mock).mockReturnValue(5000n);
-    (getCappedPoolPnl as Mock).mockReturnValue(800n);
+    (getPositiveMarketPnl as Mock).mockReturnValue(expandDecimals(1000, USD_DECIMALS));
+    (getPoolUsdWithoutPnl as Mock).mockReturnValue(expandDecimals(5000, USD_DECIMALS));
+    (getCappedPoolPnl as Mock).mockReturnValue(expandDecimals(800, USD_DECIMALS));
   });
 
   it("returns negative PnL if positionValueUsd < sizeInUsd for a long", () => {
@@ -101,6 +101,20 @@ describe("getPositionPnlUsd", () => {
       isLong: true,
     });
     expect(result).toBe(900n - 1000n); // -100n
+  });
+
+  it("scales a winning position by the positive-only pool pnl", () => {
+    (convertToUsd as Mock).mockReturnValueOnce(expandDecimals(2000, USD_DECIMALS)); // positionValueUsd
+    const result = getPositionPnlUsd({
+      marketInfo,
+      sizeInUsd: expandDecimals(1000, USD_DECIMALS),
+      sizeInTokens: 100n,
+      markPrice: 10n,
+      isLong: true,
+    });
+
+    expect(getPositiveMarketPnl).toHaveBeenCalledWith(marketInfo, true, true);
+    expect(result).toBe(expandDecimals(800, USD_DECIMALS));
   });
 });
 

--- a/sdk/src/utils/markets/multicall.ts
+++ b/sdk/src/utils/markets/multicall.ts
@@ -332,7 +332,7 @@ export function parseMarketsValuesResponse(
 
       const marketDivisor = getMarketDivisor(market);
 
-      const { longInterestUsd, shortInterestUsd } = getOiUsdFromRawValues(
+      const oiUsd = getOiUsdFromRawValues(
         {
           longInterestUsingLongToken: BigInt(dataStoreValues.longInterestUsingLongToken.returnValues[0]),
           longInterestUsingShortToken: BigInt(dataStoreValues.longInterestUsingShortToken.returnValues[0]),
@@ -342,7 +342,7 @@ export function parseMarketsValuesResponse(
         marketDivisor
       );
 
-      const { longInterestInTokens, shortInterestInTokens } = getOiInTokensFromRawValues(
+      const oiInTokens = getOiInTokensFromRawValues(
         {
           longInterestInTokensUsingLongToken: BigInt(
             dataStoreValues.longInterestInTokensUsingLongToken.returnValues[0]
@@ -378,10 +378,8 @@ export function parseMarketsValuesResponse(
       ];
 
       acc[marketAddress] = {
-        longInterestUsd,
-        shortInterestUsd,
-        longInterestInTokens,
-        shortInterestInTokens,
+        ...oiUsd,
+        ...oiInTokens,
         longPoolAmount: dataStoreValues.longPoolAmount.returnValues[0] / marketDivisor,
         shortPoolAmount: dataStoreValues.shortPoolAmount.returnValues[0] / marketDivisor,
         poolValueMin: poolValueInfoMin.poolValue,

--- a/sdk/src/utils/markets/types.ts
+++ b/sdk/src/utils/markets/types.ts
@@ -101,6 +101,15 @@ export type MarketInfo = Market &
     longInterestInTokens: bigint;
     shortInterestInTokens: bigint;
 
+    longInterestUsdUsingLongToken?: bigint;
+    longInterestUsdUsingShortToken?: bigint;
+    shortInterestUsdUsingLongToken?: bigint;
+    shortInterestUsdUsingShortToken?: bigint;
+    longInterestInTokensUsingLongToken?: bigint;
+    longInterestInTokensUsingShortToken?: bigint;
+    shortInterestInTokensUsingLongToken?: bigint;
+    shortInterestInTokensUsingShortToken?: bigint;
+
     positionFeeFactorForBalanceWasImproved: bigint;
     positionFeeFactorForBalanceWasNotImproved: bigint;
     positionImpactFactorPositive: bigint;
@@ -158,6 +167,14 @@ export const MARKET_VALUES_KEYS = [
   "shortInterestUsd",
   "longInterestInTokens",
   "shortInterestInTokens",
+  "longInterestUsdUsingLongToken",
+  "longInterestUsdUsingShortToken",
+  "shortInterestUsdUsingLongToken",
+  "shortInterestUsdUsingShortToken",
+  "longInterestInTokensUsingLongToken",
+  "longInterestInTokensUsingShortToken",
+  "shortInterestInTokensUsingLongToken",
+  "shortInterestInTokensUsingShortToken",
   "longPoolAmount",
   "shortPoolAmount",
   "poolValueMin",

--- a/sdk/src/utils/markets/utils.ts
+++ b/sdk/src/utils/markets/utils.ts
@@ -267,16 +267,31 @@ export function getOiUsdFromRawValues(
     shortInterestUsingShortToken: bigint;
   },
   marketDivisor: bigint
-): { longInterestUsd: bigint; shortInterestUsd: bigint } {
-  const longInterestUsingLongToken = rawValues.longInterestUsingLongToken / marketDivisor;
-  const longInterestUsingShortToken = rawValues.longInterestUsingShortToken / marketDivisor;
-  const shortInterestUsingLongToken = rawValues.shortInterestUsingLongToken / marketDivisor;
-  const shortInterestUsingShortToken = rawValues.shortInterestUsingShortToken / marketDivisor;
+): Pick<
+  MarketInfo,
+  | "longInterestUsd"
+  | "shortInterestUsd"
+  | "longInterestUsdUsingLongToken"
+  | "longInterestUsdUsingShortToken"
+  | "shortInterestUsdUsingLongToken"
+  | "shortInterestUsdUsingShortToken"
+> {
+  const longInterestUsdUsingLongToken = rawValues.longInterestUsingLongToken / marketDivisor;
+  const longInterestUsdUsingShortToken = rawValues.longInterestUsingShortToken / marketDivisor;
+  const shortInterestUsdUsingLongToken = rawValues.shortInterestUsingLongToken / marketDivisor;
+  const shortInterestUsdUsingShortToken = rawValues.shortInterestUsingShortToken / marketDivisor;
 
-  const longInterestUsd = longInterestUsingLongToken + longInterestUsingShortToken;
-  const shortInterestUsd = shortInterestUsingLongToken + shortInterestUsingShortToken;
+  const longInterestUsd = longInterestUsdUsingLongToken + longInterestUsdUsingShortToken;
+  const shortInterestUsd = shortInterestUsdUsingLongToken + shortInterestUsdUsingShortToken;
 
-  return { longInterestUsd, shortInterestUsd };
+  return {
+    longInterestUsd,
+    shortInterestUsd,
+    longInterestUsdUsingLongToken,
+    longInterestUsdUsingShortToken,
+    shortInterestUsdUsingLongToken,
+    shortInterestUsdUsingShortToken,
+  };
 }
 
 export function getOiInTokensFromRawValues(
@@ -287,7 +302,15 @@ export function getOiInTokensFromRawValues(
     shortInterestInTokensUsingShortToken: bigint;
   },
   marketDivisor: bigint
-): { longInterestInTokens: bigint; shortInterestInTokens: bigint } {
+): Pick<
+  MarketInfo,
+  | "longInterestInTokens"
+  | "shortInterestInTokens"
+  | "longInterestInTokensUsingLongToken"
+  | "longInterestInTokensUsingShortToken"
+  | "shortInterestInTokensUsingLongToken"
+  | "shortInterestInTokensUsingShortToken"
+> {
   const longInterestInTokensUsingLongToken = rawValues.longInterestInTokensUsingLongToken / marketDivisor;
   const longInterestInTokensUsingShortToken = rawValues.longInterestInTokensUsingShortToken / marketDivisor;
   const shortInterestInTokensUsingLongToken = rawValues.shortInterestInTokensUsingLongToken / marketDivisor;
@@ -296,7 +319,14 @@ export function getOiInTokensFromRawValues(
   const longInterestInTokens = longInterestInTokensUsingLongToken + longInterestInTokensUsingShortToken;
   const shortInterestInTokens = shortInterestInTokensUsingLongToken + shortInterestInTokensUsingShortToken;
 
-  return { longInterestInTokens, shortInterestInTokens };
+  return {
+    longInterestInTokens,
+    shortInterestInTokens,
+    longInterestInTokensUsingLongToken,
+    longInterestInTokensUsingShortToken,
+    shortInterestInTokensUsingLongToken,
+    shortInterestInTokensUsingShortToken,
+  };
 }
 
 export function getMarketPnl(marketInfo: MarketInfo, isLong: boolean, forMaxPoolValue: boolean) {
@@ -314,6 +344,65 @@ export function getMarketPnl(marketInfo: MarketInfo, isLong: boolean, forMaxPool
   const pnl = isLong ? openInterestValue - openInterestUsd : openInterestUsd - openInterestValue;
 
   return pnl;
+}
+
+function getMarketPnlByCollateralToken(
+  marketInfo: MarketInfo,
+  isLong: boolean,
+  isLongCollateral: boolean,
+  forMaxPoolValue: boolean
+) {
+  const maximize = !forMaxPoolValue;
+
+  let openInterestUsd: bigint | undefined;
+  let openInterestInTokens: bigint | undefined;
+
+  if (isLong) {
+    openInterestUsd = isLongCollateral
+      ? marketInfo.longInterestUsdUsingLongToken
+      : marketInfo.longInterestUsdUsingShortToken;
+    openInterestInTokens = isLongCollateral
+      ? marketInfo.longInterestInTokensUsingLongToken
+      : marketInfo.longInterestInTokensUsingShortToken;
+  } else {
+    openInterestUsd = isLongCollateral
+      ? marketInfo.shortInterestUsdUsingLongToken
+      : marketInfo.shortInterestUsdUsingShortToken;
+    openInterestInTokens = isLongCollateral
+      ? marketInfo.shortInterestInTokensUsingLongToken
+      : marketInfo.shortInterestInTokensUsingShortToken;
+  }
+
+  if (openInterestUsd === undefined || openInterestInTokens === undefined) {
+    return undefined;
+  }
+
+  if (openInterestUsd === 0n || openInterestInTokens === 0n) {
+    return 0n;
+  }
+
+  const price = getPriceForPnl(marketInfo.indexToken.prices, isLong, maximize);
+  const openInterestValue = convertToUsd(openInterestInTokens, marketInfo.indexToken.decimals, price)!;
+
+  return isLong ? openInterestValue - openInterestUsd : openInterestUsd - openInterestValue;
+}
+
+/**
+ * Mirrors MarketUtils.getPositivePnl, the denominator of the per-position pnl cap since v2.2c.
+ * Pool value keeps using the net {@link getMarketPnl}. Falls back to it without the collateral split.
+ */
+export function getPositiveMarketPnl(marketInfo: MarketInfo, isLong: boolean, forMaxPoolValue: boolean) {
+  const pnlUsingLongTokenAsCollateral = getMarketPnlByCollateralToken(marketInfo, isLong, true, forMaxPoolValue);
+  const pnlUsingShortTokenAsCollateral = getMarketPnlByCollateralToken(marketInfo, isLong, false, forMaxPoolValue);
+
+  if (pnlUsingLongTokenAsCollateral === undefined || pnlUsingShortTokenAsCollateral === undefined) {
+    return getMarketPnl(marketInfo, isLong, forMaxPoolValue);
+  }
+
+  return (
+    (pnlUsingLongTokenAsCollateral > 0 ? pnlUsingLongTokenAsCollateral : 0n) +
+    (pnlUsingShortTokenAsCollateral > 0 ? pnlUsingShortTokenAsCollateral : 0n)
+  );
 }
 
 export function getOpenInterestUsd(marketInfo: MarketInfo, isLong: boolean) {

--- a/sdk/src/utils/positions/utils.ts
+++ b/sdk/src/utils/positions/utils.ts
@@ -11,11 +11,11 @@ import {
 import {
   getCappedPoolPnl,
   getMarketIndexName,
-  getMarketPnl,
   getMarketPoolName,
   getMaxAllowedLeverage,
   getOpenInterestUsd,
   getPoolUsdWithoutPnl,
+  getPositiveMarketPnl,
 } from "utils/markets";
 import { Market, MarketInfo } from "utils/markets/types";
 import { applyFactor, expandDecimals, FLOAT_PRECISION_SQRT, getBasisPoints, PRECISION } from "utils/numbers";
@@ -63,7 +63,7 @@ export function getPositionPnlUsd(p: {
     return totalPnl;
   }
 
-  const poolPnl = getMarketPnl(marketInfo, isLong, true);
+  const poolPnl = getPositiveMarketPnl(marketInfo, isLong, true);
   const poolUsd = getPoolUsdWithoutPnl(marketInfo, isLong, "minPrice");
 
   const cappedPnl = getCappedPoolPnl({


### PR DESCRIPTION
https://linear.app/gmx-io/issue/FEDEV-4001/sdk-use-positive-only-pool-pnl-for-per-position-pnl-cap-22c-parity

v2.2c changed the trader-pnl cap denominator in `PositionUtils.getPositionPnlUsd` from net pool pnl (`MarketUtils.getPnl`) to positive-only pool pnl (`MarketUtils.getPositivePnl`), which computes pnl per collateral-token bucket and sums only the positive ones. Arbitrum, Avalanche and MegaETH already run 2.2c readers, so the off-chain figure diverges today whenever the cap binds and the two buckets have opposite signs — the preview reads higher than what the position actually settles at.

Surfaces the four per-(side, collateral) open interest buckets that the multicall already reads and then summed away, adds `getPositiveMarketPnl` next to `getMarketPnl`, and sources only the per-position cap from it. `getPositionInfo`, the increase/decrease previews all pick it up through that one call site.

Pool value and GM pricing keep using net `getMarketPnl`, matching the contract — only `PositionUtils` switched to positive-only upstream.

### Rollout

The buckets are optional on `MarketInfo` because three producers build it and only the multicall fills them; `/v1/markets/values` and the fast path still carry the aggregates alone. `getPositiveMarketPnl` falls back to net pnl there, so those sessions keep today's behaviour rather than breaking.

That makes this a phased rollout:

1. this PR — the fix is live on the rpc path
2. gmx-api — bump `@gmx-io/sdk` and add the eight keys to `MARKET_VALUES_FIELD_KEYS`. It already reads the raw per-collateral values and spreads `getOiUsdFromRawValues`/`getOiInTokensFromRawValues`, so the fields surface on the version bump, and the `AssertSameShape` check in `marketFields.ts` fails the build until the keys are listed.
3. once gmx-api is deployed — require the split in `hasIncompleteMarketValues` so the api path stops silently serving the old formula

Until step 2 lands, sessions bucketed into the `apiMarkets` rollout still cap against net pnl.