### PR TITLE
Hotfix: point subsquid urls at the :prod tag

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -18,7 +18,7 @@ const sdk = new GmxSdk({
   rpcUrl: "https://arb1.arbitrum.io/rpc",
   oracleUrl: "https://arbitrum-api.gmxinfra.io",
   walletClient: useWallet().walletClient,
-  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@bac941/api/graphql",
+  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
 });
 
 const { marketsInfoData, tokensData } = await sdk.markets.getMarketsInfo();

--- a/sdk/scripts/subsquid-codegen.ts
+++ b/sdk/scripts/subsquid-codegen.ts
@@ -1,7 +1,7 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum@c9407b/api/graphql",
+  schema: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
   overwrite: true,
   debug: true,
   generates: {

--- a/sdk/src/clients/v1/testUtil.ts
+++ b/sdk/src/clients/v1/testUtil.ts
@@ -19,7 +19,7 @@ export const arbitrumSdkConfig: GmxSdkConfig = {
   oracleUrl: "https://arbitrum-api.gmxinfra.io",
   rpcUrl: "https://arb1.arbitrum.io/rpc",
   walletClient: client,
-  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum@c9407b/api/graphql",
+  subsquidUrl: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
 };
 
 export const arbitrumSdk = new GmxSdk(arbitrumSdkConfig);

--- a/src/config/indexers.ts
+++ b/src/config/indexers.ts
@@ -21,7 +21,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-arbitrum-referrals/master-240506225935-51167d5/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-arbitrum-stats/master-260605170830-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum@8abb92/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql",
   },
 
   [AVALANCHE]: {
@@ -31,7 +31,7 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/gmx-avalanche-referrals/master-240415215829-f6877d6/gn",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-avalanche-stats/master-260605222642-1049f5c/gn",
-    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche@8abb92/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-avalanche:prod/api/graphql",
   },
 
   [AVALANCHE_FUJI]: {
@@ -43,11 +43,11 @@ const INDEXER_URLS: Partial<Record<ContractsChainId, IndexerUrlMap>> = {
   },
 
   [ARBITRUM_SEPOLIA]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia@8abb92/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-arb-sepolia:prod/api/graphql",
   },
 
   [MEGAETH]: {
-    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth@8abb92/api/graphql",
+    subsquid: "https://gmx.squids.live/gmx-synthetics-megaeth:prod/api/graphql",
     syntheticsStats:
       "https://api.goldsky.com/api/public/project_cmgptuc4qhclc01rh9s4q554a/subgraphs/synthetics-megaeth-stats/master-260120151613-540f334/gn",
     referrals:


### PR DESCRIPTION
The UI is pinned to squid slot `@8abb92` and the SDK codegen / v1 test util to `@c9407b`. Those pins are what keep the extra squids alive, so the SQD project cannot be cleaned up while they stand. This points everything at the `:prod` tag.

**Runtime impact: none.** `:prod` currently resolves to the exact slot the UI was pinned to — identical introspection hash and identical `squidStatus` heights across repeated samples, while `@7cff6d` and `@c9407b` differ on both. The pin was already redundant; it only meant the UI would stay behind the next `:prod` promotion.

**Checked before opening**

- `arbitrum`, `avalanche`, `megaeth`, `arb-sepolia` all answer `squidStatus` over `:prod` with HTTP 200.
- Introspection diff `:prod` vs `@c9407b` (the SDK codegen slot): additive only, 440 new fields, nothing removed. Generated subsquid types stay valid, so no regeneration is needed in this PR.
- The deployed bundle on app.gmx.io was hitting `@8abb92`, which is how the pin was found.

**Notes**

- `sdk/README.md` pointed at `@bac941`, which 404s — that slot is already deleted. Updated to `:prod` as well.
- Fuji already used `:prod` and is untouched. Separately: `gmx-synthetics-fuji:prod` currently 404s, the fuji squid is gone.
- Targeted at `master` on purpose — the point is to free the extra slots now. `release` carries the same pin and needs the same change so the next release does not reintroduce it.
