### PR TITLE
QA mocks: What's new carousel test announcements (do not merge)

### DIFF
--- a/src/components/WhatsNewToast/WhatsNewToast.tsx
+++ b/src/components/WhatsNewToast/WhatsNewToast.tsx
@@ -1,35 +1,59 @@
 import { t, Trans } from "@lingui/macro";
 import cx from "classnames";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion, useIsPresent, Variants } from "framer-motion";
+import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { EventData } from "config/events";
+import { usePrefersReducedMotion } from "lib/usePrefersReducedMotion";
 
 import { AnnouncementBanner } from "components/AnnouncementBanner/AnnouncementBanner";
+
+import { INITIAL_SLIDE_STATE, SlideDirection, jumpToSlide, stepSlide } from "./whatsNewSlideState";
 
 const AUTO_ROTATE_INTERVAL_MS = 5000;
 const SWIPE_THRESHOLD_PX = 40;
 const WHEEL_MIN_DELTA_PX = 4;
 const WHEEL_STEP_INTERVAL_MS = 350;
+const SLIDE_ENTER_OFFSET_PX = 12;
+const SLIDE_EXIT_OFFSET_PX = 8;
 const WHATS_NEW_LABEL = <Trans>What's new</Trans>;
 const SEE_MORE_LABEL = <Trans>See more</Trans>;
 
+const SLIDE_VARIANTS: Variants = {
+  enter: (shift: number) => ({ opacity: 0, x: shift * SLIDE_ENTER_OFFSET_PX }),
+  center: {
+    opacity: 1,
+    x: 0,
+    transition: {
+      opacity: { duration: 0.18, ease: "linear" },
+      x: { duration: 0.24, ease: [0.16, 1, 0.3, 1] },
+    },
+  },
+  exit: (shift: number) => ({
+    opacity: 0,
+    x: -shift * SLIDE_EXIT_OFFSET_PX,
+    transition: { duration: 0.12, ease: "easeIn" },
+  }),
+};
+
 export function WhatsNewToast({ cards, dismiss }: { cards: EventData[]; dismiss: () => void }) {
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [slide, setSlide] = useState(INITIAL_SLIDE_STATE);
   const [isPaused, setIsPaused] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
-    if (activeIndex >= cards.length && cards.length > 0) {
-      setActiveIndex(0);
+    if (slide.index >= cards.length && cards.length > 0) {
+      setSlide(INITIAL_SLIDE_STATE);
     }
-  }, [cards.length, activeIndex]);
+  }, [cards.length, slide.index]);
 
   useEffect(() => {
     if (cards.length <= 1 || isPaused) return;
     const id = window.setTimeout(() => {
-      setActiveIndex((prev) => (prev + 1) % cards.length);
+      setSlide((prev) => stepSlide(prev, 1, cards.length));
     }, AUTO_ROTATE_INTERVAL_MS);
     return () => window.clearTimeout(id);
-  }, [cards.length, isPaused, activeIndex]);
+  }, [cards.length, isPaused, slide.index]);
 
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
@@ -41,10 +65,10 @@ export function WhatsNewToast({ cards, dismiss }: { cards: EventData[]; dismiss:
     if (e.pointerType !== "mouse") return;
     setIsPaused(false);
   }, []);
-  const handleDotClick = useCallback((index: number) => setActiveIndex(index), []);
+  const handleDotClick = useCallback((index: number) => setSlide((prev) => jumpToSlide(prev, index)), []);
 
   const goRelative = useCallback(
-    (direction: 1 | -1) => setActiveIndex((prev) => (prev + direction + cards.length) % cards.length),
+    (step: SlideDirection) => setSlide((prev) => stepSlide(prev, step, cards.length)),
     [cards.length]
   );
 
@@ -124,7 +148,7 @@ export function WhatsNewToast({ cards, dismiss }: { cards: EventData[]; dismiss:
     return () => node.removeEventListener("wheel", onWheel);
   }, [cards.length, goRelative]);
 
