### PR TITLE
Add fetchGmPoolYieldPnl to SDK v2 client

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmx-io/sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/sdk/src/clients/v2/index.ts
+++ b/sdk/src/clients/v2/index.ts
@@ -130,8 +130,17 @@ import type { SdkSubaccountApproval, SdkSubaccountStatus, SubaccountState } from
 import { fetchApiTokens } from "utils/tokens/api";
 import { fetchApiTrades, searchApiTrades } from "utils/trades/api";
 import type { FetchTradesParams, SearchTradesParams, TradesListResponse } from "utils/trades/types";
+import { fetchApiGmPoolYieldPnl } from "utils/yield/api";
+import { GmPoolsYieldPnlParams, GmPoolsYieldPnlResponse } from "utils/yield/types";
 
 export type { ApyEntry, ApyParams, ApyResponse } from "utils/apy/types";
+export type {
+  GmPoolYieldPnlComponents,
+  GmPoolYieldPnlEntry,
+  GmPoolYieldPnlWindow,
+  GmPoolsYieldPnlParams,
+  GmPoolsYieldPnlResponse,
+} from "utils/yield/types";
 export type {
   GetTradingCapacityParams,
   JitDataStatus,
@@ -348,6 +357,10 @@ export class GmxApiSdk {
 
   fetchPerformanceSnapshots(params?: PerformanceParams): Promise<PerformanceSnapshots[]> {
     return fetchApiPerformanceSnapshots(this.ctx, params);
+  }
+
+  fetchGmPoolYieldPnl(params?: GmPoolsYieldPnlParams): Promise<GmPoolsYieldPnlResponse> {
+    return fetchApiGmPoolYieldPnl(this.ctx, params);
   }
 
   fetchBuybackWeeklyStats(): Promise<BuybackWeeklyStatsResponse> {

--- a/sdk/src/utils/yield/api.ts
+++ b/sdk/src/utils/yield/api.ts
@@ -1,0 +1,16 @@
+import { IHttp } from "utils/http/types";
+
+import { GmPoolsYieldPnlParams, GmPoolsYieldPnlResponse } from "./types";
+
+export async function fetchApiGmPoolYieldPnl(
+  ctx: { api: IHttp },
+  params?: GmPoolsYieldPnlParams
+): Promise<GmPoolsYieldPnlResponse> {
+  return ctx.api.fetchJson("/v1/yield/gm-pools", {
+    query: {
+      period: params?.period,
+      pools: params?.pools,
+      includeComponents: params?.includeComponents,
+    },
+  });
+}

--- a/sdk/src/utils/yield/types.ts
+++ b/sdk/src/utils/yield/types.ts
@@ -1,0 +1,34 @@
+import type { ApiParameterPeriod } from "utils/rates/types";
+
+export type GmPoolYieldPnlWindow = {
+  period: ApiParameterPeriod;
+  startTimestamp: number;
+  endTimestamp: number;
+};
+
+export type GmPoolYieldPnlComponents = {
+  realizedPnlLongUsd: number;
+  realizedPnlShortUsd: number;
+  unrealizedPnlLongUsd: number;
+  unrealizedPnlShortUsd: number;
+};
+
+export type GmPoolYieldPnlEntry = {
+  marketToken: string;
+  feeApy: number | null;
+  tradersPnlUsd: number | null;
+  tradersPnlApr: number | null;
+  timeWeightedPoolValue: number | null;
+  window: GmPoolYieldPnlWindow;
+  components?: GmPoolYieldPnlComponents | null;
+};
+
+export type GmPoolsYieldPnlResponse = {
+  pools: GmPoolYieldPnlEntry[];
+};
+
+export type GmPoolsYieldPnlParams = {
+  pools?: string[];
+  period?: ApiParameterPeriod;
+  includeComponents?: boolean;
+};

--- a/sdk/src/utils/yield/types.ts
+++ b/sdk/src/utils/yield/types.ts
@@ -20,7 +20,7 @@ export type GmPoolYieldPnlEntry = {
   tradersPnlApr: number | null;
   timeWeightedPoolValue: number | null;
   window: GmPoolYieldPnlWindow;
-  components?: GmPoolYieldPnlComponents | null;
+  components?: GmPoolYieldPnlComponents;
 };
 
 export type GmPoolsYieldPnlResponse = {


### PR DESCRIPTION
## What

SDK v2 counterpart of gmx-io/gmx-api#154: `fetchGmPoolYieldPnl()` typed fetcher for `GET /v1/yield/gm-pools` (fee-only APY + trader PnL per GM market token), plus exported response and param types.

Params: `pools?: string[]`, `period?: ApiParameterPeriod`, `includeComponents?: boolean`. PnL values are trader-perspective (positive = traders gained against the pool); metrics are null and `components` is absent for pools without indexed data — semantics documented in the API's OpenAPI contract.

Closes the SDK half of FEDEV-3811.

## Verification

- `yarn tscheck` clean, sdk vitest suite green, eslint clean on the changed files.
- Query serialization verified: `queryString.stringify` emits repeated `pools=` keys, matching the tsoa `string[]` query contract.
