### PR TITLE
Skip delisted DAI swap-only markets in keeper consistency check

### DIFF
--- a/sdk/src/configs/__tests__/markets.spec.ts
+++ b/sdk/src/configs/__tests__/markets.spec.ts
@@ -1,7 +1,7 @@
 import { withRetry } from "viem";
 import { describe, expect, it } from "vitest";
 
-import { ARBITRUM, CONTRACTS_CHAIN_IDS_DEV } from "configs/chains";
+import { ARBITRUM, AVALANCHE, CONTRACTS_CHAIN_IDS_DEV } from "configs/chains";
 import { MARKETS } from "configs/markets";
 import { getOracleKeeperUrl } from "configs/oracleKeeper";
 
@@ -20,6 +20,12 @@ const SKIPPED_KEEPER_MARKETS: Partial<Record<number, Set<string>>> = {
     "0x2347EbB8645Cc2EA0Ba92D1EC59704031F2fCCf4",
     // AI16Z/USD [WBTC.e-USDC]
     "0xD60f1BA6a76979eFfE706BF090372Ebc0A5bF169",
+    // SWAP-ONLY [USDC-DAI]
+    "0xe2fEDb9e6139a182B98e7C2688ccFa3e9A53c665",
+  ]),
+  [AVALANCHE]: new Set([
+    // SWAP-ONLY [USDC-DAI.e]
+    "0xDf8c9BD26e7C1A331902758Eb013548B2D22ab3b",
   ]),
 };
 


### PR DESCRIPTION
Ports the master-only hotfix (#2750, `b74b0861b7`) onto `release`.

The oracle keeper delisted two swap-only DAI markets, so they no longer appear in `/markets` while the config keeps them for the GM holders still in those pools. `markets.spec.ts` asserts every configured market is served by the keeper, so `release` — and every PR targeting it — has been failing CI since the delisting.

| Chain | Market | Pool |
| --- | --- | --- |
| Arbitrum | `0xe2fEDb9e6139a182B98e7C2688ccFa3e9A53c665` | SWAP-ONLY [USDC-DAI] |
| Avalanche | `0xDf8c9BD26e7C1A331902758Eb013548B2D22ab3b` | SWAP-ONLY [WETH.e-DAI.e] |

Same treatment as the OM, WELL and AI16Z markets delisted earlier: added to `SKIPPED_KEEPER_MARKETS`. The markets stay in `MARKETS` so existing GM positions keep resolving.

## Testing

- Confirmed the delisting is real, not a flaky endpoint: all three keeper URLs per chain (primary + both fallbacks) omit these two markets, while still serving other delisted markets such as the deprecated APE and XAUT pools.
- Reproduced the failure on `release` before the change — `sdk/src/configs/__tests__/markets.spec.ts` failing for chains 42161 and 43114 with `expected undefined to be defined`, matching the CI logs on unrelated PRs.
- Full CI-equivalent run locally, all green:
  - `yarn test:ci` — 141 files / 1284 tests passed, 2 skipped
  - `yarn lint:ci`, `yarn tscheck:ci`
  - `yarn test:ct` — 190 passed
  - `sdk` `test:ci` — 43 files / 591 tests passed (2 failures before this change)
  - `sdk` `lint:ci`, `tscheck:ci`
  - `sdk` `test:multicall` — 14 passed, 1 skipped
  - `sdk` `test:v2:public` — 50 passed, 2 skipped
  - `yarn npm audit` (root and sdk) — no suggestions

Test-only change, no runtime or UI surface, so no screenshots.