### PR TITLE
Align Edit margin modal tooltip labels FEDEV-4248

### DIFF
--- a/src/components/PositionEditor/PositionEditorAdvancedRows.tsx
+++ b/src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -52,12 +52,9 @@ export function PositionEditorAdvancedRows({ operation, gasPaymentParams }: Opti
       <SyntheticsInfoRow
         label={
           <TooltipWithPortal
-            handle={
-              <span className="Exchange-info-label">
-                <Trans>Margin ({position?.collateralToken?.symbol})</Trans>
-              </span>
-            }
+            handle={<Trans>Margin ({position?.collateralToken?.symbol})</Trans>}
             position="left-start"
+            variant="iconStroke"
             content={<Trans>Margin before pending borrow and funding fees</Trans>}
           />
         }


### PR DESCRIPTION
In the Edit margin modal's **Execution details** section, the two label tooltips used different affordances: "Network fee" showed an info icon while "Margin (USDC)" showed a dotted underline.

"Margin (USDC)" now uses `variant="iconStroke"`, matching "Network fee" in the same section and the identical Margin row in the Close position modal (`PositionSellerAdvancedDisplayRows.tsx`).

Linear: https://linear.app/gmx-io/issue/FEDEV-4248/edit-margin-modal-align-network-fee-and-margin-usdc-labels-with
