### PR TITLE
Route the deactivation CT spec through the incident switch

### DIFF
--- a/src/components/SettingsModal/__tests__/OneClickMultichainDeactivation.ct.spec.tsx
+++ b/src/components/SettingsModal/__tests__/OneClickMultichainDeactivation.ct.spec.tsx
@@ -92,6 +92,16 @@ test.describe("Trading Settings: multichain Express+1CT -> Express deactivation 
     gelatoRelay.simulateInsufficientBalanceForToken = ARBITRUM_WETH_ADDRESS;
     await installRpcResponder(page, chain, { gelatoRelay });
 
+    // the rollout pins express to GMX Relay; this spec is about the deactivation UX, and its
+    // harness speaks Gelato — route through the incident switch until the sunset cleanup moves
+    // the harness onto /v1/relay/*
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "api-ui-flags-cache-v2-42161",
+        JSON.stringify({ forceGelatoFallback: { enabled: true, createdAt: "", updatedAt: "" } })
+      );
+    });
+
     await mount(
       <OneClickMultichainDeactivationStory
         seedSubaccountAddress={SEEDED_SUBACCOUNT_ADDRESS}


### PR DESCRIPTION
## What

The pinned rollout (#2784) routes every express operation to GMX Relay, so the FEDEV-2133 deactivation CT spec — whose harness answers Gelato's relay methods — sent its submit into a mock that never replies and failed on both branches.

The spec now seeds the `forceGelatoFallback` incident switch into localStorage before mounting, which is the one honest way a Gelato user still exists under the pin. The spec tests the deactivation UX, not the transport; the harness moves onto `/v1/relay/*` as part of the Gelato sunset cleanup, where these mocks get rewritten anyway.

Verified locally: the spec passes in 4.7s; it was the only failure in the CT suite (198 passed).