### PR TITLE
Hotfix: Add Release 122 and 123 in-app announcement FEDEV-4247

### DIFF
--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -49,6 +49,67 @@ export type EventData = {
 
 export const appEventsData: EventData[] = [
   {
+    id: "release-122-123-highlights",
+    type: "update",
+    isActive: true,
+    startDate: "21 Aug 2026, 08:00",
+    endDate: "28 Aug 2026, 08:00",
+    variant: "info",
+    title: "App Update: Earnings Overview, Conditional Margin Deposits, Tax Exports",
+    summary: (
+      <>
+        Earn Portfolio now shows what you've earned, margin deposits can wait for a trigger, and history exports for tax
+        tools.
+      </>
+    ),
+    description: (
+      <span className="flex flex-col gap-12">
+        <span>
+          <span className="font-medium text-typography-primary">Earn Portfolio:</span> the Portfolio tab now shows what
+          you have earned without hovering. Lifetime and last-7-day totals sit above your assets, split into Staking and
+          LP, and GLV vault earnings appear for the first time. Every GM pool and GLV card carries its own 7d, expected
+          365d and lifetime line.
+        </span>
+        <span>
+          <span className="font-medium text-typography-primary">Margin deposits:</span> Edit margin now takes a trigger
+          price, so you can queue extra margin that only lands if the market reaches it. It shows as a Deposit margin
+          order you can edit or replace from the Orders tab.
+        </span>
+        <span>
+          <span className="font-medium text-typography-primary">History exports:</span> the CSV button on Trade History
+          and Claims History now opens an export picker, with a detailed GMX format plus Koinly, CoinTracker and
+          CoinLedger. Exports cover your full filtered history, not just the rows on screen.
+        </span>
+        <span>
+          <span className="font-medium text-typography-primary">Trade History:</span> the settlement tooltip on a closed
+          position now reconciles the whole lifecycle, from the margin you put in through every increase, withdrawal and
+          partial close to the final payout. Executed swaps show their swap fee and price impact alongside.
+        </span>
+        <span>
+          <span className="font-medium text-typography-primary">Order warnings:</span> the copy for an order that cannot
+          execute is now the same across the Orders tab, the tradebox and position editing, and each one tells you what
+          to do about it. A limit increase with a trigger beyond your liquidation price is now previewed as a fresh
+          position and warns you.
+        </span>
+        <span>
+          <span className="font-medium text-typography-primary">Wallet funding:</span> Buy with card and Transfer from
+          another chain are available from Receive for every wallet, not just email and social logins. On desktop,
+          Receive to Wallet has a proper Back button.
+        </span>
+        <span>
+          <span className="font-medium text-typography-primary">Links:</span> app URLs no longer contain "#". Your old
+          links and bookmarks still work and are rewritten in place, keeping your referral code, network and page.
+        </span>
+        <span>
+          <span className="font-medium text-typography-primary">Fixes:</span> position PnL matches what the contract
+          settles when the pool PnL cap applies, Staking Power Share shows three decimals on the GMX card so you can see
+          small changes in your share, swap slippage no longer accepts values above 99%, and the TP/SL edit icon on the
+          chart is visible again in light mode.
+        </span>
+      </span>
+    ),
+  },
+  {
     id: "release-121-highlights",
     type: "update",
     isActive: true,


### PR DESCRIPTION
Publishes one in-app announcement covering Releases 122 and 123: the one-line summary in the What's New toast, the full write-up on the Announcements page. Release 122 shipped on 13 August without an announcement, so this card covers both.

Standard `appEventsData` entry — `type: update`, `variant: info`, no `chains` (so it shows on Arbitrum, Avalanche and MegaETH), no read-more link. Dates are 21 Aug 08:00 to 28 Aug 08:00 UTC, so the end date sits past the QQQ/SPY listing announcement going up on 24 August and the two rotate in the carousel rather than one replacing the other.

Every claim in the copy maps to a merged PR: Earn Portfolio (#2772), conditional margin deposits (#2739), tax-compatible CSV exports (#2718), lifecycle settlement (#2729) and pure-swap fee/impact (#2727), order tooltip standardization (#2719) and limit-increase-beyond-liquidation (#2740), wallet funding for all wallet types (#2771) and desktop Receive back button (#2770), path-based URLs (#2732, re-landed in #2760), and the four fixes (#2743 + #2756, #2751, #2747, #2745).

The Links paragraph depends on path-based URLs being live: verified against production before pushing, `app.gmx.io`'s entry bundle carries the `legacyHashUrl` module that the revert in #2759 had removed.

Left out deliberately, per the ticket: the Gelato-to-GMX-relay Express migration (#2769), the DAI-delisting position-close fix, the VIP page copy (#2762), the delisting announcement changes (#2774), Datadog log volume (#2764), the RPC test harness (#2763), the SDK yield endpoint (#2768), and the smaller Release 122 polish.

## Testing

Drove the change in the running app at 1440x900 (screenshots below):

- What's New toast renders the title over two lines and the full summary over three, with no ellipsis cut-off. Measured the clamped element directly: `scrollHeight` 55 equals `clientHeight` 55, so `line-clamp-3` is not truncating.
- Announcements page card shows the summary first, then the description, with all eight section labels rendering in the highlighted style (`font-medium text-typography-primary`), matching the Release 117/118/120/121 entries.
- Carousel rotation: temporarily made a second entry eligible and confirmed the toast cycles through both titles via the `aria-live` region, neither displacing the other. `MAX_TOAST_CARDS` is 4, so this card plus the QQQ/SPY one both fit.
- Expired entries stay on the Announcements page while dropping out of the toast — the Release 117/118/120/121 cards are still listed below this one.
- Card carries no chain tag.

Checks run locally: `tscheck:ci`, `lint:ci`, `test:ci`, `test:ct` (199 passed), and `sdk test:ci` — all green. The diff is purely additive; the one unrelated prettier reflow in the Release 121 entry was reverted, and that drift is pre-existing on master.

Linear: https://linear.app/gmx-io/issue/FEDEV-4247/in-app-announcement-release-122-and-123-highlights
