### PR TITLE
Show sub-cent values on Referrals chart Y axis and tooltips FEDEV-4264

### DIFF
--- a/src/components/Referrals/shared/charts/GmxBarChart.tsx
+++ b/src/components/Referrals/shared/charts/GmxBarChart.tsx
@@ -9,7 +9,7 @@ import {
   YAxis,
 } from "recharts";
 
-import { formatUsd } from "lib/numbers";
+import { formatChartTooltipUsd, integerYAxisTickFormatter, usdYAxisTickFormatter } from "./chartValueUtils";
 
 const CHART_MARGIN = { top: 8, right: 0, bottom: 0, left: 0 };
 
@@ -34,25 +34,6 @@ const CHART_CURSOR_PROPS = {
   strokeWidth: 1,
   strokeDasharray: "2 2",
 };
-
-function usdYAxisTickFormatter(value: number) {
-  if (!isFinite(value) || value === 0) return "0";
-
-  return formatCompactNumber(value, 2);
-}
-
-function integerYAxisTickFormatter(value: number) {
-  if (!isFinite(value) || value === 0) return "0";
-
-  return formatCompactNumber(value, 0);
-}
-
-function formatCompactNumber(value: number, maximumFractionDigits: number) {
-  return new Intl.NumberFormat("en-US", {
-    notation: "compact",
-    maximumFractionDigits,
-  }).format(value);
-}
 
 const MIN_POINT_SIZE_PX = 3;
 
@@ -137,7 +118,7 @@ function SimpleChartTooltip({
 }) {
   if (!active || !payload?.length) return null;
   const item = payload[0].payload;
-  const value = isUsd ? formatUsd(item[fieldName]) : item[fieldName];
+  const value = isUsd ? formatChartTooltipUsd(item[fieldName]) : item[fieldName];
 
   return (
     <div className="rounded-8 border border-stroke-primary bg-slate-900 p-10">

--- a/src/components/Referrals/shared/charts/chartValueUtils.ts
+++ b/src/components/Referrals/shared/charts/chartValueUtils.ts
@@ -1,0 +1,49 @@
+import { USD_DECIMALS } from "config/factors";
+import { bigintToNumber, clamp, expandDecimals, formatUsd } from "lib/numbers";
+import { bigMath } from "sdk/utils/bigmath";
+
+const USD_TICK_SIGNIFICANT_DIGITS = 3;
+const SUB_CENT_USD_SIGNIFICANT_DIGITS = 2;
+const MAX_USD_FRACTION_DIGITS = 9;
+const ONE_CENT_USD = expandDecimals(1, USD_DECIMALS - 2);
+
+export function usdYAxisTickFormatter(value: number) {
+  if (!isFinite(value) || value === 0) return "0";
+
+  const maximumFractionDigits = clamp(
+    getFractionDigitsForSignificantDigits(value, USD_TICK_SIGNIFICANT_DIGITS),
+    2,
+    MAX_USD_FRACTION_DIGITS
+  );
+
+  return formatCompactNumber(value, maximumFractionDigits);
+}
+
+export function integerYAxisTickFormatter(value: number) {
+  if (!isFinite(value) || value === 0) return "0";
+
+  return formatCompactNumber(value, 0);
+}
+
+export function formatChartTooltipUsd(usd: bigint) {
+  if (usd === 0n || bigMath.abs(usd) >= ONE_CENT_USD) return formatUsd(usd);
+
+  const displayDecimals = clamp(
+    getFractionDigitsForSignificantDigits(bigintToNumber(usd, USD_DECIMALS), SUB_CENT_USD_SIGNIFICANT_DIGITS),
+    2,
+    MAX_USD_FRACTION_DIGITS
+  );
+
+  return formatUsd(usd, { displayDecimals });
+}
+
+function getFractionDigitsForSignificantDigits(value: number, significantDigits: number) {
+  return significantDigits - 1 - Math.floor(Math.log10(Math.abs(value)));
+}
+
+function formatCompactNumber(value: number, maximumFractionDigits: number) {
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits,
+  }).format(value);
+}


### PR DESCRIPTION
## Summary

- USD Y-axis ticks on the Referrals charts now keep up to 3 significant digits (capped at 9 fraction digits) instead of a fixed 2 fraction digits, so an affiliate with dust rebates no longer gets an axis of zeros.
- Chart tooltips format sub-cent amounts with 2 significant digits instead of collapsing them into `< $0.01`.
- Tick and tooltip formatting moved out of `GmxBarChart` into a shared `chartValueUtils` module.

Linear: https://linear.app/gmx-io/issue/FEDEV-4264/smaller-values-around-0-are-missing-for-small-values-for-y-axis-of
