### PR TITLE
Block leading zeros in number inputs (FEDEV-4105)

### DIFF
--- a/src/components/NumberInput/NumberInput.spec.ts
+++ b/src/components/NumberInput/NumberInput.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeNumberInputValue } from "./NumberInput";
+
+describe("sanitizeNumberInputValue", () => {
+  it("accepts valid numbers", () => {
+    expect(sanitizeNumberInputValue("")).toBe("");
+    expect(sanitizeNumberInputValue("0")).toBe("0");
+    expect(sanitizeNumberInputValue("5")).toBe("5");
+    expect(sanitizeNumberInputValue("1234")).toBe("1234");
+    expect(sanitizeNumberInputValue("10")).toBe("10");
+    expect(sanitizeNumberInputValue("100")).toBe("100");
+  });
+
+  it("keeps decimals working", () => {
+    expect(sanitizeNumberInputValue("0.")).toBe("0.");
+    expect(sanitizeNumberInputValue("0.005")).toBe("0.005");
+    expect(sanitizeNumberInputValue("1.5")).toBe("1.5");
+    expect(sanitizeNumberInputValue("1.000")).toBe("1.000");
+  });
+
+  it("converts a comma to a dot", () => {
+    expect(sanitizeNumberInputValue("1,5")).toBe("1.5");
+    expect(sanitizeNumberInputValue("0,005")).toBe("0.005");
+  });
+
+  it("prepends a zero to a leading dot", () => {
+    expect(sanitizeNumberInputValue(".")).toBe("0.");
+    expect(sanitizeNumberInputValue(",")).toBe("0.");
+    expect(sanitizeNumberInputValue(".5")).toBe("0.5");
+  });
+
+  it("rejects leading zeros", () => {
+    expect(sanitizeNumberInputValue("00")).toBe(undefined);
+    expect(sanitizeNumberInputValue("05")).toBe(undefined);
+    expect(sanitizeNumberInputValue("0005")).toBe(undefined);
+    expect(sanitizeNumberInputValue("01.5")).toBe(undefined);
+    expect(sanitizeNumberInputValue("00.5")).toBe(undefined);
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(sanitizeNumberInputValue("abc")).toBe(undefined);
+    expect(sanitizeNumberInputValue("1a")).toBe(undefined);
+    expect(sanitizeNumberInputValue("1.2.3")).toBe(undefined);
+    expect(sanitizeNumberInputValue("-1")).toBe(undefined);
+    expect(sanitizeNumberInputValue(" 1")).toBe(undefined);
+  });
+});

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -3,11 +3,25 @@ import { ChangeEvent, KeyboardEvent, RefObject } from "react";
 
 import { limitDecimals } from "lib/numbers";
 
-function escapeSpecialRegExpChars(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+const inputRegex = /^(?:0|[1-9]\d*)(?:\.\d*)?$/;
 
-const inputRegex = RegExp(`^\\d*(?:\\\\[.])?\\d*$`);
+export function sanitizeNumberInputValue(rawValue: string): string | undefined {
+  let newValue = rawValue.replace(/,/g, ".");
+
+  if (newValue === "") {
+    return newValue;
+  }
+
+  if (newValue.startsWith(".")) {
+    newValue = `0${newValue}`;
+  }
+
+  if (!inputRegex.test(newValue)) {
+    return undefined;
+  }
+
+  return newValue;
+}
 
 type Props = {
   value?: string | number;
@@ -40,20 +54,17 @@ function NumberInput({
 }: Props) {
   function onChange(e: ChangeEvent<HTMLInputElement>) {
     if (!onValueChange) return;
-    // Replace comma with dot
-    let newValue = e.target.value.replace(/,/g, ".");
-    if (newValue === ".") {
-      newValue = "0.";
+
+    let newValue = sanitizeNumberInputValue(e.target.value);
+
+    if (newValue === undefined) return;
+
+    if (maxDecimals !== undefined) {
+      newValue = limitDecimals(newValue, maxDecimals);
     }
 
-    if (newValue === "" || inputRegex.test(escapeSpecialRegExpChars(newValue))) {
-      if (maxDecimals !== undefined) {
-        newValue = limitDecimals(newValue, maxDecimals);
-      }
-
-      e.target.value = newValue;
-      onValueChange(e);
-    }
+    e.target.value = newValue;
+    onValueChange(e);
   }
   return (
     <input


### PR DESCRIPTION
## Summary

Numeric fields accepted any number of leading zeros ("0005" shown while the $ value reads $5). Per [FEDEV-4105](https://linear.app/gmx-io/issue/FEDEV-4105/bug-numeric-inputs-accept-multiple-leading-zeros), edits are now blocked Hyperliquid-style:

- The integer part is a single `0` or starts with 1-9; after a leading `0` only `.` is accepted.
- Any edit that would produce leading zeros (typing or pasting, e.g. `0005`) is rejected and the field keeps its previous value.
- Zeros after the decimal point stay unrestricted (`0.005` remains valid).
- Existing behavior kept: comma converts to dot, a leading `.` becomes `0.` (now also `.5` → `0.5`).

The old escape-and-match regex in `NumberInput` is replaced with an explicit `sanitizeNumberInputValue` covered by unit tests. All numeric fields (trade box, Pay/Receive, position editor, TP/SL, GMX account deposit/withdraw/send) share this component.

## Testing

- `yarn vitest run src/components/NumberInput/NumberInput.spec.ts` — 6/6 green
- `yarn tscheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)