### PR TITLE
Fix sticky Shift tab rerouting swap-only pool clicks FEDEV-4249

### DIFF
--- a/src/components/GmSwap/GmSwapBox/GmSwapBox.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmSwapBox.tsx
@@ -1,8 +1,9 @@
 import { msg } from "@lingui/macro";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import {
   selectPoolsDetailsAvailableModes,
+  selectPoolsDetailsAvailableOperations,
   selectPoolsDetailsGlvOrMarketAddress,
   selectPoolsDetailsMode,
   selectPoolsDetailsOperation,
@@ -11,6 +12,7 @@ import {
   selectPoolsDetailsSetOperation,
   selectPoolsDetailsSetSelectedMarketAddressForGlv,
 } from "context/PoolsDetailsContext/selectors";
+import { selectShiftAvailableMarkets } from "context/SyntheticsStateContext/selectors/shiftSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { Mode, Operation } from "domain/synthetics/markets/types";
 import { useLocalizedMap } from "lib/i18n";
@@ -37,6 +39,23 @@ export function GmSwapBox() {
   const setSelectedMarketAddressForGlv = useSelector(selectPoolsDetailsSetSelectedMarketAddressForGlv);
 
   const availableModes = useSelector(selectPoolsDetailsAvailableModes);
+  const availableOperations = useSelector(selectPoolsDetailsAvailableOperations);
+  const shiftAvailableMarkets = useSelector(selectShiftAvailableMarkets);
+
+  // A sticky Shift operation must not mount GmShiftBox for a non-shiftable market (it would
+  // replace the selected market on mount); clamp only once shift availability is loaded.
+  const isShiftAvailabilityKnown = shiftAvailableMarkets.length > 0;
+  const operationToRender =
+    isShiftAvailabilityKnown && !availableOperations.includes(operation) ? Operation.Deposit : operation;
+
+  useEffect(
+    function fallbackUnavailableOperation() {
+      if (operationToRender !== operation) {
+        setOperation(operationToRender);
+      }
+    },
+    [operation, operationToRender, setOperation]
+  );
 
   const localizedModeLabels = useLocalizedMap(MODE_LABELS);
 
@@ -59,7 +78,7 @@ export function GmSwapBox() {
         type="inline"
       />
 
-      {operation === Operation.Deposit || operation === Operation.Withdrawal ? (
+      {operationToRender === Operation.Deposit || operationToRender === Operation.Withdrawal ? (
         <GmSwapBoxDepositWithdrawal />
       ) : (
         <GmShiftBox

--- a/src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
@@ -2,16 +2,15 @@ import { msg } from "@lingui/macro";
 import { useMemo } from "react";
 
 import {
+  selectPoolsDetailsAvailableOperations,
   selectPoolsDetailsGlvOrMarketAddress,
   selectPoolsDetailsOperation,
   selectPoolsDetailsSetOperation,
 } from "context/PoolsDetailsContext/selectors";
 import { selectGlvAndMarketsInfoData } from "context/SyntheticsStateContext/selectors/globalSelectors";
-import { selectShiftAvailableMarkets } from "context/SyntheticsStateContext/selectors/shiftSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 import { isGlvInfo } from "domain/synthetics/markets/glv";
 import { Operation } from "domain/synthetics/markets/types";
-import { getGlvOrMarketAddress } from "domain/synthetics/markets/utils";
 import { useLocalizedMap } from "lib/i18n";
 import { getByKey } from "lib/objects";
 
@@ -28,8 +27,6 @@ const OPERATION_LABELS_GLV = {
   [Operation.Withdrawal]: msg`Sell GLV`,
   [Operation.Shift]: msg`Shift GM`,
 };
-
-const OPERATIONS = [Operation.Deposit, Operation.Withdrawal, Operation.Shift];
 
 const operationClassNames = {
   [Operation.Deposit]: {
@@ -53,24 +50,9 @@ export function GmSwapBoxHeader({ isInCurtain }: Props) {
   const setOperation = useSelector(selectPoolsDetailsSetOperation);
 
   const marketsInfoData = useSelector(selectGlvAndMarketsInfoData);
-  const shiftAvailableMarkets = useSelector(selectShiftAvailableMarkets);
   const marketInfo = getByKey(marketsInfoData, selectedGlvOrMarketAddress);
 
-  const availableOperations = useMemo(() => {
-    if (shiftAvailableMarkets.length === 0) {
-      return [Operation.Deposit, Operation.Withdrawal];
-    }
-
-    const isSelectedMarketShiftAvailable = Boolean(
-      shiftAvailableMarkets.find((market) => getGlvOrMarketAddress(market) === selectedGlvOrMarketAddress)
-    );
-
-    if (!isSelectedMarketShiftAvailable) {
-      return [Operation.Deposit, Operation.Withdrawal];
-    }
-
-    return OPERATIONS;
-  }, [selectedGlvOrMarketAddress, shiftAvailableMarkets]);
+  const availableOperations = useSelector(selectPoolsDetailsAvailableOperations);
 
   const localizedOperationLabelsGM = useLocalizedMap(OPERATION_LABELS_GM);
   const localizedOperationLabelsGLV = useLocalizedMap(OPERATION_LABELS_GLV);

--- a/src/components/GmSwap/GmSwapBox/getGmSwapBoxAvailableOperations.spec.ts
+++ b/src/components/GmSwap/GmSwapBox/getGmSwapBoxAvailableOperations.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { GlvInfo, MarketInfo, Operation } from "domain/synthetics/markets/types";
+
+import { getGmSwapBoxAvailableOperations } from "./getGmSwapBoxAvailableOperations";
+
+const BTC_USDC_MARKET = { marketTokenAddress: "0x47c031236e19d024b42f8AE6780E44A573170703" } as MarketInfo;
+const SWAP_ONLY_MARKET = { marketTokenAddress: "0x9C2433dFD71096C435Be9465220BB2B189375eA7" } as MarketInfo;
+const GLV = { isGlv: true, glvTokenAddress: "0x528A5bac7E746C9A509A1f4F6dF58A03d44279F9" } as unknown as GlvInfo;
+
+describe("getGmSwapBoxAvailableOperations", () => {
+  it("returns deposit and withdrawal when there are no shift-available markets", () => {
+    expect(
+      getGmSwapBoxAvailableOperations({
+        shiftAvailableMarkets: [],
+        selectedGlvOrMarketAddress: BTC_USDC_MARKET.marketTokenAddress,
+      })
+    ).toEqual([Operation.Deposit, Operation.Withdrawal]);
+  });
+
+  it("returns deposit and withdrawal when the selected market is not shift-available", () => {
+    expect(
+      getGmSwapBoxAvailableOperations({
+        shiftAvailableMarkets: [BTC_USDC_MARKET],
+        selectedGlvOrMarketAddress: SWAP_ONLY_MARKET.marketTokenAddress,
+      })
+    ).toEqual([Operation.Deposit, Operation.Withdrawal]);
+  });
+
+  it("returns deposit and withdrawal when no market is selected", () => {
+    expect(
+      getGmSwapBoxAvailableOperations({
+        shiftAvailableMarkets: [BTC_USDC_MARKET],
+        selectedGlvOrMarketAddress: undefined,
+      })
+    ).toEqual([Operation.Deposit, Operation.Withdrawal]);
+  });
+
+  it("includes shift when the selected market is shift-available", () => {
+    expect(
+      getGmSwapBoxAvailableOperations({
+        shiftAvailableMarkets: [BTC_USDC_MARKET],
+        selectedGlvOrMarketAddress: BTC_USDC_MARKET.marketTokenAddress,
+      })
+    ).toEqual([Operation.Deposit, Operation.Withdrawal, Operation.Shift]);
+  });
+
+  it("matches a shift-available glv by its glv token address", () => {
+    expect(
+      getGmSwapBoxAvailableOperations({
+        shiftAvailableMarkets: [GLV],
+        selectedGlvOrMarketAddress: GLV.glvTokenAddress,
+      })
+    ).toEqual([Operation.Deposit, Operation.Withdrawal, Operation.Shift]);
+  });
+});

--- a/src/components/GmSwap/GmSwapBox/getGmSwapBoxAvailableOperations.ts
+++ b/src/components/GmSwap/GmSwapBox/getGmSwapBoxAvailableOperations.ts
@@ -1,0 +1,24 @@
+import { GlvOrMarketInfo, Operation } from "domain/synthetics/markets/types";
+import { getGlvOrMarketAddress } from "domain/synthetics/markets/utils";
+
+export function getGmSwapBoxAvailableOperations({
+  shiftAvailableMarkets,
+  selectedGlvOrMarketAddress,
+}: {
+  shiftAvailableMarkets: GlvOrMarketInfo[];
+  selectedGlvOrMarketAddress: string | undefined;
+}): Operation[] {
+  if (shiftAvailableMarkets.length === 0) {
+    return [Operation.Deposit, Operation.Withdrawal];
+  }
+
+  const isSelectedMarketShiftAvailable = Boolean(
+    shiftAvailableMarkets.find((market) => getGlvOrMarketAddress(market) === selectedGlvOrMarketAddress)
+  );
+
+  if (!isSelectedMarketShiftAvailable) {
+    return [Operation.Deposit, Operation.Withdrawal];
+  }
+
+  return [Operation.Deposit, Operation.Withdrawal, Operation.Shift];
+}

--- a/src/context/PoolsDetailsContext/selectors/poolsDetailsDerivedSelectors.ts
+++ b/src/context/PoolsDetailsContext/selectors/poolsDetailsDerivedSelectors.ts
@@ -11,6 +11,7 @@ import {
   selectSrcChainId,
   selectTokensData,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
+import { selectShiftAvailableMarkets } from "context/SyntheticsStateContext/selectors/shiftSelectors";
 import { makeSelectFindSwapPath } from "context/SyntheticsStateContext/selectors/tradeSelectors";
 import { createSelector } from "context/SyntheticsStateContext/utils";
 import { getAreBothCollateralsCrossChain } from "domain/multichain/areBothCollateralsCrossChain";
@@ -30,6 +31,7 @@ import { convertTokenAddress, getToken } from "sdk/configs/tokens";
 import { SwapPricingType } from "sdk/utils/orders/types";
 
 import { getGmSwapBoxAvailableModes } from "components/GmSwap/GmSwapBox/getGmSwapBoxAvailableModes";
+import { getGmSwapBoxAvailableOperations } from "components/GmSwap/GmSwapBox/getGmSwapBoxAvailableOperations";
 
 import {
   PLATFORM_TOKEN_DECIMALS,
@@ -96,6 +98,13 @@ export const selectPoolsDetailsAvailableModes = createSelector((q): Mode[] => {
   const areBothCollateralsCrossChain = q(selectPoolsDetailsAreBothCollateralsCrossChain);
 
   return getGmSwapBoxAvailableModes({ operation, market: marketInfo, paySource, areBothCollateralsCrossChain });
+});
+
+export const selectPoolsDetailsAvailableOperations = createSelector((q): Operation[] => {
+  const shiftAvailableMarkets = q(selectShiftAvailableMarkets);
+  const selectedGlvOrMarketAddress = q(selectPoolsDetailsGlvOrMarketAddress);
+
+  return getGmSwapBoxAvailableOperations({ shiftAvailableMarkets, selectedGlvOrMarketAddress });
 });
 
 export const selectPoolsDetailsSelectedMarketInfoForGlv = createSelector((q) => {


### PR DESCRIPTION
Linear: https://linear.app/gmx-io/issue/FEDEV-4249/sticky-shift-gm-tab-reroutes-swap-only-pool-clicks-to-the-top-tvl-pool

## Problem

The Buy/Sell/Shift `operation` is in-memory state shared across the whole Pools section, so a previously selected **Shift GM** tab survives navigation. Opening a non-shiftable pool (swap-only pools always are) with that state mounts `GmShiftBox`, whose `useUpdateMarkets` effect silently replaces the selected market with `shiftAvailableGlvOrMarkets[0]` — the top-TVL pool (BTC/USD [BTC-USDC] on Arbitrum). Reported by QA as "clicking a SWAP-ONLY pool opens BTC-USDC"; it reproduces on production the same way, and "disappears" because a reload resets the tab state.

## Change

- Extracted the header's available-operations logic into `getGmSwapBoxAvailableOperations` and exposed it as `selectPoolsDetailsAvailableOperations`; `GmSwapBoxHeader` now uses the selector instead of its inline copy.
- `GmSwapBox` clamps the rendered operation to the available ones, so `GmShiftBox` can never mount for a non-shiftable market (a state-only reset would be too late — the child effect fires in the same commit). An effect then realigns the stored operation.
- The clamp waits until shift availability is known (`shiftAvailableMarkets` non-empty): an empty list cannot reroute (`useUpdateMarkets` bails on `[0] === undefined`), and clamping during loading would desync `GmDepositWithdrawalBox` flags from the stored operation on `?operation=shift` deep links.

## Testing

- Repro flow (was failing, now passes): open BTC/USD [BTC-USDC] details → select Shift GM → breadcrumb back to Pools → click SWAP-ONLY [USDC-USDC.E] → stays on the swap-only pool with Buy GM active; URL keeps `market=0x9C24…5eA7`.
- Shift still works: Shift GM tab on BTC/USD [BTC-USDC] renders the shift box with a receive market; URL unchanged.
- Deep links on a fresh tab: `?market=<BTC-USDC>&operation=shift` ends on the shift box with no mixed Pay/Receive state sampled during load; `?market=<swap-only>&operation=shift` stays on the swap-only pool with only Buy/Sell tabs.
- Verification screenshot attached to FEDEV-4249.
- Suites: app vitest (1602 passed), playwright-ct (198 passed), sdk vitest, tscheck, eslint, prettier.