-  const safeIndex = cards.length > 0 ? Math.min(activeIndex, cards.length - 1) : 0;
+  const safeIndex = cards.length > 0 ? Math.min(slide.index, cards.length - 1) : 0;
   const current = cards[safeIndex];
 
   const footerLink = useMemo(
@@ -150,6 +174,7 @@ export function WhatsNewToast({ cards, dismiss }: { cards: EventData[]; dismiss:
   if (!current) return null;
 
   const isCarousel = cards.length > 1;
+  const slideShift = prefersReducedMotion ? 0 : slide.direction;
 
   return (
     <div
@@ -180,9 +205,40 @@ export function WhatsNewToast({ cards, dismiss }: { cards: EventData[]; dismiss:
         footerLink={footerLink}
         dots={dots}
       >
-        <CardContent event={current} variant={current.variant ?? "info"} />
+        <div className="grid grid-cols-1">
+          {isCarousel &&
+            cards.map((card) => (
+              <div key={card.id} aria-hidden className="invisible col-start-1 row-start-1">
+                <CardContent event={card} variant={card.variant ?? "info"} />
+              </div>
+            ))}
+          <AnimatePresence initial={false} custom={slideShift}>
+            <Slide key={current.id} shift={slideShift}>
+              <CardContent event={current} variant={current.variant ?? "info"} />
+            </Slide>
+          </AnimatePresence>
+        </div>
       </AnnouncementBanner>
     </div>
+  );
+}
+
+function Slide({ shift, children }: { shift: number; children: ReactNode }) {
+  const isPresent = useIsPresent();
+
+  return (
+    <motion.div
+      className={cx("col-start-1 row-start-1", !isPresent && "pointer-events-none")}
+      aria-hidden={isPresent ? undefined : true}
+      custom={shift}
+      variants={SLIDE_VARIANTS}
+      initial="enter"
+      animate="center"
+      exit="exit"
+      data-qa="whats-new-slide"
+    >
+      {children}
+    </motion.div>
   );
 }
 

--- a/src/components/WhatsNewToast/whatsNewSlideState.ts
+++ b/src/components/WhatsNewToast/whatsNewSlideState.ts
@@ -1,0 +1,18 @@
+export type SlideDirection = 1 | -1;
+
+export type WhatsNewSlideState = {
+  index: number;
+  direction: SlideDirection;
+};
+
+export const INITIAL_SLIDE_STATE: WhatsNewSlideState = { index: 0, direction: 1 };
+
+export function stepSlide(state: WhatsNewSlideState, step: SlideDirection, count: number): WhatsNewSlideState {
+  if (count <= 1) return state;
+  return { index: (state.index + step + count) % count, direction: step };
+}
+
+export function jumpToSlide(state: WhatsNewSlideState, index: number): WhatsNewSlideState {
+  if (index === state.index) return state;
+  return { index, direction: index > state.index ? 1 : -1 };
+}

--- a/src/config/events.tsx
+++ b/src/config/events.tsx
@@ -48,6 +48,66 @@ export type EventData = {
 };
 
 export const appEventsData: EventData[] = [
+  // TEST-ONLY mock announcements for FEDEV-4262 QA. Do not merge into release.
+  {
+    id: "qa-mock-tall",
+    type: "update",
+    isActive: true,
+    startDate: "30 Aug 2026, 10:00",
+    endDate: "31 Dec 2027, 0:00",
+    variant: "info",
+    title: "QA mock: a deliberately long announcement title that wraps onto two lines",
+    summary: (
+      <>
+        This is the tallest card in the set. Its summary runs for three full lines, so it defines the height that every
+        other announcement in the rotation has to hold while the toast is open.
+      </>
+    ),
+    description: (
+      <>
+        Tallest card of the QA set: a two line title with a three line summary. It sets the height of the What's new
+        card, so the shorter announcements in the rotation keep that height instead of resizing.
+      </>
+    ),
+  },
+  {
+    id: "qa-mock-one-line",
+    type: "update",
+    isActive: true,
+    startDate: "30 Aug 2026, 9:00",
+    endDate: "31 Dec 2027, 0:00",
+    variant: "success",
+    title: "QA mock: one line announcement",
+    summary: <>A single line of text.</>,
+    description: (
+      <>
+        Shortest card of the QA set: one line of title and one line of summary. Following the tall card, it should keep
+        the same card height, with the extra space sitting above the See more link.
+      </>
+    ),
+  },
+  {
+    id: "qa-mock-links",
+    type: "update",
+    isActive: true,
+    startDate: "30 Aug 2026, 8:00",
+    endDate: "31 Dec 2027, 0:00",
+    variant: "warning",
+    title: "QA mock: announcement with inline links",
+    summary: (
+      <>
+        Open <Link to="/trade">Trade</Link> or <Link to="/pools">Pools</Link>, or follow{" "}
+        <ExternalLink href="https://x.com/GMX_IO">GMX on X</ExternalLink>. All three stay clickable during a slide
+        change.
+      </>
+    ),
+    description: (
+      <>
+        Links card of the QA set. Use it to check that links inside a summary stay clickable throughout a slide change,
+        and that the announcement leaving the screen never intercepts a click meant for the incoming one.
+      </>
+    ),
+  },
   {
     id: "qqq-spy-arbitrum-listing",
     type: "listing",

--- a/src/lib/usePrefersReducedMotion.ts
+++ b/src/lib/usePrefersReducedMotion.ts
@@ -1,0 +1,5 @@
+import { useMedia } from "react-use";
+
+export function usePrefersReducedMotion(): boolean {
+  return useMedia("(prefers-reduced-motion: reduce)", false);
+}


### PR DESCRIPTION
**Test-only. Do not merge.** Mock announcements on top of #2806 so the What's new carousel has something to page through.

Only `src/config/events.tsx` is touched — three mocks at the top of `appEventsData`, marked with a `TEST-ONLY` comment. No product code is changed here.

### What the mocks are for

| id | shape | what it exercises |
| --- | --- | --- |
| `qa-mock-tall` | 2-line title + 3-line summary (95px) | tallest card — it sets the height the whole rotation holds |
| `qa-mock-one-line` | 1-line title + 1-line summary (40px) | the one-line announcement — shows the card keeping the tall height, with the extra space above **See more** |
| `qa-mock-links` | 1-line title + 2-line summary with `Trade` / `Pools` / external links | links must stay clickable through a slide change, and the outgoing slide must never intercept a click |

They have no `chains` restriction and run until 31 Dec 2027, so they show on every network. Together with the live QQQ/SPY announcement that fills all four toast slots (`MAX_TOAST_CARDS = 4`).

### How to test

1. The toast only appears for announcements you have not dismissed yet. If it does not show, clear `visited-announcements` in localStorage and reload.
2. Page through with the dots, arrow keys, swipe and trackpad. Hovering pauses auto-rotation.
3. Watch the bottom edge of the card, the **See more** link and the dots — they should not move between slides, including on the one-line announcement.
4. Reduced motion (macOS: System Settings → Accessibility → Display → Reduce motion) should cross-fade with no sideways movement, and still not hard-cut.

The mocks also appear on the `/announcements` page — expected, they are ordinary entries in the announcements config.
