### PR TITLE
Fix trade history margin delta FEDEV-4261

### DIFF
--- a/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
@@ -661,6 +661,12 @@ describe("TradeHistoryRow helpers", () => {
         ],
         "priceImpact": "< +$ 0.01",
         "size": "+$ 3.62",
+        "sizeComment": [
+          {
+            "key": "Margin delta",
+            "value": "+3.02 USDC",
+          },
+        ],
         "timestamp": "18 Sep 2023, 16:43",
         "timestampUTC": "UTC: 2023-09-18 12:43:18",
       }
@@ -1034,6 +1040,82 @@ describe("TradeHistoryRow helpers", () => {
 
       expect(details.action).toBe("Create TWAP");
       expect(details.price).toBe("N/A");
+    });
+
+    it("uses the position collateral token for executed increases with a swap path", () => {
+      const gmxToken = {
+        ...executeOrderIncreaseLong.targetCollateralToken,
+        name: "GMX",
+        symbol: "GMX",
+        decimals: 18,
+        address: "0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a",
+        isStable: false,
+      };
+      const executedIncrease = {
+        ...executeOrderIncreaseLong,
+        swapPath: ["0x55391D178Ce46e7AC8eaAEa50A72D1A5a8A622Da"],
+        targetCollateralToken: gmxToken,
+        initialCollateralDeltaAmount: 204_579_982_339_079_771n,
+      };
+
+      expect(formatPositionMessage(executedIncrease, minCollateralUsd).sizeComment).toEqual([
+        { key: "Margin delta", value: "+0.20458\u00a0GMX" },
+      ]);
+      expect(formatPositionMessage({ ...executedIncrease, sizeDeltaUsd: 0n }, minCollateralUsd).size).toBe(
+        "0.20458\u00a0GMX"
+      );
+    });
+
+    it("does not hide a non-zero target collateral amount with fewer decimals", () => {
+      const executedIncrease = {
+        ...executeOrderIncreaseLong,
+        initialCollateralToken: {
+          ...executeOrderIncreaseLong.initialCollateralToken,
+          name: "Wrapped Ether",
+          symbol: "WETH",
+          decimals: 18,
+          address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          isStable: false,
+        },
+        initialCollateralTokenAddress: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        swapPath: ["0x55391D178Ce46e7AC8eaAEa50A72D1A5a8A622Da"],
+        initialCollateralDeltaAmount: 1_510_000n,
+      };
+
+      expect(formatPositionMessage(executedIncrease, minCollateralUsd).sizeComment).toEqual([
+        { key: "Margin delta", value: "+1.51\u00a0USDC" },
+      ]);
+    });
+
+    it("keeps request and decrease rows denominated in the initial collateral token", () => {
+      const gmxToken = {
+        ...executeOrderIncreaseLong.targetCollateralToken,
+        name: "GMX",
+        symbol: "GMX",
+        decimals: 18,
+        address: "0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a",
+        isStable: false,
+      };
+      const action = {
+        ...executeOrderIncreaseLong,
+        swapPath: ["0x55391D178Ce46e7AC8eaAEa50A72D1A5a8A622Da"],
+        targetCollateralToken: gmxToken,
+        initialCollateralDeltaAmount: 1_510_000n,
+      };
+
+      const request = formatPositionMessage(
+        { ...action, eventName: TradeActionType.OrderCreated, sizeDeltaUsd: 0n },
+        minCollateralUsd
+      );
+      const decrease = formatPositionMessage({ ...action, orderType: OrderType.MarketDecrease }, minCollateralUsd);
+      const withdrawal = formatPositionMessage(
+        { ...action, orderType: OrderType.MarketDecrease, sizeDeltaUsd: 0n },
+        minCollateralUsd
+      );
+
+      expect(request.size).toBe("1.51\u00a0USDC");
+      expect(decrease.sizeComment).toEqual([{ key: "Margin delta", value: "-1.51\u00a0USDC" }]);
+      expect(withdrawal.size).toBe("1.51\u00a0USDC");
     });
   });
 

