### PR TITLE
Hotfix: legacy hash url rewrite breaks wallet connect in MetaMask in-app browser

### DIFF
--- a/src/lib/legacyHashUrl.spec.ts
+++ b/src/lib/legacyHashUrl.spec.ts
@@ -29,12 +29,12 @@ describe("getUrlWithoutLegacyHashRoute", () => {
     );
   });
 
-  // Relocating these out of the query once broke social login: the Privy SDK reads them from
-  // window.location.search to finish the OAuth redirect flow.
-  it("keeps Privy OAuth redirect params in the query", () => {
-    expect(getUrlWithoutLegacyHashRoute("https://app.gmx.io/?privy_oauth_code=abc&privy_oauth_state=xyz#/trade")).toBe(
-      "https://app.gmx.io/trade?privy_oauth_code=abc&privy_oauth_state=xyz"
-    );
+  // The Privy SDK reads these from window.location.search to finish the OAuth redirect flow, and
+  // any rewrite mid-flow silently breaks social login — the url must be left completely alone.
+  it("leaves a url with Privy OAuth redirect params untouched", () => {
+    expect(
+      getUrlWithoutLegacyHashRoute("https://app.gmx.io/?privy_oauth_code=abc&privy_oauth_state=xyz#/trade")
+    ).toBeUndefined();
   });
 
   it("keeps the anchor of the hash route", () => {
@@ -82,6 +82,39 @@ describe("watchLegacyHashUrl", () => {
 
     const target = new URL(navigate.mock.calls[0][0]);
     expect(`${target.pathname}${target.search}`).toBe("/trade?ref=CODE");
+    stop();
+  });
+
+  // The default navigation must stay in-document: a `location.replace` reloads the app and kills
+  // whatever is in flight, a wallet connect above all.
+  it("rewrites the url in place by default, without a document navigation", () => {
+    window.history.replaceState({}, "", "/");
+    const onPopState = vi.fn();
+    window.addEventListener("popstate", onPopState);
+    const stop = watchLegacyHashUrl();
+
+    window.history.replaceState({}, "", "/#/builders?utm_source=x");
+    window.dispatchEvent(new Event("hashchange"));
+
+    expect(`${window.location.pathname}${window.location.search}`).toBe("/builders?utm_source=x");
+    expect(window.location.hash).toBe("");
+    // react-router re-reads the location on popstate, but dismisses events with an undefined state.
+    expect(onPopState).toHaveBeenCalledTimes(1);
+    expect(onPopState.mock.calls[0][0].state).not.toBeUndefined();
+
+    window.removeEventListener("popstate", onPopState);
+    stop();
+  });
+
+  it("does not navigate while a Privy OAuth redirect is being finished", () => {
+    window.history.replaceState({}, "", "/?privy_oauth_code=abc");
+    const navigate = vi.fn();
+    const stop = watchLegacyHashUrl(navigate);
+
+    window.history.replaceState({}, "", "/?privy_oauth_code=abc#/trade");
+    window.dispatchEvent(new Event("hashchange"));
+
+    expect(navigate).not.toHaveBeenCalled();
     stop();
   });
 

--- a/src/lib/legacyHashUrl.ts
+++ b/src/lib/legacyHashUrl.ts
@@ -1,3 +1,8 @@
+// Privy puts these into the query string when returning from a social-login (OAuth) redirect and
+// reads them back from location.search to finish login. Rewriting the url out from under the SDK
+// silently broke social login before (89f2d7ac11), so a url carrying them is left alone.
+const PRIVY_OAUTH_QUERY_PARAMS = ["privy_oauth_code", "privy_oauth_state", "privy_oauth_provider", "privy_oauth_error"];
+
 /**
  * The app used to run on hash routing (`https://app.gmx.io/#/trade?ref=CODE`). Old bookmarks,
  * shared links and third-party integrations still point there, and the fragment never reaches the
@@ -9,6 +14,10 @@ export function getUrlWithoutLegacyHashRoute(href: string): string | undefined {
 
   // Plain anchors like `#bridge` are not legacy routes.
   if (!url.hash.startsWith("#/")) {
+    return undefined;
+  }
+
+  if (PRIVY_OAUTH_QUERY_PARAMS.some((param) => url.searchParams.has(param))) {
     return undefined;
   }
 
@@ -49,10 +58,9 @@ export function redirectLegacyHashUrl() {
 /**
  * Following a legacy link while already sitting on its path only changes the fragment, so the
  * document is not reloaded and the rewrite above never runs again. The landing page is the exposed
- * one, since it always sits on `/`. Navigating rather than rewriting the history entry is what
- * makes the router pick the new path up.
+ * one, since it always sits on `/`.
  */
-export function watchLegacyHashUrl(navigate = (url: string) => window.location.replace(url)) {
+export function watchLegacyHashUrl(navigate = replaceUrlInPlace) {
   const handleHashChange = () => {
     const url = getUrlWithoutLegacyHashRoute(window.location.href);
 
@@ -64,4 +72,22 @@ export function watchLegacyHashUrl(navigate = (url: string) => window.location.r
   window.addEventListener("hashchange", handleHashChange);
 
   return () => window.removeEventListener("hashchange", handleHashChange);
+}
+
+/**
+ * Rewrites the url without a document navigation: `location.replace` reloads the app and kills
+ * whatever is in flight, a wallet connect above all. `replaceState` alone is invisible to the
+ * router, so a popstate event follows — it must carry a non-undefined `state`, or react-router
+ * dismisses it as extraneous.
+ */
+function replaceUrlInPlace(url: string) {
+  try {
+    const state = window.history.state ?? null;
+
+    window.history.replaceState(state, "", url);
+    window.dispatchEvent(new PopStateEvent("popstate", { state }));
+  } catch {
+    // Safari throttles history rewrites (SecurityError past 100 in 10 seconds); dropping this one
+    // is better than falling back to a reload.
+  }
 }

--- a/src/lib/legacyHashUrlRedirect.spec.ts
+++ b/src/lib/legacyHashUrlRedirect.spec.ts
@@ -14,6 +14,16 @@ describe("legacyHashUrlRedirect", () => {
     expect(window.location.search).toBe("?ref=CODE");
   });
 
+  it("leaves a Privy OAuth return url untouched while the module is being imported", async () => {
+    window.history.replaceState({}, "", "/?privy_oauth_code=abc&privy_oauth_state=xyz#/trade");
+
+    await import("./legacyHashUrlRedirect");
+
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.search).toBe("?privy_oauth_code=abc&privy_oauth_state=xyz");
+    expect(window.location.hash).toBe("#/trade");
+  });
+
   it("leaves a path based url untouched", async () => {
     window.history.replaceState({}, "", "/buy_gmx?foo=bar#bridge");
 


### PR DESCRIPTION
## Summary

Since Aug 13 (release-122), the wallet-connect failure rate for users in MetaMask's in-app browser jumped from ~3% to 26–56%, while desktop and non-MetaMask mobile users stayed flat at ~3–4% — 227 distinct users affected. Datadog `routes.ui` metric events bisected by `@uiReport.version` point at the change that replaced `useHashQueryParams` with the module-eval legacy `#/` url rewrite (`legacyHashUrl.ts`).

Two deltas vs the old code:

- The `privy_oauth_*` guard from hotfix 89f2d7ac11 was lost. The Privy SDK reads these params from `location.search` to finish a social-login redirect, and rewriting the url out from under it silently breaks login. In-app browsers block popups, so they always use the redirect flow.
- `watchLegacyHashUrl` handled `hashchange` with `window.location.replace()` — a full document navigation that reloads the app and kills anything in flight, a wallet connect above all. MetaMask in-app users re-enter through saved `#/` favourites, so fragment-only changes are common exactly there. This also matches the Safari-only `history.replaceState() more than 100 times per 10 seconds` errors that appeared on Aug 13.

## Fix

- `getUrlWithoutLegacyHashRoute` bails out entirely when `location.search` carries any `privy_oauth_*` param — the same semantics as 89f2d7ac11. The root route's `RedirectWithQuery` keeps the params in `location.search`, so login still completes.
- The `hashchange` watcher now rewrites the url in place: `history.replaceState` plus a dispatched `popstate` carrying a non-`undefined` state (history v4 dismisses stateless popstate events as extraneous), so react-router picks the new path up without a reload. Wrapped in try/catch so Safari's replaceState throttle degrades to skipping one rewrite instead of erroring.

## Testing

- Unit specs updated/added: a Privy OAuth return url is left untouched (module-eval and watcher paths), and the default watcher navigation rewrites the url in place — popstate fired with a state payload, document not reloaded.
- `test:ci` (1358 passed), `test:ct` (198 passed; the OneClickTradingMode spec is a known local-only flake), sdk `test:ci` (603 passed), `tscheck`, eslint, prettier.
- Browser-verified on the dev server: `/#/buy_gmx` rewrites to `/buy_gmx` before the router mounts; setting `#/referrals` in place soft-navigates through the router (it continues into the `/referrals/traders` default-tab redirect) with a window marker proving the document was not reloaded; `/buy_gmx?privy_oauth_code=…#/trade` stays byte-identical after load.

Release carries the same code and needs this patch as well — separate PR.