### PR TITLE
Hotfix: stop history.replaceState loop breaking wallet in-app browsers FEDEV-4237

### DIFF
--- a/src/domain/synthetics/trade/useTradeParamsProcessor.spec.ts
+++ b/src/domain/synthetics/trade/useTradeParamsProcessor.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { ARBITRUM, AVALANCHE } from "config/chains";
 
-import { isSupportedTradeLinkChainId } from "./useTradeParamsProcessor";
+import { getCleanedTradeSearch, isSupportedTradeLinkChainId } from "./useTradeParamsProcessor";
 
 describe("isSupportedTradeLinkChainId", () => {
   it("accepts supported settlement-chain links", () => {
@@ -11,5 +11,28 @@ describe("isSupportedTradeLinkChainId", () => {
 
   it("rejects retired settlement-chain links", () => {
     expect(isSupportedTradeLinkChainId("3637", ARBITRUM)).toBe(false);
+  });
+});
+
+describe("getCleanedTradeSearch", () => {
+  it("strips consumed trade link params and keeps the rest", () => {
+    expect(getCleanedTradeSearch("?from=USDC&to=ETH&mode=market&utm_source=x")).toBe("utm_source=x");
+  });
+
+  it("strips a search consisting only of trade link params to an empty string", () => {
+    expect(getCleanedTradeSearch("?to=ETH&pool=WETH-USDC")).toBe("");
+  });
+
+  it("returns undefined when only unrelated params are present, so no replace is triggered", () => {
+    expect(getCleanedTradeSearch("?utm_source=Trust_iOS_Browser&testExampleAb=0")).toBe(undefined);
+    expect(getCleanedTradeSearch("?privy_connector=injected")).toBe(undefined);
+  });
+
+  it("returns undefined for an empty search", () => {
+    expect(getCleanedTradeSearch("")).toBe(undefined);
+  });
+
+  it("ignores encoding-only differences instead of rewriting the url forever", () => {
+    expect(getCleanedTradeSearch("?utm_content=a%20b")).toBe(undefined);
   });
 });

--- a/src/domain/synthetics/trade/useTradeParamsProcessor.ts
+++ b/src/domain/synthetics/trade/useTradeParamsProcessor.ts
@@ -44,6 +44,25 @@ export function isSupportedTradeLinkChainId(chainIdFromParams: string, activeCha
   );
 }
 
+const TRADE_LINK_SEARCH_PARAMS = ["mode", "from", "to", "market", "pool", "collateral", "chainId"];
+
+// Returns the search without the consumed trade params, or `undefined` when nothing would change:
+// replacing the url with an identical search re-runs the effect and loops into WebKit's replaceState rate limit.
+export function getCleanedTradeSearch(search: string): string | undefined {
+  const original = new URLSearchParams(search);
+  const cleaned = new URLSearchParams(search);
+
+  for (const param of TRADE_LINK_SEARCH_PARAMS) {
+    cleaned.delete(param);
+  }
+
+  if (cleaned.toString() === original.toString()) {
+    return undefined;
+  }
+
+  return cleaned.toString();
+}
+
 export function useTradeParamsProcessor() {
   const setTradeConfig = useSelector(selectTradeboxSetTradeConfig);
   const availableTokensOptions = useSelector(selectTradeboxAvailableTokensOptions);
@@ -64,11 +83,30 @@ export function useTradeParamsProcessor() {
   });
 
   const changingNetwork = useRef(false);
+  const cleanupTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(cleanupTimerRef.current), []);
+
   useEffect(() => {
     if (changingNetwork.current) {
       return;
     }
     changingNetwork.current = true;
+
+    // One pending timer only: rescheduling on every effect pass would keep pushing the cleanup out.
+    const scheduleSearchCleanup = () => {
+      if (cleanupTimerRef.current !== undefined) {
+        return;
+      }
+
+      cleanupTimerRef.current = setTimeout(() => {
+        cleanupTimerRef.current = undefined;
+        const cleanedSearch = getCleanedTradeSearch(history.location.search);
+        if (cleanedSearch !== undefined) {
+          history.replace({ search: cleanedSearch });
+        }
+      }, 2000);
+    };
 
     async function changeNetwork() {
       const { tradeType } = params;
@@ -83,15 +121,10 @@ export function useTradeParamsProcessor() {
       } = searchParams;
 
       if (chainIdFromParams && !isSupportedTradeLinkChainId(chainIdFromParams, chainId)) {
-        const query = new URLSearchParams(history.location.search);
-        query.delete("mode");
-        query.delete("from");
-        query.delete("to");
-        query.delete("market");
-        query.delete("pool");
-        query.delete("collateral");
-        query.delete("chainId");
-        history.replace({ search: query.toString() });
+        const cleanedSearch = getCleanedTradeSearch(history.location.search);
+        if (cleanedSearch !== undefined) {
+          history.replace({ search: cleanedSearch });
+        }
         return;
       }
 
@@ -166,19 +199,7 @@ export function useTradeParamsProcessor() {
             tradeOptions.marketAddress = marketPool?.marketTokenAddress;
           }
         }
-        setTimeout(() => {
-          if (history.location.search) {
-            const query = new URLSearchParams(history.location.search);
-            query.delete("mode");
-            query.delete("from");
-            query.delete("to");
-            query.delete("market");
-            query.delete("pool");
-            query.delete("collateral");
-            query.delete("chainId");
-            history.replace({ search: query.toString() });
-          }
-        }, 2000);
+        scheduleSearchCleanup();
       }
 
       if (!isMatch(latestTradeOptions.current, tradeOptions)) {
@@ -186,19 +207,7 @@ export function useTradeParamsProcessor() {
       }
 
       if (history.location.search && !toToken && !pool) {
-        setTimeout(() => {
-          if (history.location.search) {
-            const query = new URLSearchParams(history.location.search);
-            query.delete("mode");
-            query.delete("from");
-            query.delete("to");
-            query.delete("market");
-            query.delete("pool");
-            query.delete("collateral");
-            query.delete("chainId");
-            history.replace({ search: query.toString() });
-          }
-        }, 2000);
+        scheduleSearchCleanup();
       }
     }
 


### PR DESCRIPTION
Linear: https://linear.app/gmx-io/issue/FEDEV-4237/fix-wallet-connect-in-metamask-in-app-browser-broken-by-path-based

## Summary

Fixes the `history.replaceState` loop in `useTradeParamsProcessor` surfaced by path-based URLs (Datadog: `SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds`, ~42k events since release-123, WebKit-only, 15% of current error volume).

Root cause: any search param outside the consumed set (`utm_source`, `privy_connector`, A/B flags, …) kept `history.location.search` truthy forever. The cleanup effect then called `history.replace` with an identical search string — which still emits a location update, re-runs the effect via the `searchParams` dep, and loops until WebKit's rate limit throws. The scheduled timeouts also had no guard, so every pass stacked another one.

This is the primary suspect for the remaining MetaMask/Trust in-app browser connect failures (FEDEV-4237): the WebKit quota is page-global, so once exhausted, Privy's own `history.replaceState` calls during login throw mid-flow and the modal hangs at "connecting". The affected Datadog cohorts are wallet in-app browser entries (`utm_source=Trust_iOS_Browser`, `utm_source=BitgetWallet`, `privy_connector=injected`).

Fix:
- `getCleanedTradeSearch()` — pure helper returning the search minus consumed trade params, or `undefined` when nothing changes (comparison is on normalized form, so encoding-only differences don't rewrite the URL either). No replace happens when the URL carries only unrelated params — the loop's engine.
- Single-pending timer via ref (`scheduleSearchCleanup`) instead of stacking a new `setTimeout` per effect pass; cleared on unmount.
- Same guard applied to the unsupported-`chainId` branch.

Deep links keep working: consumed params are still applied to the tradebox and stripped from the URL ~2s later; unrelated params are now simply left in place.

If MetaMask in-app connect heals on prod with this, the path-URLs revert (#2782) can stay unmerged; otherwise #2782 remains plan B.

## Testing

- New behavior specs for `getCleanedTradeSearch` (strip + keep-rest, all-consumed → empty string, unrelated-only → `undefined`, empty search, encoding-only no-op) — 7/7 green.
- `yarn tscheck`, eslint, prettier on touched files — clean.
- `yarn test:ci` (app), `yarn test:ct`, SDK `yarn test:ci` — green.
- Instrumented browser check on the built branch (Playwright, `history.replaceState` wrapped with a counter): `/trade?testExampleAb=0&utm_source=Trust_iOS_Browser` (top Datadog cohorts) → **0 calls in 20s**, params left in place; `/trade?to=ETH&utm_source=x` → exactly **1 call**, URL becomes `/trade?utm_source=x` (deep link applied and stripped, unrelated param preserved), no further growth.
