### PR TITLE
Apply trade deep link params instead of dropping them FEDEV-4258

### DIFF
--- a/src/domain/synthetics/trade/useTradeParamsProcessor.spec.ts
+++ b/src/domain/synthetics/trade/useTradeParamsProcessor.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import { ARBITRUM, AVALANCHE } from "config/chains";
+import { TradeType } from "sdk/utils/trade/types";
 
-import { getCleanedTradeSearch, isSupportedTradeLinkChainId } from "./useTradeParamsProcessor";
+import { getCleanedTradeSearch, getTradeLinkTradeType, isSupportedTradeLinkChainId } from "./useTradeParamsProcessor";
 
 describe("isSupportedTradeLinkChainId", () => {
   it("accepts supported settlement-chain links", () => {
@@ -34,5 +35,27 @@ describe("getCleanedTradeSearch", () => {
 
   it("ignores encoding-only differences instead of rewriting the url forever", () => {
     expect(getCleanedTradeSearch("?utm_content=a%20b")).toBe(undefined);
+  });
+});
+
+describe("getTradeLinkTradeType", () => {
+  it("takes the trade type from the path", () => {
+    expect(getTradeLinkTradeType("short", TradeType.Long)).toBe(TradeType.Short);
+  });
+
+  it("matches the path trade type case-insensitively", () => {
+    expect(getTradeLinkTradeType("SWAP", TradeType.Long)).toBe(TradeType.Swap);
+  });
+
+  it("falls back to the current trade type when the link carries none", () => {
+    expect(getTradeLinkTradeType(undefined, TradeType.Short)).toBe(TradeType.Short);
+  });
+
+  it("falls back to the current trade type when the link carries an unknown one", () => {
+    expect(getTradeLinkTradeType("perp", TradeType.Swap)).toBe(TradeType.Swap);
+  });
+
+  it("stays undefined while the tradebox has no trade type yet", () => {
+    expect(getTradeLinkTradeType(undefined, undefined)).toBeUndefined();
   });
 });

--- a/src/domain/synthetics/trade/useTradeParamsProcessor.ts
+++ b/src/domain/synthetics/trade/useTradeParamsProcessor.ts
@@ -63,6 +63,25 @@ export function getCleanedTradeSearch(search: string): string | undefined {
   return cleaned.toString();
 }
 
+/**
+ * `/trade?to=BTC` carries no trade type in the path, so such a link has to be resolved against the
+ * one the tradebox is already on — otherwise `to` matches neither token list and is dropped unapplied.
+ */
+export function getTradeLinkTradeType(
+  tradeTypeFromPath: string | undefined,
+  currentTradeType: TradeType | undefined
+): TradeType | undefined {
+  if (tradeTypeFromPath) {
+    const validTradeType = getMatchingValueFromObject(TradeType, tradeTypeFromPath);
+
+    if (validTradeType) {
+      return validTradeType as TradeType;
+    }
+  }
+
+  return currentTradeType;
+}
+
 export function useTradeParamsProcessor() {
   const setTradeConfig = useSelector(selectTradeboxSetTradeConfig);
   const availableTokensOptions = useSelector(selectTradeboxAvailableTokensOptions);
@@ -134,13 +153,12 @@ export function useTradeParamsProcessor() {
 
       const toToken = to ?? market;
 
+      const linkTradeType = getTradeLinkTradeType(tradeType, latestTradeOptions.current.tradeType);
+
       const tradeOptions: TradeOptions = {};
 
-      if (tradeType) {
-        const validTradeType = getMatchingValueFromObject(TradeType, tradeType);
-        if (validTradeType) {
-          tradeOptions.tradeType = validTradeType as TradeType;
-        }
+      if (linkTradeType) {
+        tradeOptions.tradeType = linkTradeType;
       }
 
       if (tradeMode) {
@@ -178,9 +196,8 @@ export function useTradeParamsProcessor() {
         });
 
         if (toTokenInfo) {
-          const isSwapTrade = tradeOptions.tradeType === TradeType.Swap;
-          const isLongOrShortTrade =
-            tradeOptions.tradeType === TradeType.Long || tradeOptions.tradeType === TradeType.Short;
+          const isSwapTrade = linkTradeType === TradeType.Swap;
+          const isLongOrShortTrade = linkTradeType === TradeType.Long || linkTradeType === TradeType.Short;
           const isTokenInSwapList = isSwapTrade && isTokenInList(toTokenInfo, swapTokens);
           const isTokenInIndexList = isLongOrShortTrade && isTokenInList(toTokenInfo, indexTokens);
 

--- a/src/domain/synthetics/trade/useTradeParamsProcessor.ts
+++ b/src/domain/synthetics/trade/useTradeParamsProcessor.ts
@@ -63,10 +63,7 @@ export function getCleanedTradeSearch(search: string): string | undefined {
   return cleaned.toString();
 }
 
-/**
- * `/trade?to=BTC` carries no trade type in the path, so such a link has to be resolved against the
- * one the tradebox is already on — otherwise `to` matches neither token list and is dropped unapplied.
- */
+// A link without a trade type in the path is resolved against the one the tradebox is already on.
 export function getTradeLinkTradeType(
   tradeTypeFromPath: string | undefined,
   currentTradeType: TradeType | undefined
@@ -104,7 +101,13 @@ export function useTradeParamsProcessor() {
   const changingNetwork = useRef(false);
   const cleanupTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
-  useEffect(() => () => clearTimeout(cleanupTimerRef.current), []);
+  useEffect(
+    () => () => {
+      clearTimeout(cleanupTimerRef.current);
+      cleanupTimerRef.current = undefined;
+    },
+    []
+  );
 
   useEffect(() => {
     if (changingNetwork.current) {
@@ -114,7 +117,7 @@ export function useTradeParamsProcessor() {
 
     // One pending timer only: rescheduling on every effect pass would keep pushing the cleanup out.
     const scheduleSearchCleanup = () => {
-      if (cleanupTimerRef.current !== undefined) {
+      if (cleanupTimerRef.current !== undefined || getCleanedTradeSearch(history.location.search) === undefined) {
         return;
       }
 
@@ -223,14 +226,17 @@ export function useTradeParamsProcessor() {
         setTradeConfig(tradeOptions);
       }
 
-      if (history.location.search && !toToken && !pool) {
+      if (history.location.search && !toToken) {
         scheduleSearchCleanup();
       }
     }
 
-    changeNetwork().then(() => {
-      changingNetwork.current = false;
-    });
+    changeNetwork()
+      // A declined network switch must not latch the guard.
+      .catch(() => undefined)
+      .then(() => {
+        changingNetwork.current = false;
+      });
   }, [
     params,
     searchParams,

--- a/src/domain/synthetics/trade/useTradeboxState.ts
+++ b/src/domain/synthetics/trade/useTradeboxState.ts
@@ -183,7 +183,12 @@ export function useTradeboxState(
         localStorage.setItem(JSON.stringify(getSyntheticsTradeOptionsKey(chainId)), JSON.stringify(newState));
 
         if (latestEnabled.current && newState.tradeType !== oldState.tradeType) {
-          latestHistory.current.replace(`/trade/${newState.tradeType.toLowerCase()}`);
+          latestHistory.current.replace({
+            pathname: `/trade/${newState.tradeType.toLowerCase()}`,
+            // Deep link params (`?to=`, `?pool=`, `?collateral=`) are only applied once markets load,
+            // and this sync runs before that — replacing the path alone would drop them unapplied.
+            search: latestHistory.current.location.search,
+          });
         }
         return newState;
       });
@@ -225,8 +230,11 @@ export function useTradeboxState(
         return;
       }
 
-      setStoredOptionsOnChain({
+      setStoredOptionsOnChain((oldState) => ({
         ...INITIAL_SYNTHETICS_TRADE_OPTIONS_STATE,
+        // A `/trade/short` link is applied before the chain defaults resolve, so falling back to the
+        // initial trade type here would bounce a first-time visitor back to long.
+        tradeType: oldState.tradeType,
         markets: {
           [market.indexTokenAddress]: {
             long: market.marketTokenAddress,
@@ -237,7 +245,7 @@ export function useTradeboxState(
           indexTokenAddress: market.indexTokenAddress,
           fromTokenAddress: market.shortTokenAddress,
         },
-      });
+      }));
       setSyncedChainId(chainId);
     },
     [

--- a/src/domain/synthetics/trade/useTradeboxState.ts
+++ b/src/domain/synthetics/trade/useTradeboxState.ts
@@ -185,8 +185,7 @@ export function useTradeboxState(
         if (latestEnabled.current && newState.tradeType !== oldState.tradeType) {
           latestHistory.current.replace({
             pathname: `/trade/${newState.tradeType.toLowerCase()}`,
-            // Deep link params (`?to=`, `?pool=`, `?collateral=`) are only applied once markets load,
-            // and this sync runs before that — replacing the path alone would drop them unapplied.
+            // The search still carries deep link params here, they are applied once markets load.
             search: latestHistory.current.location.search,
           });
         }
@@ -232,9 +231,8 @@ export function useTradeboxState(
 
       setStoredOptionsOnChain((oldState) => ({
         ...INITIAL_SYNTHETICS_TRADE_OPTIONS_STATE,
-        // A `/trade/short` link is applied before the chain defaults resolve, so falling back to the
-        // initial trade type here would bounce a first-time visitor back to long.
-        tradeType: oldState.tradeType,
+        // A `/trade/short` link is applied before the chain defaults resolve, so keep its trade type.
+        tradeType: oldState.tradeType ?? INITIAL_SYNTHETICS_TRADE_OPTIONS_STATE.tradeType,
         markets: {
           [market.indexTokenAddress]: {
             long: market.marketTokenAddress,


### PR DESCRIPTION
Trade deep links lost their query params a moment after load and never applied what they asked for. Reproduced on `release` and identically on prod.

Three independent causes, all reproducible on a **fresh browser profile** — the stored trade type defaults to Long, which is why `#/trade/long?to=X` happened to work and the bug looked intermittent:

- **The trade-type → path sync wiped the whole search.** `setStoredOptionsOnChain` replaced the url with a bare `/trade/<type>`, and it fires before markets load — i.e. before `useTradeParamsProcessor` can consume `to`/`pool`/`collateral`/`from`. It took `ref` and `utm_*` with it too. It now replaces the pathname only.
- **`?to=` was ignored when the path carried no trade type.** `#/trade?to=BTC` matched neither the swap nor the index token list, so the token was dropped and the params scrubbed 2s later. `getTradeLinkTradeType()` now resolves such a link against the trade type the tradebox is already on.
- **First-time visitors were bounced to Long.** The chain sync reset to the initial state whenever the chain had no usable stored options, overriding the trade type the link had just applied. It now keeps the current one, which also stops a chain switch from resetting the tab.

The second commit converges the cleanup that #2783 introduced: release the timer ref on teardown (otherwise the "already scheduled" guard latches and nothing is ever stripped), never arm a timer with nothing to strip, clean a `pool` that has no `to` to resolve it against — reachable only now that the search survives the path sync — and stop a declined network switch from latching the re-entry guard.

Linear: https://linear.app/gmx-io/issue/FEDEV-4258/bug-trade-deep-links-drop-their-query-params-before-applying-them

## Testing

Driven in a real browser against the dev build, fresh profile per case, reading the applied chart token from `document.title`. Re-run after rebasing onto the current `release` (which is back on hash routing after #2789 merged master):

| link | before | after |
| --- | --- | --- |
| `#/trade?to=BTC` | ETH, params scrubbed | BTC |
| `#/trade/swap?to=USDC` | params wiped at ~0.5s, ETH | stays swap, USDC |
| `#/trade/short?to=BTC` | bounced to `#/trade/long`, ETH | stays short, BTC |
| `#/trade/long?to=SOL` | SOL (already worked) | SOL |
| `#/trade/swap?to=USDC&utm_source=x` | params wiped, ETH | USDC applied, `utm_source` kept |
| `#/trade/long?pool=WETH-USDC` | param stuck in the url | cleaned |

Convergence checked by counting url rewrites over 20s: `#/trade?utm_source=x&privy_connector=injected` → 0, `#/trade/swap?to=USDC&utm_source=x` → 1 (strips `to`, keeps `utm_source`). On the path-routed build the same cases measured 244 → 0 and 3 `replaceState` calls respectively.

Regressions checked: Long/Short/Swap tab clicks still drive the url; switching to Avalanche keeps the tab (short and swap) and loads a valid market; `?chainId=43114&to=BTC` still switches network and applies the token; `?ref=CODE` still lands in `GMX-referralCode`.

`yarn test:ci` (167 files), `yarn test:ct` (199 passed), `sdk yarn test:ci` (46 files), `yarn tscheck`, eslint and prettier on the changed files — all green on the rebased branch.