--- a/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -52,7 +52,7 @@ export const formatPositionMessage = (
   minCollateralUsd: bigint,
   relativeTimestamp = true
 ): RowDetails => {
-  const collateralToken = tradeAction.initialCollateralToken;
+  const collateralToken = getMarginDeltaCollateralToken(tradeAction);
   const isV22Action = tradeAction.srcChainId !== undefined;
 
   let sizeDeltaUsd = tradeAction.sizeDeltaUsd;
@@ -1040,37 +1040,40 @@ function getSizeComment(tradeAction: PositionTradeAction): Line[] | undefined {
     return undefined;
   }
 
+  const collateralToken = getMarginDeltaCollateralToken(tradeAction);
   const signedMarginDelta = isDecreaseOrderType(tradeAction.orderType)
     ? -tradeAction.initialCollateralDeltaAmount
     : tradeAction.initialCollateralDeltaAmount;
   const displayDecimals = calculateDisplayDecimals(
     tradeAction.initialCollateralDeltaAmount,
-    tradeAction.initialCollateralToken.decimals,
+    collateralToken.decimals,
     undefined,
-    tradeAction.initialCollateralToken.isStable
+    collateralToken.isStable
   );
 
-  if (roundsToZero(signedMarginDelta, tradeAction.initialCollateralToken.decimals, displayDecimals)) {
+  if (roundsToZero(signedMarginDelta, collateralToken.decimals, displayDecimals)) {
     return undefined;
   }
 
-  const formattedMarginDelta = formatTokenAmount(
-    signedMarginDelta,
-    tradeAction.initialCollateralToken.decimals,
-    tradeAction.initialCollateralToken.symbol,
-    {
-      useCommas: true,
-      displayPlus: true,
-      displayDecimals,
-      isStable: tradeAction.initialCollateralToken.isStable,
-    }
-  );
+  const formattedMarginDelta = formatTokenAmount(signedMarginDelta, collateralToken.decimals, collateralToken.symbol, {
+    useCommas: true,
+    displayPlus: true,
+    displayDecimals,
+    isStable: collateralToken.isStable,
+  });
 
   if (!formattedMarginDelta) {
     return undefined;
   }
 
   return lines(infoRow(t`Margin delta`, formattedMarginDelta));
+}
+
+function getMarginDeltaCollateralToken(tradeAction: PositionTradeAction) {
+  const isExecutedIncrease =
+    tradeAction.eventName === TradeActionType.OrderExecuted && isIncreaseOrderType(tradeAction.orderType);
+
+  return isExecutedIncrease ? tradeAction.targetCollateralToken : tradeAction.initialCollateralToken;
 }
 
 export function getTokenPriceByTradeAction(tradeAction: PositionTradeAction) {

--- a/src/domain/synthetics/historyExport/tradeExport.spec.ts
+++ b/src/domain/synthetics/historyExport/tradeExport.spec.ts
@@ -8,6 +8,10 @@ import type { MarketFilterLongShortItemData } from "components/TableMarketFilter
 import { buildTradeCsvRows, filterRawTradeActionsForExport } from "./tradeExport";
 
 const USDC_PRICE = "1000000000000000000000000";
+const USDC_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+const GMX_ADDRESS = "0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a";
+const SWAP_MARKET_ADDRESS = "0x55391D178Ce46e7AC8eaAEa50A72D1A5a8A622Da";
+const POSITION_MARKET_ADDRESS = "0x0000000000000000000000000000000000000001";
 
 describe("buildTradeCsvRows", () => {
   it("keeps an action row and expands an executed swap cashflow", () => {
@@ -66,6 +70,105 @@ describe("buildTradeCsvRows", () => {
       received_amount: "0.25",
       received_currency: "ETH",
       net_action_result_usd: "",
+    });
+  });
+
+  it("denominates executed increase collateral in the position collateral token", () => {
+    const rows = buildTradeCsvRows({
+      chainId: 42161,
+      rawActions: [
+        {
+          id: "executed-increase",
+          eventName: TradeActionType.OrderExecuted,
+          account: "0xAccount",
+          orderType: OrderType.MarketIncrease,
+          orderKey: "0xExecutedIncrease",
+          timestamp: 1783425600,
+          transactionHash: "0xExecutedIncreaseHash",
+          marketAddress: POSITION_MARKET_ADDRESS,
+          swapPath: [SWAP_MARKET_ADDRESS],
+          initialCollateralTokenAddress: USDC_ADDRESS,
+          initialCollateralDeltaAmount: "204579982339079771",
+          sizeDeltaUsd: "0",
+          collateralTokenPriceMin: "7382800000000",
+          isLong: true,
+          shouldUnwrapNativeToken: false,
+        },
+        {
+          id: "created-increase",
+          eventName: TradeActionType.OrderCreated,
+          account: "0xAccount",
+          orderType: OrderType.LimitIncrease,
+          orderKey: "0xCreatedIncrease",
+          timestamp: 1783425601,
+          transactionHash: "0xCreatedIncreaseHash",
+          marketAddress: POSITION_MARKET_ADDRESS,
+          swapPath: [SWAP_MARKET_ADDRESS],
+          initialCollateralTokenAddress: USDC_ADDRESS,
+          initialCollateralDeltaAmount: "1510000",
+          sizeDeltaUsd: "0",
+          isLong: true,
+          shouldUnwrapNativeToken: false,
+        },
+        {
+          id: "executed-decrease",
+          eventName: TradeActionType.OrderExecuted,
+          account: "0xAccount",
+          orderType: OrderType.MarketDecrease,
+          orderKey: "0xExecutedDecrease",
+          timestamp: 1783425602,
+          transactionHash: "0xExecutedDecreaseHash",
+          marketAddress: POSITION_MARKET_ADDRESS,
+          swapPath: [SWAP_MARKET_ADDRESS],
+          initialCollateralTokenAddress: USDC_ADDRESS,
+          initialCollateralDeltaAmount: "1510000",
+          sizeDeltaUsd: "0",
+          isLong: true,
+          shouldUnwrapNativeToken: false,
+        },
+      ] as any,
+      marketsInfoData: {
+        [POSITION_MARKET_ADDRESS]: {
+          indexToken: { symbol: "GMX", decimals: 18 },
+          indexTokenAddress: GMX_ADDRESS,
+          isSpotOnly: false,
+        },
+        [SWAP_MARKET_ADDRESS]: {
+          marketTokenAddress: SWAP_MARKET_ADDRESS,
+          longTokenAddress: GMX_ADDRESS,
+          shortTokenAddress: USDC_ADDRESS,
+          longToken: { address: GMX_ADDRESS },
+          shortToken: { address: USDC_ADDRESS },
+        },
+      } as any,
+      tokensData: {
+        [USDC_ADDRESS]: { address: USDC_ADDRESS, symbol: "USDC", decimals: 6, isStable: true },
+        [GMX_ADDRESS]: { address: GMX_ADDRESS, symbol: "GMX", decimals: 18 },
+      } as any,
+    });
+
+    expect(rows.find((row) => row.record_id === "42161:executed-increase:action")).toMatchObject({
+      collateral_delta_amount: "0.204579982339079771",
+      collateral_token_symbol: "GMX",
+      collateral_token_address: GMX_ADDRESS,
+      data_completeness: "partial",
+      manual_review_reason: "increase pay-token amount unavailable after swap",
+    });
+    expect(rows.find((row) => row.record_id === "42161:executed-increase:cashflow:0")).toBeUndefined();
+    expect(rows.find((row) => row.record_id === "42161:created-increase:action")).toMatchObject({
+      collateral_delta_amount: "1.51",
+      collateral_token_symbol: "USDC",
+      collateral_token_address: USDC_ADDRESS,
+    });
+    expect(rows.find((row) => row.record_id === "42161:executed-decrease:action")).toMatchObject({
+      collateral_delta_amount: "1.51",
+      collateral_token_symbol: "USDC",
+      collateral_token_address: USDC_ADDRESS,
+    });
+    expect(rows.find((row) => row.record_id === "42161:executed-decrease:cashflow:0")).toMatchObject({
+      received_amount: "1.51",
+      received_currency: "USDC",
+      received_token_address: USDC_ADDRESS,
     });
   });
 

--- a/src/domain/synthetics/historyExport/tradeExport.ts
+++ b/src/domain/synthetics/historyExport/tradeExport.ts
@@ -302,16 +302,21 @@ export function buildTradeCsvRows({
     const isIncrease = isIncreaseOrderType(action.orderType);
     const isDecrease = isDecreaseOrderType(action.orderType) || isLiquidationOrderType(action.orderType);
     const marketInfo = getMetadata(marketsInfoData, action.marketAddress);
-    const collateralToken = getMetadata(tokensData, action.initialCollateralTokenAddress);
+    const initialCollateralToken = getMetadata(tokensData, action.initialCollateralTokenAddress);
     const targetTokenAddress = getTargetTokenAddress({ action, chainId, marketsInfoData });
     const targetToken = getMetadata(tokensData, targetTokenAddress);
+    const usesTargetCollateralToken = isExecuted && isIncrease && Boolean(action.swapPath?.length);
+    const collateralTokenAddress = usesTargetCollateralToken
+      ? targetTokenAddress
+      : action.initialCollateralTokenAddress;
+    const collateralToken = usesTargetCollateralToken ? targetToken : initialCollateralToken;
     const indexToken = marketInfo?.indexToken;
     const reviewReasons: string[] = [];
 
     if (!isSwap && action.marketAddress && !marketInfo) {
       reviewReasons.push("market metadata unavailable");
     }
-    if (action.initialCollateralTokenAddress && !collateralToken) {
+    if (action.initialCollateralTokenAddress && !initialCollateralToken) {
       reviewReasons.push("collateral token metadata unavailable");
     }
     if ((action.swapPath?.length ?? 0) > 0 && !targetTokenAddress) {
@@ -319,6 +324,9 @@ export function buildTradeCsvRows({
     }
     if (targetTokenAddress && !targetToken) {
       reviewReasons.push("output token metadata unavailable");
+    }
+    if (usesTargetCollateralToken && BigInt(action.initialCollateralDeltaAmount ?? 0) > 0n) {
+      reviewReasons.push("increase pay-token amount unavailable after swap");
     }
     if (isSwap && isExecuted && (action.swapFeeUsd === null || action.swapFeeUsd === undefined)) {
       reviewReasons.push("swap fee unavailable");
@@ -365,7 +373,7 @@ export function buildTradeCsvRows({
     row.event_name = action.eventName;
     row.status = getTradeStatus(action.eventName);
     row.market_name = isSwap
-      ? [collateralToken?.symbol, targetToken?.symbol].filter(Boolean).join("/")
+      ? [initialCollateralToken?.symbol, targetToken?.symbol].filter(Boolean).join("/")
       : marketInfo
         ? getMarketIndexName(marketInfo)
         : "";
@@ -388,8 +396,10 @@ export function buildTradeCsvRows({
     row.acceptable_price = formatContractPriceDecimal(action.acceptablePrice, indexToken?.decimals);
     row.execution_price = formatContractPriceDecimal(action.executionPrice, indexToken?.decimals);
     row.contract_trigger_price = formatContractPriceDecimal(action.contractTriggerPrice, indexToken?.decimals);
-    row.input_amount = isSwap ? formatDecimal(action.initialCollateralDeltaAmount, collateralToken?.decimals) : "";
-    row.input_token_symbol = isSwap ? collateralToken?.symbol ?? "" : "";
+    row.input_amount = isSwap
+      ? formatDecimal(action.initialCollateralDeltaAmount, initialCollateralToken?.decimals)
+      : "";
+    row.input_token_symbol = isSwap ? initialCollateralToken?.symbol ?? "" : "";
     row.output_amount = formatDecimal(action.executionAmountOut, targetToken?.decimals);
     row.output_token_symbol =
       action.executionAmountOut !== null && action.executionAmountOut !== undefined ? targetToken?.symbol ?? "" : "";
@@ -433,7 +443,7 @@ export function buildTradeCsvRows({
     row.index_token_symbol = indexToken?.symbol ?? "";
     row.index_token_address = marketInfo?.indexTokenAddress ?? "";
     row.collateral_token_symbol = collateralToken?.symbol ?? "";
-    row.collateral_token_address = action.initialCollateralTokenAddress ?? "";
+    row.collateral_token_address = collateralTokenAddress ?? "";
     row.input_token_address = isSwap ? action.initialCollateralTokenAddress ?? "" : "";
     row.output_token_address =
       action.executionAmountOut !== null && action.executionAmountOut !== undefined ? targetTokenAddress ?? "" : "";
@@ -471,15 +481,15 @@ export function buildTradeCsvRows({
           actionRow: row,
           actionId,
           legIndex: 0,
-          sentAmount: formatDecimal(action.initialCollateralDeltaAmount, collateralToken?.decimals),
-          sentCurrency: collateralToken?.symbol,
+          sentAmount: formatDecimal(action.initialCollateralDeltaAmount, initialCollateralToken?.decimals),
+          sentCurrency: initialCollateralToken?.symbol,
           sentTokenAddress: action.initialCollateralTokenAddress ?? undefined,
           receivedAmount: formatDecimal(action.executionAmountOut, targetToken?.decimals),
           receivedCurrency: targetToken?.symbol,
           receivedTokenAddress: targetTokenAddress,
         })
       );
-    } else if (isIncrease && BigInt(action.initialCollateralDeltaAmount) > 0n) {
+    } else if (isIncrease && !usesTargetCollateralToken && BigInt(action.initialCollateralDeltaAmount) > 0n) {
       rows.push(
         createCashflowRow({
           actionRow: row,
@@ -487,7 +497,7 @@ export function buildTradeCsvRows({
           legIndex: 0,
           sentAmount: formatDecimal(action.initialCollateralDeltaAmount, collateralToken?.decimals),
           sentCurrency: collateralToken?.symbol,
-          sentTokenAddress: action.initialCollateralTokenAddress ?? undefined,
+          sentTokenAddress: collateralTokenAddress ?? undefined,
           usdValuation: formatTokenUsd(action.initialCollateralDeltaAmount, collateralPrice),
           valuationSource: collateralPrice ? "indexed collateral token price" : undefined,
         })
@@ -506,9 +516,7 @@ export function buildTradeCsvRows({
     } else if (isDecrease && sizeDeltaUsd === 0n && BigInt(action.initialCollateralDeltaAmount) > 0n) {
       const receivedRaw = action.executionAmountOut ?? action.initialCollateralDeltaAmount;
       const receivedToken = action.executionAmountOut ? targetToken : collateralToken;
-      const receivedAddress = action.executionAmountOut
-        ? targetTokenAddress
-        : action.initialCollateralTokenAddress ?? undefined;
+      const receivedAddress = action.executionAmountOut ? targetTokenAddress : collateralTokenAddress ?? undefined;
       rows.push(
         createCashflowRow({
           actionRow: row,


### PR DESCRIPTION
## Summary

- Display executed increase margin deltas using the post-swap position collateral token.
- Keep request, decrease, liquidation, deposit, and withdrawal token semantics unchanged.
- Correct canonical CSV collateral fields and avoid fabricating swapped-input wallet cashflows when the executed event does not expose that amount.
- Add regression coverage for decimal mismatches in both directions and collateral-only actions.

Linear: https://linear.app/gmx-io/issue/FEDEV-4261/bug-trade-history-margin-delta-is-wrong-when-the-pay-token-is-not-the
