### PR TITLE
Cancel conditional margin deposits on full position close FEDEV-4252

### DIFF
--- a/src/components/PositionSeller/PositionSeller.tsx
+++ b/src/components/PositionSeller/PositionSeller.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from "@lingui/macro";
+import { Plural, t, Trans } from "@lingui/macro";
 import cx from "classnames";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useKey, useLatest } from "react-use";
@@ -24,6 +24,7 @@ import {
   selectBlockTimestampData,
   selectMarketsInfoData,
 } from "context/SyntheticsStateContext/selectors/globalSelectors";
+import { makeSelectOrdersByPositionKey } from "context/SyntheticsStateContext/selectors/orderSelectors";
 import {
   selectPositionSellerAvailableReceiveTokens,
   selectPositionSellerDecreaseAmounts,
@@ -49,6 +50,7 @@ import {
   reportMultichainExpressSubmitError,
 } from "domain/synthetics/express/validateMultichainExpressSubmit";
 import { OrderType } from "domain/synthetics/orders";
+import { getMarginDepositCancelOrderParams } from "domain/synthetics/orders/marginDeposit";
 import { sendBatchOrderTxn } from "domain/synthetics/orders/sendBatchOrderTxn";
 import { useOrderTxnCallbacks } from "domain/synthetics/orders/useOrderTxnCallbacks";
 import { formatLeverage, formatLiquidationPrice } from "domain/synthetics/positions";
@@ -87,6 +89,7 @@ import {
   formatUsd,
   parseValue,
 } from "lib/numbers";
+import { EMPTY_ARRAY } from "lib/objects";
 import { useJsonRpcProvider } from "lib/rpc";
 import { useHasOutdatedUi } from "lib/useHasOutdatedUi";
 import { userAnalytics } from "lib/userAnalytics";
@@ -280,6 +283,13 @@ export function PositionSeller() {
   const markPrice = useSelector(selectPositionSellerMarkPrice);
   const { maxLiquidity: maxSwapLiquidity } = useSelector(selectPositionSellerMaxLiquidityPath);
   const decreaseAmounts = useSelector(selectPositionSellerDecreaseAmounts);
+  const positionOrders = useSelector(makeSelectOrdersByPositionKey(position?.key));
+
+  // only market 100% closes: a TWAP close executes over a window where the deposit still protects the position
+  const marginDepositCancelParams = useMemo(
+    () => (isMarket && decreaseAmounts?.isFullClose ? getMarginDepositCancelOrderParams(positionOrders) : EMPTY_ARRAY),
+    [isMarket, decreaseAmounts?.isFullClose, positionOrders]
+  );
 
   useDebugExecutionPrice(chainId, {
     skip: true,
@@ -427,7 +437,7 @@ export function PositionSeller() {
     return {
       createOrderParams,
       updateOrderParams: [],
-      cancelOrderParams: [],
+      cancelOrderParams: marginDepositCancelParams,
     };
   }, [
     account,
@@ -443,6 +453,7 @@ export function PositionSeller() {
     executionFee?.gasLimit,
     isMarket,
     isTwap,
+    marginDepositCancelParams,
     marketsInfoData,
     numberOfParts,
     position,
@@ -1193,6 +1204,16 @@ export function PositionSeller() {
                 {twapSplitReceiveSwapProfitFeeWarning && (
                   <AlertInfoCard type="warning" hideClose>
                     {twapSplitReceiveSwapProfitFeeWarning}
+                  </AlertInfoCard>
+                )}
+
+                {marginDepositCancelParams.length > 0 && (
+                  <AlertInfoCard hideClose>
+                    <Plural
+                      value={marginDepositCancelParams.length}
+                      one="Closing will also cancel your pending margin deposit and return its funds."
+                      other="Closing will also cancel your # pending margin deposits and return their funds."
+                    />
                   </AlertInfoCard>
                 )}
 

--- a/src/domain/synthetics/orders/__tests__/marginDeposit.spec.ts
+++ b/src/domain/synthetics/orders/__tests__/marginDeposit.spec.ts
@@ -5,7 +5,12 @@ import { mockPositionInfo } from "domain/synthetics/testUtils/mocks";
 import { expandDecimals } from "lib/numbers";
 import { mockMarketsInfoData, mockTokensData } from "sdk/test/mock";
 
-import { getMarginDepositProjections, getMarginDepositRiskLevel, isMarginDepositOrder } from "../marginDeposit";
+import {
+  getMarginDepositCancelOrderParams,
+  getMarginDepositProjections,
+  getMarginDepositRiskLevel,
+  isMarginDepositOrder,
+} from "../marginDeposit";
 import { OrderType } from "../types";
 
 const tokensData = mockTokensData();
@@ -67,6 +72,55 @@ describe("isMarginDepositOrder", () => {
         isTwap: true,
       })
     ).toBe(false);
+  });
+});
+
+describe("getMarginDepositCancelOrderParams", () => {
+  const depositOrder = {
+    key: "0xdeposit",
+    orderType: OrderType.LimitIncrease,
+    sizeDeltaUsd: 0n,
+    initialCollateralDeltaAmount: expandDecimals(100, 6),
+  };
+  const stopLossOrder = {
+    key: "0xstopLoss",
+    orderType: OrderType.StopLossDecrease,
+    sizeDeltaUsd: usd(1000),
+    initialCollateralDeltaAmount: 0n,
+  };
+  const limitIncreaseOrder = {
+    key: "0xlimitIncrease",
+    orderType: OrderType.LimitIncrease,
+    sizeDeltaUsd: usd(1000),
+    initialCollateralDeltaAmount: expandDecimals(100, 6),
+  };
+  const twapDepositLikeOrder = {
+    key: "0xtwap",
+    orderType: OrderType.LimitIncrease,
+    sizeDeltaUsd: 0n,
+    initialCollateralDeltaAmount: expandDecimals(100, 6),
+    isTwap: true,
+  };
+
+  it("cancels only margin deposits, leaving TP/SL and regular increases untouched", () => {
+    expect(
+      getMarginDepositCancelOrderParams([stopLossOrder, depositOrder, limitIncreaseOrder, twapDepositLikeOrder])
+    ).toEqual([{ orderKey: "0xdeposit" }]);
+  });
+
+  it("cancels every margin deposit of the position", () => {
+    expect(getMarginDepositCancelOrderParams([depositOrder, { ...depositOrder, key: "0xdeposit2" }])).toEqual([
+      { orderKey: "0xdeposit" },
+      { orderKey: "0xdeposit2" },
+    ]);
+  });
+
+  it("cancels nothing when the position has no margin deposits", () => {
+    expect(getMarginDepositCancelOrderParams([stopLossOrder, limitIncreaseOrder])).toEqual([]);
+  });
+
+  it("cancels nothing when the position has no orders", () => {
+    expect(getMarginDepositCancelOrderParams([])).toEqual([]);
   });
 });
 

--- a/src/domain/synthetics/orders/__tests__/utils.spec.ts
+++ b/src/domain/synthetics/orders/__tests__/utils.spec.ts
@@ -249,7 +249,7 @@ describe("getOrderErrors — margin deposit orders", () => {
     expect(result.level).toBeUndefined();
   });
 
-  it("returns the red state and skips the standard increase checks when no position matches", () => {
+  it("reports an orphaned deposit and skips the standard increase checks when no position matches", () => {
     const otherCollateralPosition = mockPositionInfo({
       marketInfo,
       collateralTokenAddress: tokensData.BTC.address,
@@ -267,7 +267,19 @@ describe("getOrderErrors — margin deposit orders", () => {
     });
 
     // the standard path would add the "collateralToken" mismatch warning here
-    expect(errorKeys(result)).toEqual(["marginDepositInsufficient"]);
+    expect(errorKeys(result)).toEqual(["marginDepositNoPosition"]);
+    expect(result.level).toBe("error");
+  });
+
+  it("reports an orphaned deposit when the account has no positions at all", () => {
+    const result = getOrderErrors({
+      ...depositParams,
+      positionsInfoData: {},
+      order: makeDepositOrder(),
+    });
+
+    expect(errorKeys(result)).toEqual(["marginDepositNoPosition"]);
+    expect(result.level).toBe("error");
   });
 
   it("stays silent while positions are still loading", () => {

--- a/src/domain/synthetics/orders/marginDeposit.ts
+++ b/src/domain/synthetics/orders/marginDeposit.ts
@@ -1,5 +1,6 @@
 import { maxUint256 } from "viem";
 
+import type { CancelOrderTxnParams } from "sdk/utils/orderTransactions";
 import type { UserReferralInfo } from "sdk/utils/referrals/types";
 
 import { OrderType } from "./types";
@@ -23,6 +24,13 @@ export function isMarginDepositOrder(order: MarginDepositOrderLike): boolean {
   return (
     order.orderType === OrderType.LimitIncrease && order.sizeDeltaUsd === 0n && order.initialCollateralDeltaAmount > 0n
   );
+}
+
+/** Contracts auto-cancel only decrease orders, so a full close cancels margin deposits in the same batch. */
+export function getMarginDepositCancelOrderParams(
+  positionOrders: (MarginDepositOrderLike & { key: string })[]
+): CancelOrderTxnParams[] {
+  return positionOrders.filter((order) => isMarginDepositOrder(order)).map((order) => ({ orderKey: order.key }));
 }
 
 /** Index-token collateral follows the trigger price at execution, so the deposit is valued there. */

--- a/src/domain/synthetics/orders/utils.tsx
+++ b/src/domain/synthetics/orders/utils.tsx
@@ -103,25 +103,31 @@ function getMarginDepositOrderErrors(p: {
 
   const position = Object.values(positionsInfoData).find((pos) => isOrderForPosition(order, pos.key));
 
-  let riskLevel: ReturnType<typeof getMarginDepositRiskLevel> = "insufficient";
-
-  if (position) {
-    const projections = getMarginDepositProjections({
-      position,
-      depositAmount: order.initialCollateralDeltaAmount,
-      triggerPrice: order.triggerPrice,
-      minCollateralUsd,
-      userReferralInfo,
-      pendingFeesUsd: position.pendingBorrowingFeesUsd + position.pendingFundingFeesUsd,
-    });
-
-    riskLevel = getMarginDepositRiskLevel({
-      isLong: order.isLong,
-      triggerPrice: order.triggerPrice,
-      currentLiqPrice: position.liquidationPrice,
-      nextLiqPrice: projections?.nextLiqPrice,
-    });
+  if (!position) {
+    return [
+      {
+        msg: t`This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds.`,
+        level: "error",
+        key: "marginDepositNoPosition",
+      },
+    ];
   }
+
+  const projections = getMarginDepositProjections({
+    position,
+    depositAmount: order.initialCollateralDeltaAmount,
+    triggerPrice: order.triggerPrice,
+    minCollateralUsd,
+    userReferralInfo,
+    pendingFeesUsd: position.pendingBorrowingFeesUsd + position.pendingFundingFeesUsd,
+  });
+
+  const riskLevel = getMarginDepositRiskLevel({
+    isLong: order.isLong,
+    triggerPrice: order.triggerPrice,
+    currentLiqPrice: position.liquidationPrice,
+    nextLiqPrice: projections?.nextLiqPrice,
+  });
 
   if (riskLevel === "insufficient") {
     return [

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4399,6 +4399,10 @@ msgstr "Plätze 4–18"
 msgid "Set acceptable price impact"
 msgstr "Akzeptablen Preiseinfluss festlegen"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "Die Position dieser Margin-Einzahlung wurde geschlossen, aber die Einzahlung ist weiterhin aktiv. Brechen Sie sie ab, um die Mittel zurückzuerhalten."
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}s"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "Meine Erträge"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {Beim Schließen wird auch Ihre ausstehende Margin-Einzahlung abgebrochen und die Mittel zurückerstattet.} other {Beim Schließen werden auch Ihre # ausstehenden Margin-Einzahlungen abgebrochen und die Mittel zurückerstattet.}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4399,6 +4399,10 @@ msgstr "4-18 places"
 msgid "Set acceptable price impact"
 msgstr "Set acceptable price impact"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}s"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "My earnings"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4399,6 +4399,10 @@ msgstr "Puestos 4-18"
 msgid "Set acceptable price impact"
 msgstr "Establecer impacto en el precio aceptable"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "La posición de este depósito de margen se cerró, pero el depósito sigue activo. Cancélalo para recuperar sus fondos."
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}s"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "Mis ganancias"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {Al cerrar también se cancelará tu depósito de margen pendiente y se devolverán sus fondos.} other {Al cerrar también se cancelarán tus # depósitos de margen pendientes y se devolverán sus fondos.}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4399,6 +4399,10 @@ msgstr "4e-18e places"
 msgid "Set acceptable price impact"
 msgstr "Définir l'impact sur le prix acceptable"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "La position de ce dépôt de marge a été clôturée, mais le dépôt est toujours actif. Annulez-le pour récupérer ses fonds."
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}s"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "Mes gains"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {La clôture annulera également votre dépôt de marge en attente et restituera ses fonds.} other {La clôture annulera également vos # dépôts de marge en attente et restituera leurs fonds.}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4399,6 +4399,10 @@ msgstr "4〜18位"
 msgid "Set acceptable price impact"
 msgstr "許容可能な価格への影響を設定する"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "この証拠金入金のポジションは決済されましたが、入金は引き続き有効です。キャンセルして資金を回収してください。"
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}秒"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "収益"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {決済すると、保留中の証拠金入金もキャンセルされ、資金が返却されます。} other {決済すると、保留中の#件の証拠金入金もキャンセルされ、資金が返却されます。}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4399,6 +4399,10 @@ msgstr "4-18위"
 msgid "Set acceptable price impact"
 msgstr "허용 가격 영향 설정"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "이 증거금 예치의 포지션이 종료되었지만 예치는 여전히 활성 상태입니다. 예치를 취소하여 자금을 회수하세요."
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}초"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "내 수익"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {포지션을 종료하면 대기 중인 증거금 예치도 취소되고 자금이 반환됩니다.} other {포지션을 종료하면 대기 중인 #건의 증거금 예치도 취소되고 자금이 반환됩니다.}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4399,6 +4399,10 @@ msgstr ""
 msgid "Set acceptable price impact"
 msgstr ""
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr ""
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11897,6 +11901,10 @@ msgstr ""
 
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
+msgstr ""
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
 msgstr ""
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4399,6 +4399,10 @@ msgstr "4–18 места"
 msgid "Set acceptable price impact"
 msgstr "Установить допустимое влияние на цену"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "Позиция этого депозита маржи была закрыта, но депозит всё ещё активен. Отмените его, чтобы вернуть средства."
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}с"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "Мой доход"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {При закрытии также будет отменён ожидающий депозит маржи, а его средства возвращены.} other {При закрытии также будут отменены # ожидающих депозитов маржи, а их средства возвращены.}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4399,6 +4399,10 @@ msgstr "第 4-18 名"
 msgid "Set acceptable price impact"
 msgstr "設定可接受的價格影響"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "該保證金存入的倉位已平倉，但存入仍處於活躍狀態。請取消該訂單以取回資金。"
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}s"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "我的收益"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {平倉時也會取消您待處理的保證金存入並退回其資金。} other {平倉時也會取消您 # 筆待處理的保證金存入並退回其資金。}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4399,6 +4399,10 @@ msgstr "第 4-18 名"
 msgid "Set acceptable price impact"
 msgstr "设置可接受的价格影响"
 
+#: src/domain/synthetics/orders/utils.tsx
+msgid "This margin deposit's position was closed, but the deposit is still active. Cancel it to reclaim its funds."
+msgstr "该保证金存入的仓位已平仓，但存入仍处于活跃状态。请取消该订单以取回资金。"
+
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
 #: src/components/GmxAccountModal/WalletSendView.tsx
@@ -11898,6 +11902,10 @@ msgstr "{idleSeconds}s"
 #: src/components/Earn/Portfolio/EarningsOverview/MyEarningsCard.tsx
 msgid "My earnings"
 msgstr "我的收益"
+
+#: src/components/PositionSeller/PositionSeller.tsx
+msgid "{0, plural, one {Closing will also cancel your pending margin deposit and return its funds.} other {Closing will also cancel your # pending margin deposits and return their funds.}}"
+msgstr "{0, plural, one {平仓时也会取消您待处理的保证金存入并退回其资金。} other {平仓时也会取消您 # 笔待处理的保证金存入并退回其资金。}}"
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Indices"


### PR DESCRIPTION
Fixes the interface half of [FEDEV-4252](https://linear.app/gmx-io/issue/FEDEV-4252/bug-conditional-margin-deposits-remain-active-after-position-close).

Conditional margin deposits are submitted as zero-size `LimitIncrease` orders with `autoCancel: true`, but `OrderUtils.updateAutoCancelList` registers only `LimitDecrease` and `StopLossDecrease` in the per-position auto-cancel list. The flag is stored on the order and never acted on, so closing a position leaves the deposit active with its collateral reserved, and it can later be evaluated against a position reopened with the same market, collateral token and direction.

The complete fix is in gmx-synthetics and is **not** in this PR (see below). This is the interface mitigation.

## Changes

- **Market 100% close cancels the position's margin deposits** in the same batch as the close order, refunding reserved collateral and unused execution fee through the normal cancel flow. The close modal shows a notice when this will happen. New domain helper `getMarginDepositCancelOrderParams` reuses `isMarginDepositOrder` and the existing `makeSelectOrdersByPositionKey` selector.
- **Orphaned deposits get honest copy on the Orders tab.** `getMarginDepositOrderErrors` defaulted its risk level to `insufficient` when no position matched, so an orphan showed "would not leave the position above the liquidation requirement at the trigger price" — advice that cannot help. It now returns a dedicated `marginDepositNoPosition` error telling the user to cancel and reclaim the funds.

### Scope decisions

- **Only market closes at 100%.** Partial closes leave deposits alone (the position survives). TWAP closes are excluded deliberately: a TWAP executes over a window during which the deposit still protects the position, and it can be cancelled midway.
- **Cancels are submitted, not deferred.** They ride in the transaction that creates the close order, so if that close later fails at execution the deposits are already cancelled. Recreating a deposit is cheap; orphaned reserved collateral is not.
- Ordinary size-increasing `LimitIncrease` and Stop Market orders are untouched, and the "Auto-cancel TP/SL" setting is not involved.

## Testing

- New unit specs for `getMarginDepositCancelOrderParams`: only deposits are selected out of a mixed TP/SL + limit-increase + TWAP order set, multiple deposits on one position, no deposits, and an empty order list.
- New specs in `utils.spec.ts` for the orphan error: no matching position at all, and a same-market position with different collateral (which must not fall back to the standard increase checks).
- Full app suite (1602 passed), component tests, SDK suite (617 passed), `tscheck`, eslint and prettier all pass.
- Both new strings are translated in all 9 locales; `lingui compile` passes.

Not browser-verified: exercising this needs an open position with a pending conditional deposit on a funded account, so the close-modal notice has not been visually confirmed in-app.

## Follow-ups (not in this PR)

- **gmx-synthetics** must widen the auto-cancel lifecycle for this to cover liquidations, keeper-executed closes and closes made elsewhere: accept `LimitIncrease && sizeDeltaUsd == 0 && swapPath.length == 0` in `updateAutoCancelList` and `validateTotalCallbackGasLimitForAutoCancelOrders`, derive a position key for that shape in `BaseOrderUtils.getPositionKey`, make `OrderHandler.updateOrder` resync list membership idempotently from post-update state, and backfill orders created before the upgrade. No SC ticket filed yet.
- **SDK:** `getBatchOrderMulticallPayload` executes creates before cancels. Once the on-chain cap counts deposits, replacing one at the limit would revert with `MaxAutoCancelOrdersExceeded` before the cancel runs; cancels should be reordered ahead of creates.
