### PR TITLE
Skip delisted DAI swap-only markets in keeper consistency check

### DIFF
--- a/sdk/src/configs/__tests__/markets.spec.ts
+++ b/sdk/src/configs/__tests__/markets.spec.ts
@@ -1,7 +1,7 @@
 import { withRetry } from "viem";
 import { describe, expect, it } from "vitest";
 
-import { ARBITRUM, CONTRACTS_CHAIN_IDS_DEV } from "configs/chains";
+import { ARBITRUM, AVALANCHE, CONTRACTS_CHAIN_IDS_DEV } from "configs/chains";
 import { MARKETS } from "configs/markets";
 import { getOracleKeeperUrl } from "configs/oracleKeeper";
 
@@ -20,6 +20,12 @@ const SKIPPED_KEEPER_MARKETS: Partial<Record<number, Set<string>>> = {
     "0x2347EbB8645Cc2EA0Ba92D1EC59704031F2fCCf4",
     // AI16Z/USD [WBTC.e-USDC]
     "0xD60f1BA6a76979eFfE706BF090372Ebc0A5bF169",
+    // SWAP-ONLY [USDC-DAI]
+    "0xe2fEDb9e6139a182B98e7C2688ccFa3e9A53c665",
+  ]),
+  [AVALANCHE]: new Set([
+    // SWAP-ONLY [USDC-DAI.e]
+    "0xDf8c9BD26e7C1A331902758Eb013548B2D22ab3b",
   ]),
 };
 


### PR DESCRIPTION
## Why

The DAI markets are being delisted, so the oracle keeper stops returning them from `/markets` while `MARKETS` still lists them:

* `SWAP-ONLY [USDC-DAI]` — `0xe2fEDb9e6139a182B98e7C2688ccFa3e9A53c665` (Arbitrum)
* `SWAP-ONLY [USDC-DAI.e]` — `0xDf8c9BD26e7C1A331902758Eb013548B2D22ab3b` (Avalanche)

`markets.spec.ts` asserts every configured market is present in the keeper response, so during the previous delisting attempt it failed on Arbitrum (`expected undefined to be defined`) and took the required `Linting, Type Checking, and Tests` check down on every open PR, unrelated to their diffs. This lands the skip entries ahead of time so the next delisting pass does not turn CI red.

## Why skip instead of removing the markets

The market entries stay in `MARKETS` on purpose — the Arbitrum `USDC-DAI` pool still has 3012.10 GM outstanding (`totalSupply` on the market token), and dropping it from the config would leave those holders without a UI to exit. Avalanche holds 0.99 GM. This matches how the earlier delistings were handled: OM, WELL and AI16Z markets are all still in the config and only excluded from the keeper comparison.

The trade-off is that these two markets are no longer verified against the keeper at all, which is acceptable for markets that are going away.

Note that the unpriced-token crash these tokens caused in the position seller is fixed separately in #2744 — this PR is only about the config/keeper consistency check.