### PR TITLE
Pin every rollout chain to GMX Relay

### DIFF
--- a/src/config/relay.spec.ts
+++ b/src/config/relay.spec.ts
@@ -87,22 +87,29 @@ describe("lazy assignment of the relay split", () => {
     expect(ab.getAbStorage().gmxRelay).toBeUndefined();
   });
 
-  it("assigns on the first submit and the assignment sticks", async () => {
+  // a pinned chain routes everyone without assigning; the coin machinery stays for a revert to "ab"
+  it("routes a pinned chain to gmx without tossing the coin", async () => {
     localStorage.clear();
     vi.resetModules();
-    vi.stubGlobal("crypto", globalThis.crypto);
 
     const ab = await import("config/ab");
     const relay = await import("config/relay");
 
-    const first = relay.getRelayProviderForSubmit(ARBITRUM);
-    const assigned = ab.getAbStorage().gmxRelay;
+    expect(relay.getRelayProviderForSubmit(ARBITRUM)).toBe("gmx");
+    expect(ab.getAbStorage().gmxRelay).toBeUndefined();
+  });
 
-    expect(assigned).toBeDefined();
-    expect(first).toBe(assigned!.enabled ? "gmx" : "gelato");
+  it("tosses the coin once and the assignment sticks", async () => {
+    localStorage.clear();
+    vi.resetModules();
+
+    const ab = await import("config/ab");
+
+    const first = ab.ensureAbFlagRolled("gmxRelay");
+    expect(ab.getAbStorage().gmxRelay).toBeDefined();
 
     for (let i = 0; i < 5; i++) {
-      expect(relay.getRelayProviderForSubmit(ARBITRUM)).toBe(first);
+      expect(ab.ensureAbFlagRolled("gmxRelay")).toBe(first);
     }
   });
 });

--- a/src/config/relay.ts
+++ b/src/config/relay.ts
@@ -14,10 +14,12 @@ const rawEnvRelayProvider = import.meta.env.VITE_APP_RELAY_PROVIDER;
 const ENV_RELAY_PROVIDER: RelayProvider | undefined =
   rawEnvRelayProvider === "gmx" || rawEnvRelayProvider === "gelato" ? rawEnvRelayProvider : undefined;
 
