### PR TITLE
Fix invisible TP/SL chart edit icon in light mode FEDEV-4167

### DIFF
--- a/src/components/TVChartContainer/DynamicLine.tsx
+++ b/src/components/TVChartContainer/DynamicLine.tsx
@@ -156,6 +156,7 @@ export function DynamicLine({
         .setQuantityBackgroundColor(chartLabelColors.button.bg[theme])
         .setQuantityFont(`normal ${bodyFontSizePt + 4}pt "Relative", sans-serif`)
         .setQuantityBorderColor(orderBodyBgBorderColor)
+        .setQuantityTextColor(chartLabelColors.button.icon[theme])
 
         .setCancelButtonBackgroundColor(chartLabelColors.button.bg[theme])
         .setCancelButtonBorderColor(orderBodyBgBorderColor)


### PR DESCRIPTION
## Problem

In light mode the edit (pencil) control on TP/SL order labels in the TradingView chart is invisible: `DynamicLine` sets the quantity button's background, font and border, but never its text color, so the `✎` glyph falls back to the charting library default (white) on top of the white button background (`chartLabelColors.button.bg.light = #FFFFFF`).

## Fix

Set `setQuantityTextColor(chartLabelColors.button.icon[theme])` on the order line, matching what the position line already does in `StaticLine.tsx`. `theme` is already an effect dependency, so the line is recreated with the right color when the theme changes.

Nothing else changes: the cancel `X`, label content, alignment and the `onModify` edit handler are untouched.

Linear: [FEDEV-4167](https://linear.app/gmx-io/issue/FEDEV-4167/bug-tpsl-chart-edit-icon-is-invisible-in-light-mode)