### PR TITLE
Hotfix: force UI update, bump uiVersion to 2.0

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,3 +1,3 @@
 {
-  "uiVersion": 1.9
+  "uiVersion": 2.0
 }


### PR DESCRIPTION
Follow-up to #2816, which switched the subsquid urls to the `:prod` tag.

Tabs that are still running an older bundle keep querying the pinned slots baked into that bundle — `@8abb92`, and older ones like `@c9407b` / `@bac941`. Until those tabs reload, the old slots cannot be deleted from the SQD project without breaking someone mid-session. Bumping the required version makes every stale tab demand a refresh (`useHasOutdatedUi` compares this number against the bundled `UI_VERSION` and blocks order submission with "Page outdated. Refresh").

`1.9` -> `2.0`, same one-line change as #2746 (1.9), #2736 (1.8) and #2096 (1.7).

Order that makes this work: merge and deploy this, give stale tabs time to roll over, then delete `@7cff6d` and `@c9407b`. The slot currently behind `:prod` (`8abb92`) must stay.
