### PR TITLE
Hotfix force UI update: bump uiVersion to 1.9

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,3 +1,3 @@
 {
-  "uiVersion": 1.8
+  "uiVersion": 1.9
 }


### PR DESCRIPTION
Forces clients still running an older bundle onto the freshly deployed one, so nobody keeps the build that crashed the position seller (#2744).

`useHasOutdatedUi` compares the `uiVersion` served from `/config.json` against the value baked into the running bundle. With the bump, stale clients get the `Page outdated. Refresh` toast and order actions are blocked until they reload — which matters here because the app shell is served cache-first by the service worker, so a stale bundle can otherwise survive a plain reload.

Deploy after the hotfix bundle is live (it is).