### PR TITLE
Cap Swap custom slippage at 99% FEDEV-4021

### DIFF
--- a/src/components/PercentageInput/PercentageInput.tsx
+++ b/src/components/PercentageInput/PercentageInput.tsx
@@ -11,6 +11,8 @@ import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
 
 export const NUMBER_WITH_TWO_DECIMALS = /^\d+(\.\d{0,2})?$/; // 0.00 ~ 99.99
 
+export const MAX_PERCENTAGE_INPUT_VALUE = 99 * 100; // basis points
+
 function getValueText(value: number) {
   return roundToTwoDecimals((value / BASIS_POINTS_DIVISOR) * 100).toString();
 }
@@ -37,7 +39,7 @@ export default function PercentageInput({
   onChange,
   defaultValue,
   value,
-  maxValue = 99 * 100,
+  maxValue = MAX_PERCENTAGE_INPUT_VALUE,
   highValue,
   lowValue,
   suggestions = DEFAULT_SUGGESTIONS,

--- a/src/components/TradeBox/SwapSlippageField.tsx
+++ b/src/components/TradeBox/SwapSlippageField.tsx
@@ -12,6 +12,7 @@ import { useSelector } from "context/SyntheticsStateContext/utils";
 import { formatPercentage } from "lib/numbers";
 
 import ExternalLink from "components/ExternalLink/ExternalLink";
+import { MAX_PERCENTAGE_INPUT_VALUE, NUMBER_WITH_TWO_DECIMALS } from "components/PercentageInput/PercentageInput";
 import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
 
 import { useTradeboxChanges } from "./hooks/useTradeboxChanges";
@@ -64,11 +65,26 @@ export function SwapSlippageField({ disabled }: { disabled?: boolean }) {
   const handleCustomChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
-      setCustomValue(value);
 
-      const numValue = parseFloat(value);
-      if (!isNaN(numValue) && numValue >= 0) {
-        const bps = Math.round(numValue * 100);
+      if (value === "") {
+        setCustomValue("");
+        return;
+      }
+
+      const bps = Math.round(parseFloat(value) * 100);
+
+      if (isNaN(bps)) {
+        return;
+      }
+
+      if (bps >= MAX_PERCENTAGE_INPUT_VALUE) {
+        setCustomValue((MAX_PERCENTAGE_INPUT_VALUE / 100).toString());
+        setAllowedSlippage(MAX_PERCENTAGE_INPUT_VALUE);
+        return;
+      }
+
+      if (NUMBER_WITH_TWO_DECIMALS.test(value)) {
+        setCustomValue(value);
         setAllowedSlippage(bps);
       }
     },


### PR DESCRIPTION
Closes [FEDEV-4021](https://linear.app/gmx-io/issue/FEDEV-4021/bug-swap-custom-slippage-accepts-values-above-99percent).

### Problem

The custom "Allowed slippage" input in the Swap tradebox accepted any non-negative number, so values like `100%` or `101%` could be entered and carried into `minOutputAmount`, failing later in the order flow instead of being rejected in the UI.

### Fix

`SwapSlippageField.handleCustomChange` now mirrors the shared `PercentageInput`:

- values `>= 99%` are clamped to `99%` (both the input text and the stored bps);
- input is validated against `NUMBER_WITH_TWO_DECIMALS`, so non-numeric input and more than two decimals are rejected;
- an empty field still leaves the reset to `handleCustomBlur` (unchanged behavior).

The `99 * 100` bound is extracted from `PercentageInput` into `MAX_PERCENTAGE_INPUT_VALUE` and reused — the default `maxValue` is unchanged, so consumers that override it (e.g. max network fee buffer with `1000 * 100`) keep working.

### Testing

Swap tab → custom "Allowed slippage":

- `100` / `101` / `150` / `1e3` → clamps to `99`;
- `98.99`, `0.35` → accepted;
- `1.2345` → trimmed to `1.23`;
- `abc`, `-5` → not entered;
- empty or `0` + blur → collapses back to the "Custom" chip and restores the saved default;
- presets `0.3 / 0.5 / 1.0 / 1.5` and the reset on direction / receive-token change are unchanged;
- min receive reflects the selected slippage.

Regression: default slippage in Settings, allowed slippage in the long/short tradebox and Position Seller, acceptable price impact, and the max network fee buffer (`maxValue` override) all behave as before.
