### PR TITLE
Require UI 1.9 so pre-relay tabs demand a refresh

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,3 +1,3 @@
 {
-  "uiVersion": 1.8
+  "uiVersion": 1.9
 }


### PR DESCRIPTION
## What

One line: `uiVersion` 1.8 → 1.9 in `public/config.json`.

## Why

This file is the app's existing force-update mechanism: the build bakes the value in as `UI_VERSION`, every session re-fetches the deployed copy no-cache, and `useHasOutdatedUi` turns a version gap into "Page outdated. Refresh" on the trading actions themselves. Bumping it in the release that runs 100% GMX Relay makes every pre-relay tab — the ones that would submit into Gelato after its Sept 1 shutdown — block at the button and ask for a refresh, while fresh bundles pass untouched.

No banners: the block sits exactly where a stale tab would otherwise fail.