### PR TITLE
Hide Gain/Loss and Est. PnL for invalid TP/SL prices FEDEV-4265

### DIFF
--- a/src/components/OrdersModal/TPSLInputRow.spec.tsx
+++ b/src/components/OrdersModal/TPSLInputRow.spec.tsx
@@ -1,6 +1,7 @@
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
+import { ComponentProps } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { expandDecimals } from "lib/numbers";
@@ -22,6 +23,32 @@ const positionData = {
   isLong: true,
   indexTokenDecimals: 18,
 };
+
+const shortPositionData = { ...positionData, isLong: false };
+
+function renderRow(props: Partial<ComponentProps<typeof TPSLInputRow>> = {}) {
+  const view = render(
+    <I18nProvider i18n={i18n}>
+      <TPSLInputRow
+        type="takeProfit"
+        priceValue=""
+        onPriceChange={vi.fn()}
+        positionData={positionData}
+        variant="full"
+        {...props}
+      />
+    </I18nProvider>
+  );
+
+  const inputs = view.getAllByRole("textbox") as HTMLInputElement[];
+
+  return {
+    view,
+    priceInput: inputs[0],
+    gainLossInput: inputs[1],
+    estimatedPnlText: view.getByText("Est. PnL").nextElementSibling?.textContent ?? "",
+  };
+}
 
 describe("TPSLInputRow", () => {
   it("keeps long derived percentages unchanged and contained within the PnL row", () => {
@@ -61,5 +88,100 @@ describe("TPSLInputRow", () => {
     const calculatedPrice = onPriceChange.mock.calls[onPriceChange.mock.calls.length - 1][0];
     expect(calculatedPrice).toMatch(/^\d+(?:\.\d+)?$/);
     expect(calculatedPrice).not.toMatch(/[eE]/);
+  });
+});
+
+describe("TPSLInputRow with a blocking price direction error", () => {
+  const invalidDirectionCases = [
+    {
+      name: "a long TP price below the mark price",
+      type: "takeProfit",
+      positionData,
+      priceValue: "90",
+      priceError: "Set TP price above mark price",
+    },
+    {
+      name: "a short TP price above the mark price",
+      type: "takeProfit",
+      positionData: shortPositionData,
+      priceValue: "110",
+      priceError: "Set TP price below mark price",
+    },
+    {
+      name: "a long SL price above the mark price",
+      type: "stopLoss",
+      positionData,
+      priceValue: "110",
+      priceError: "Set SL price below mark price",
+    },
+    {
+      name: "a short SL price below the mark price",
+      type: "stopLoss",
+      positionData: shortPositionData,
+      priceValue: "90",
+      priceError: "Set SL price above mark price",
+    },
+  ] as const;
+
+  it.each(invalidDirectionCases)("hides the derived gain/loss and estimated PnL for $name", (testCase) => {
+    const { priceInput, gainLossInput, estimatedPnlText } = renderRow({
+      type: testCase.type,
+      positionData: testCase.positionData,
+      priceValue: testCase.priceValue,
+      priceError: testCase.priceError,
+    });
+
+    expect(priceInput.className).toContain("text-red-500");
+    expect(gainLossInput.value).toBe("");
+    expect(gainLossInput.placeholder).toBe("-");
+    expect(estimatedPnlText).toBe("-");
+  });
+
+  it("hides the derived values in the compact variant as well", () => {
+    const { gainLossInput, estimatedPnlText } = renderRow({
+      variant: "compact",
+      priceValue: "90",
+      priceError: "Set TP price above mark price",
+    });
+
+    expect(gainLossInput.value).toBe("");
+    expect(gainLossInput.placeholder).toBe("Gain");
+    expect(estimatedPnlText).toBe("-");
+  });
+
+  it("still derives a trigger price from a gain entered by the user", () => {
+    const onPriceChange = vi.fn();
+    const { view, gainLossInput } = renderRow({
+      priceValue: "90",
+      priceError: "Set TP price above mark price",
+      onPriceChange,
+    });
+
+    fireEvent.change(gainLossInput, { target: { value: "50" } });
+
+    expect(onPriceChange).toHaveBeenCalledWith("105");
+    expect((view.getAllByRole("textbox")[1] as HTMLInputElement).value).toBe("50");
+  });
+
+  it("keeps the derived gain and estimated PnL for a valid take profit price", () => {
+    const { gainLossInput, estimatedPnlText } = renderRow({ priceValue: "110" });
+
+    expect(gainLossInput.value).toBe("100");
+    expect(gainLossInput.placeholder).toBe("0");
+    expect(estimatedPnlText).toContain("+");
+    expect(estimatedPnlText).toContain("100.00%");
+  });
+
+  it("keeps the capped loss and estimated PnL for a beyond-liquidation warning", () => {
+    const { gainLossInput, estimatedPnlText } = renderRow({
+      type: "stopLoss",
+      positionData: { ...positionData, liquidationPrice: expandDecimals(92, 30) },
+      priceValue: "90",
+      priceWarning: "This trigger price is beyond the current liquidation price.",
+    });
+
+    expect(gainLossInput.value).toBe("100");
+    expect(gainLossInput.placeholder).toBe("0");
+    expect(estimatedPnlText).toContain("-100.00%");
   });
 });

--- a/src/components/OrdersModal/TPSLInputRow.tsx
+++ b/src/components/OrdersModal/TPSLInputRow.tsx
@@ -304,8 +304,11 @@ export function TPSLInputRow({
     if (lastEditedField === "gainLoss") {
       return gainLossInputValue;
     }
+    if (priceError) {
+      return "";
+    }
     return formatGainLossValue(displayMode);
-  }, [lastEditedField, gainLossInputValue, formatGainLossValue, displayMode]);
+  }, [lastEditedField, gainLossInputValue, priceError, formatGainLossValue, displayMode]);
 
   const derivedEstimatedPnl = useMemo(() => {
     if (currentPriceValue === undefined || currentPriceValue === 0n) return undefined;
@@ -365,6 +368,8 @@ export function TPSLInputRow({
   };
 
   const estimatedPnl = useMemo(() => {
+    if (priceError) return undefined;
+
     const base = estimatedPnlProp ?? derivedEstimatedPnl;
     if (!base) return base;
 
@@ -383,7 +388,15 @@ export function TPSLInputRow({
       pnlPercentage:
         pnlCollateralUsd > 0n ? bigMath.mulDiv(cappedPnlUsd, 10000n, pnlCollateralUsd) : base.pnlPercentage,
     };
-  }, [estimatedPnlProp, derivedEstimatedPnl, getCollateralUsdForPnl, currentPriceValue, liquidationPrice, isLong]);
+  }, [
+    priceError,
+    estimatedPnlProp,
+    derivedEstimatedPnl,
+    getCollateralUsdForPnl,
+    currentPriceValue,
+    liquidationPrice,
+    isLong,
+  ]);
   const estimatedPnlDisplay = estimatedPnl ? formatDeltaUsd(estimatedPnl.pnlUsd, estimatedPnl.pnlPercentage) : "-";
 
   const formattedMarkPrice = useMemo(() => {
@@ -551,7 +564,7 @@ export function TPSLInputRow({
               className="bg-transparent h-24 w-full min-w-0 p-0 text-16 outline-none"
               inputRef={secondInputRef}
               onValueChange={handleGainLossChange}
-              placeholder="0"
+              placeholder={priceError ? "-" : "0"}
             />
             <DisplayModeSelector
               mode={displayMode}


### PR DESCRIPTION
## Summary

- Stop deriving the Gain/Loss field and Est. PnL in `TPSLInputRow` while the trigger price has a blocking direction error, so an invalid TP no longer reads as `Gain 100%` next to `Est. PnL -100%`.
- Show `-` for Est. PnL and use `-` as the Gain/Loss placeholder in the full variant instead of `0`, which would read as break-even.
- Keep the Gain/Loss field usable: a value typed there still derives the trigger price, and valid prices keep their calculated Gain/Loss and Est. PnL.
- Leave the beyond-liquidation warning untouched — it arrives as a separate non-blocking `priceWarning`, so its capped `-100%` loss keeps rendering (FEDEV-4002).
- Add regression coverage for the four invalid-direction states (TP/SL x long/short), the compact tradebox variant, gain-driven price derivation, and the unchanged valid / beyond-liquidation states.

Linear: https://linear.app/gmx-io/issue/FEDEV-4265/bug-hide-misleading-gainloss-and-est-pnl-for-invalid-tpsl-prices
