### PR TITLE
Hotfix position seller crash on unpriced reachable token

### DIFF
--- a/src/context/SyntheticsStateContext/selectors/positionSellerSelectors.ts
+++ b/src/context/SyntheticsStateContext/selectors/positionSellerSelectors.ts
@@ -491,11 +491,18 @@ export const selectPositionSellerAvailableReceiveTokens = createSelector((q) => 
 
   const reachableTokens = reachableAddresses
     .flatMap((address) => {
-      const token = getByKey(tokensData, address)!;
+      const token = getByKey(tokensData, address);
+
+      if (!token) {
+        return [];
+      }
 
       if (token.isWrapped && !wasNativeTokenInserted) {
+        const nativeToken = getByKey(tokensData, NATIVE_TOKEN_ADDRESS);
+
         wasNativeTokenInserted = true;
-        return [getByKey(tokensData, NATIVE_TOKEN_ADDRESS)!, token];
+
+        return nativeToken ? [nativeToken, token] : [token];
       }
 
       return [token];


### PR DESCRIPTION
## Problem

Closing a position is impossible on Arbitrum and Avalanche — the close modal is killed by the error boundary:

```
TypeError: Cannot read properties of undefined (reading 'isWrapped')
  at positionSellerSelectors.ts:496:17
  at Array.flatMap (<anonymous>)
  at positionSellerSelectors.ts:493:6
  at PositionSeller.tsx:157:34
```

## Cause

The DAI markets were delisted today, and the oracle stopped publishing tickers for `DAI` (`0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1`) and `DAI.e` (`0xd586E7F844cEa2F87f50152665BCbc2C279D8d70`) — verified against the primary and both fallback keeper endpoints.

* `useTokensDataRequest` drops tokens without a price, so `DAI` is no longer in `tokensData`.
* `REACHABLE_TOKENS` is prebuilt from the static `MARKETS` config, which still contains the swap-only `USDC-DAI` (`0xe2fEDb9e6139a182B98e7C2688ccFa3e9A53c665`) and `USDC-DAI.e` (`0xDf8c9BD26e7C1A331902758Eb013548B2D22ab3b`) markets, so `DAI` stays in the reachable set.
* `selectPositionSellerAvailableReceiveTokens` non-null asserted the lookup and then read `token.isWrapped`, which threw.

Because the swap graph is connected through USDC, this hit 22 of 23 collateral tokens on Arbitrum and 9 of 10 on Avalanche — practically every position on both chains.

## Fix

Skip reachable tokens that are missing from `tokensData`, and only insert the native token when it is actually present. An unpriced token now silently drops out of the receive-token list instead of taking down the modal, which also makes future delistings safe.

## Follow-ups (not in this PR)

* Remove the delisted swap-only DAI markets from the markets config and regenerate the prebuilt swap data.
* `hasPartialData` in `useTokenRecentPricesData` compares against the warm `PRICES_CACHE`, so a permanently missing ticker is never detected as partial data — no warning, no fallback.