### PR TITLE
Require the per-collateral open interest from the api FEDEV-4001

### DIFF
--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.spec.ts
@@ -16,6 +16,14 @@ function value(marketTokenAddress: string, updatedAt: number | null): RawMarketV
     marketTokenAddress,
     updatedAt,
     virtualInventoryForPositionsInTokens: 0n,
+    longInterestUsdUsingLongToken: 0n,
+    longInterestUsdUsingShortToken: 0n,
+    shortInterestUsdUsingLongToken: 0n,
+    shortInterestUsdUsingShortToken: 0n,
+    longInterestInTokensUsingLongToken: 0n,
+    longInterestInTokensUsingShortToken: 0n,
+    shortInterestInTokensUsingLongToken: 0n,
+    shortInterestInTokensUsingShortToken: 0n,
   } as RawMarketValues;
 }
 
@@ -107,6 +115,27 @@ describe("hasStaleMarketValues", () => {
       )
     ).toBe(true);
     expect(hasIncompleteMarketValues([config("0xa")], [], new Set())).toBe(true);
+  });
+
+  it("flags values without the per-collateral open interest split as incomplete", () => {
+    const withoutSplit = {
+      ...value("0xa", 1_000_000),
+      shortInterestInTokensUsingShortToken: undefined,
+    } as unknown as RawMarketValues;
+
+    expect(hasIncompleteMarketValues([config("0xa")], [withoutSplit], new Set())).toBe(true);
+    expect(hasStaleMarketValues([config("0xa")], [withoutSplit], new Set())).toBe(true);
+  });
+
+  it("ignores a missing per-collateral split for disabled markets", () => {
+    const withoutSplit = {
+      ...value("0xdisabled", 1_000_000),
+      longInterestUsdUsingLongToken: undefined,
+    } as unknown as RawMarketValues;
+
+    expect(hasIncompleteMarketValues([config("0xdisabled", true)], [withoutSplit], new Set(["0xdisabled"]))).toBe(
+      false
+    );
   });
 
   it("ignores disabled markets even when their values are null or stale", () => {

--- a/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
+++ b/src/domain/synthetics/markets/useMarketsInfoRequest/useApiMarketsInfoRequest.ts
@@ -66,6 +66,19 @@ export function hasStaleMarketValues(
   return false;
 }
 
+// Without the per-collateral split the pnl cap silently falls back to the pre-2.2c net formula,
+// so treat it as missing data and let the rpc path serve it instead.
+const PER_COLLATERAL_OPEN_INTEREST_FIELDS = [
+  "longInterestUsdUsingLongToken",
+  "longInterestUsdUsingShortToken",
+  "shortInterestUsdUsingLongToken",
+  "shortInterestUsdUsingShortToken",
+  "longInterestInTokensUsingLongToken",
+  "longInterestInTokensUsingShortToken",
+  "shortInterestInTokensUsingLongToken",
+  "shortInterestInTokensUsingShortToken",
+] as const satisfies readonly (keyof RawMarketValues)[];
+
 export function hasIncompleteMarketValues(
   configData: RawMarketConfig[] | undefined,
   valuesData: RawMarketValues[] | undefined,
@@ -91,7 +104,8 @@ export function hasIncompleteMarketValues(
       config.maxCollateralSumLongTokenShort === undefined ||
       config.maxCollateralSumShortTokenLong === undefined ||
       config.maxCollateralSumShortTokenShort === undefined ||
-      value.virtualInventoryForPositionsInTokens === undefined
+      value.virtualInventoryForPositionsInTokens === undefined ||
+      PER_COLLATERAL_OPEN_INTEREST_FIELDS.some((field) => value[field] === undefined)
     );
   });
 }


### PR DESCRIPTION
https://linear.app/gmx-io/issue/FEDEV-4001/sdk-use-positive-only-pool-pnl-for-per-position-pnl-cap-22c-parity

> Blocked on gmx-io/gmx-api#147 being deployed. Merging before that takes every session off the api markets path and onto rpc.

Phase 3 of FEDEV-4001, after #2743 (sdk) and gmx-io/gmx-api#147 (api).

`getPositiveMarketPnl` falls back to the pre-2.2c net formula when the open interest split by collateral token is absent, which is the right behaviour for a data source that cannot supply it but the wrong one once gmx-api can. Right now `apiMarkets` and `api100` are both enabled, so `isInRolloutBucket` returns true unconditionally and every session reads market data from `/v1/markets/values` — meaning nobody actually gets the v2.2c cap and rpc is only a degraded-mode fallback.

This marks the eight fields as required in `hasIncompleteMarketValues`, the same treatment `virtualInventoryForPositionsInTokens` got. If the api response lacks them the data is flagged incomplete, which feeds `hasStaleMarketValues` and takes those sessions to rpc, where the split is present. Once gmx-api serves the fields the api path takes over again and the cap is correct on both.

Deliberately not added to `MARKET_VALUES_V22C_FIELDS`: that assertion throws instead of degrading, and the convention in this repo is to graduate a field there only after the api has been serving it for a while.

Expect a transient bump in the markets staleness metric and the api fallback counter for as long as any pod is still on the old response shape.