+// pinned after the split proved parity: reverting a chain to "ab" restores the 30/70 experiment,
+// and `forceGelatoFallback` remains the instant incident switch above every pin
 const RELAY_ROLLOUT: Partial<Record<ContractsChainId, RelayRollout>> = {
-  [ARBITRUM]: "ab",
-  [AVALANCHE]: "ab",
-  [MEGAETH]: "ab",
+  [ARBITRUM]: "gmx",
+  [AVALANCHE]: "gmx",
+  [MEGAETH]: "gmx",
 };
 
 export function resolveRelayProvider(rollout: RelayRollout | undefined, isAbEnabled: boolean): RelayProvider {

--- a/src/context/SyntheticsStateContext/selectors/__tests__/expressSelectors.spec.ts
+++ b/src/context/SyntheticsStateContext/selectors/__tests__/expressSelectors.spec.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { setAbFlagEnabled } from "config/ab";
 import { ARBITRUM } from "config/chains";
-import { IS_EXPRESS_AVAILABLE_UI_FLAG } from "domain/synthetics/uiFlags/useUiFlagsRequest";
+import {
+  FORCE_GELATO_FALLBACK_UI_FLAG,
+  IS_EXPRESS_AVAILABLE_UI_FLAG,
+} from "domain/synthetics/uiFlags/useUiFlagsRequest";
 
 import { SyntheticsState } from "../../SyntheticsStateContextProvider";
 import { selectIsExpressTransactionAvailable } from "../expressSelectors";
@@ -10,9 +12,11 @@ import { selectIsExpressTransactionAvailable } from "../expressSelectors";
 function makeState({
   isSponsoredCallAllowed,
   isExpressAvailable,
+  isGelatoForced = false,
 }: {
   isSponsoredCallAllowed: boolean;
   isExpressAvailable: boolean;
+  isGelatoForced?: boolean;
 }): SyntheticsState {
   return {
     globals: { chainId: ARBITRUM },
@@ -21,42 +25,37 @@ function makeState({
     sponsoredCallBalanceData: { isSponsoredCallAllowed },
     uiFlags: {
       [IS_EXPRESS_AVAILABLE_UI_FLAG]: { enabled: isExpressAvailable, createdAt: "", updatedAt: "" },
+      [FORCE_GELATO_FALLBACK_UI_FLAG]: { enabled: isGelatoForced, createdAt: "", updatedAt: "" },
     },
   } as unknown as SyntheticsState;
 }
 
+// with every chain pinned to GMX Relay, the only Gelato users left are the ones the incident
+// switch moved there — so the Gelato cases arrange themselves through that switch
 describe("selectIsExpressTransactionAvailable", () => {
-  afterEach(() => {
-    setAbFlagEnabled("gmxRelay", false);
-  });
-
   describe("on GMX Relay", () => {
     it("survives an empty Gelato sponsor balance", () => {
-      setAbFlagEnabled("gmxRelay", true);
-
       const state = makeState({ isSponsoredCallAllowed: false, isExpressAvailable: true });
 
       expect(selectIsExpressTransactionAvailable(state)).toBe(true);
     });
 
     it("is taken away by our own kill switch", () => {
-      setAbFlagEnabled("gmxRelay", true);
-
       const state = makeState({ isSponsoredCallAllowed: true, isExpressAvailable: false });
 
       expect(selectIsExpressTransactionAvailable(state)).toBe(false);
     });
   });
 
-  describe("on Gelato", () => {
+  describe("on Gelato via the incident switch", () => {
     it("is taken away by an empty Gelato sponsor balance", () => {
-      const state = makeState({ isSponsoredCallAllowed: false, isExpressAvailable: true });
+      const state = makeState({ isSponsoredCallAllowed: false, isExpressAvailable: true, isGelatoForced: true });
 
       expect(selectIsExpressTransactionAvailable(state)).toBe(false);
     });
 
     it("survives our kill switch", () => {
-      const state = makeState({ isSponsoredCallAllowed: true, isExpressAvailable: false });
+      const state = makeState({ isSponsoredCallAllowed: true, isExpressAvailable: false, isGelatoForced: true });
 
       expect(selectIsExpressTransactionAvailable(state)).toBe(true);
     });

--- a/src/lib/transactions/sendExpressTransaction.spec.ts
+++ b/src/lib/transactions/sendExpressTransaction.spec.ts
@@ -1,15 +1,19 @@
 import { StatusCode as appGaslessStatusCode } from "@gelatocloud/gasless";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-import { setAbFlagEnabled } from "config/ab";
 import { ARBITRUM } from "config/chains";
+import { API_UI_FLAGS_CACHE_KEY } from "config/localStorage";
+import { FORCE_GELATO_FALLBACK_UI_FLAG } from "domain/synthetics/uiFlags/uiFlags";
 import { sendExpressTransaction } from "lib/transactions/sendExpressTransaction";
 import { StatusCode as sdkGaslessStatusCode } from "sdk/utils/gelatoRelay";
 
 describe("@gelatocloud/gasless dedupe", () => {
-  // the rollout flag rolls randomly per browser; unpinned, this Gelato-path spec inherits the roll
+  // with the rollout pinned to gmx, the incident switch is what still routes a user to Gelato
   beforeAll(() => {
-    setAbFlagEnabled("gmxRelay", false);
+    localStorage.setItem(
+      `${API_UI_FLAGS_CACHE_KEY}-${ARBITRUM}`,
+      JSON.stringify({ [FORCE_GELATO_FALLBACK_UI_FLAG]: { enabled: true, createdAt: "", updatedAt: "" } })
+    );
   });
   it("app and sdk imports resolve to the same module instance", () => {
     expect(sdkGaslessStatusCode).toBe(appGaslessStatusCode);


### PR DESCRIPTION
## What

Sets `RELAY_ROLLOUT` to `gmx` for Arbitrum, Avalanche and MegaETH — every express operation now routes through GMX Relay.

## Why

Two days of the 30% split showed parity or better on everything except latency: split landed at 32-35% of unique senders, relayer failures at 0.2%/day after the fee cluster cleared, execution latency identical to Gelato (3534ms median both arms), and our submit path loses 5x fewer operations than Gelato's. The remaining ~1.4s acceptance+broadcast gap is keeper-side tuning, tracked separately.

Pinning (rather than raising the ab share to 1) also removes the post-Gelato-shutdown trap: an unassigned browser under an "ab" rollout reads as a Gelato user, gets availability-gated by Gelato's dead sponsor tank, and can never earn an assignment. A pin routes everyone by config.

## Rollback semantics

- `forceGelatoFallback` ui-flag remains the instant incident switch and outranks the pin (covered by tests).
- Reverting a chain to `"ab"` restores the 30/70 experiment: the coin-toss machinery and the `gmxRelay: 0.3` config stay in place, untouched.

## Testing

Existing relay suites reworked for the pinned world: a pinned chain routes without tossing the coin, the coin machinery keeps its own tests, and the Gelato-side selector/dedupe specs now arrange their Gelato user through the incident switch — which is the only way one exists after this change.