### PR TITLE
Fill Max with full precision and release the approve button on a short allowance FEDEV-4268

### DIFF
--- a/src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
+++ b/src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -7,7 +7,6 @@ import { zeroAddress } from "viem";
 
 import { ARBITRUM, ContractsChainId } from "config/chains";
 import { type ChainIcons, getIcons } from "config/icons";
-import { MAX_METAMASK_MOBILE_DECIMALS } from "config/ui";
 import { SetPendingTransactions } from "context/PendingTxnsContext/PendingTxnsContext";
 import { calculateStakeBonusPercentage } from "domain/stake/calculateStakeBonusPercentage";
 import {
@@ -25,10 +24,9 @@ import { useMultipleWalletExtensionsChainError } from "lib/chains/getMultipleWal
 import { callContract } from "lib/contracts";
 import { helperToast } from "lib/helperToast";
 import { StakingProcessedData } from "lib/legacy";
-import { formatAmount, formatAmountFree, formatUsd, limitDecimals, numberWithCommas, parseValue } from "lib/numbers";
+import { formatAmount, formatAmountFree, formatUsd, numberWithCommas, parseValue } from "lib/numbers";
 import { UncheckedJsonRpcSigner } from "lib/rpc/UncheckedJsonRpcSigner";
 import { getPageOutdatedError, useHasOutdatedUi } from "lib/useHasOutdatedUi";
-import useIsMetamaskMobile from "lib/wallets/useIsMetamaskMobile";
 import { abis } from "sdk/abis";
 import { NATIVE_TOKEN_ADDRESS } from "sdk/configs/tokens";
 import type { StakingPowerResponse } from "sdk/utils/staking/types";
@@ -129,7 +127,6 @@ export function StakeModal(props: {
   const [isStaking, setIsStaking] = useState(false);
   const [isUnstaking, setIsUnstaking] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
-  const isMetamaskMobile = useIsMetamaskMobile();
   const icons = getIcons(chainId);
   const hasOutdatedUi = useHasOutdatedUi();
   const multipleWalletExtensionsChainError = useMultipleWalletExtensionsChainError();
@@ -331,12 +328,8 @@ export function StakeModal(props: {
 
   const handleStakeMax = useCallback(() => {
     if (stakeMaxAmount === undefined) return;
-    const formattedMaxAmount = formatAmountFree(stakeMaxAmount, 18, 18);
-    const finalMaxAmount = isMetamaskMobile
-      ? limitDecimals(formattedMaxAmount, MAX_METAMASK_MOBILE_DECIMALS)
-      : formattedMaxAmount;
-    setStakeValue(finalMaxAmount);
-  }, [isMetamaskMobile, setStakeValue, stakeMaxAmount]);
+    setStakeValue(formatAmountFree(stakeMaxAmount, 18, 18));
+  }, [setStakeValue, stakeMaxAmount]);
 
   const handleUnstakeMax = useCallback(() => {
     if (unstakeMaxAmount === undefined) return;

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -3,7 +3,6 @@ export const WS_LOST_FOCUS_TIMEOUT = 60_000;
 export const TRADE_LOST_FOCUS_TIMEOUT = 15_000;
 
 export const PERCENTAGE_SUGGESTIONS = [10, 25, 50, 75];
-export const MAX_METAMASK_MOBILE_DECIMALS = 5;
 
 export const TRADE_HISTORY_PER_PAGE = 25;
 export const CLAIMS_HISTORY_PER_PAGE = 25;

--- a/src/domain/tokens/approveTokens.tsx
+++ b/src/domain/tokens/approveTokens.tsx
@@ -43,6 +43,10 @@ type Params = {
 
 type PermitFallbackReason = "unsupported" | "disabled" | "permitsDisabled" | "failed" | "invalidSignature";
 
+export type ApproveTokensResult = {
+  hash: `0x${string}`;
+};
+
 export function getApproveSubmittedToastContent({ txUrl }: { txUrl: string }) {
   return (
     <div>
@@ -71,7 +75,7 @@ export async function approveTokens({
   includeMessage,
   approveAmount,
   permitParams,
-}: Params): Promise<void> {
+}: Params): Promise<ApproveTokensResult | undefined> {
   setIsApproving(true);
 
   if (approveAmount === undefined) {
@@ -172,6 +176,8 @@ export async function approveTokens({
       };
       setPendingTxns([...pendingTxns, pendingTxn]);
     }
+
+    return { hash: res.hash as `0x${string}` };
   } catch (e) {
     onApproveFail?.(e, { isPermit: false });
     // eslint-disable-next-line no-console

--- a/src/domain/tokens/insufficientApproval.spec.tsx
+++ b/src/domain/tokens/insufficientApproval.spec.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { ARBITRUM, SOURCE_BASE_MAINNET } from "config/chains";
+import { GLV_MARKETS } from "config/markets";
+import { getMappedTokenId } from "config/multichain";
+import { MARKETS } from "sdk/configs/markets";
+import { getTokenBySymbol } from "sdk/configs/tokens";
+
+import { formatApprovalAmount, getApprovalTokenDisplay } from "./insufficientApproval";
+
+describe("getApprovalTokenDisplay", () => {
+  it("resolves a configured token by its own symbol and decimals", () => {
+    const weth = getTokenBySymbol(ARBITRUM, "WETH");
+
+    expect(getApprovalTokenDisplay(ARBITRUM, weth.address)).toEqual({ symbol: "WETH", decimals: 18 });
+  });
+
+  it("resolves a GM market token", () => {
+    const marketTokenAddress = Object.keys(MARKETS[ARBITRUM])[0];
+
+    expect(getApprovalTokenDisplay(ARBITRUM, marketTokenAddress)).toEqual({ symbol: "GM", decimals: 18 });
+  });
+
+  it("resolves a GLV token", () => {
+    const glvAddress = Object.keys(GLV_MARKETS[ARBITRUM])[0];
+
+    expect(getApprovalTokenDisplay(ARBITRUM, glvAddress)).toEqual({ symbol: "GLV", decimals: 18 });
+  });
+
+  it("resolves a regular token on a source chain with that chain's decimals", () => {
+    const usdcOnArbitrum = getTokenBySymbol(ARBITRUM, "USDC");
+    const usdcOnBase = getMappedTokenId(ARBITRUM, usdcOnArbitrum.address, SOURCE_BASE_MAINNET)!;
+
+    expect(getApprovalTokenDisplay(SOURCE_BASE_MAINNET, usdcOnBase.address)).toEqual({
+      symbol: "USDC",
+      decimals: usdcOnBase.decimals,
+    });
+  });
+
+  it("names a GLV token on a source chain without its internal key", () => {
+    const glvOnArbitrum = Object.keys(GLV_MARKETS[ARBITRUM])[0];
+    const glvOnBase = getMappedTokenId(ARBITRUM, glvOnArbitrum, SOURCE_BASE_MAINNET)!;
+
+    expect(getApprovalTokenDisplay(SOURCE_BASE_MAINNET, glvOnBase.address)).toEqual({ symbol: "GLV", decimals: 18 });
+  });
+
+  it("returns undefined for an unknown address", () => {
+    expect(getApprovalTokenDisplay(ARBITRUM, "0x0000000000000000000000000000000000000001")).toBeUndefined();
+  });
+});
+
+describe("formatApprovalAmount", () => {
+  it("keeps the full token precision so the shortfall is visible", () => {
+    expect(formatApprovalAmount(1234100000000000n, { symbol: "WETH", decimals: 18 })).toBe("0.0012341 WETH");
+    expect(formatApprovalAmount(1230000000000000n, { symbol: "WETH", decimals: 18 })).toBe("0.00123 WETH");
+  });
+});

--- a/src/domain/tokens/insufficientApproval.tsx
+++ b/src/domain/tokens/insufficientApproval.tsx
@@ -1,0 +1,83 @@
+import { Trans } from "@lingui/macro";
+
+import { getMultichainTokenId } from "config/multichain";
+import { isGlvAddress } from "domain/synthetics/markets/glv";
+import { formatAmountFree } from "lib/numbers";
+import type { AnyChainId } from "sdk/configs/chains";
+import { isMarketTokenAddress } from "sdk/configs/markets";
+import { getToken } from "sdk/configs/tokens";
+
+export type ApprovalTokenDisplay = {
+  symbol: string;
+  decimals: number;
+};
+
+function getConfiguredToken(chainId: number, tokenAddress: string) {
+  try {
+    return getToken(chainId, tokenAddress);
+  } catch {
+    return undefined;
+  }
+}
+
+function getPlatformTokenSymbol(multichainSymbol: string): string {
+  return multichainSymbol.startsWith("<GLV") ? "GLV" : "GM";
+}
+
+export function getApprovalTokenDisplay(chainId: AnyChainId, tokenAddress: string): ApprovalTokenDisplay | undefined {
+  if (isGlvAddress(chainId, tokenAddress)) {
+    return { symbol: "GLV", decimals: 18 };
+  }
+
+  if (isMarketTokenAddress(chainId, tokenAddress)) {
+    return { symbol: "GM", decimals: 18 };
+  }
+
+  const token = getConfiguredToken(chainId, tokenAddress);
+  if (token) {
+    return { symbol: token.symbol, decimals: token.decimals };
+  }
+
+  const multichainTokenId = getMultichainTokenId(chainId, tokenAddress);
+  if (multichainTokenId) {
+    return {
+      symbol: multichainTokenId.isPlatformToken
+        ? getPlatformTokenSymbol(multichainTokenId.symbol)
+        : multichainTokenId.symbol,
+      decimals: multichainTokenId.decimals,
+    };
+  }
+
+  return undefined;
+}
+
+export function formatApprovalAmount(amount: bigint, display: ApprovalTokenDisplay): string {
+  return `${formatAmountFree(amount, display.decimals)} ${display.symbol}`;
+}
+
+export function getInsufficientApprovalToastContent({
+  chainId,
+  tokenAddress,
+  approvedAmount,
+  requiredAmount,
+}: {
+  chainId: AnyChainId;
+  tokenAddress: string;
+  approvedAmount: bigint;
+  requiredAmount: bigint;
+}) {
+  const display = getApprovalTokenDisplay(chainId, tokenAddress);
+
+  if (!display) {
+    return <Trans>The approved amount is lower than the required amount. Approve again or reduce the amount.</Trans>;
+  }
+
+  const approved = formatApprovalAmount(approvedAmount, display);
+  const required = formatApprovalAmount(requiredAmount, display);
+
+  return (
+    <Trans>
+      Approved {approved}, but {required} is required. Approve again or reduce the amount.
+    </Trans>
+  );
+}

--- a/src/domain/tokens/useMaxAvailableAmount.ts
+++ b/src/domain/tokens/useMaxAvailableAmount.ts
@@ -1,9 +1,7 @@
 import { getSourceChainDecimalsMapped } from "config/multichain";
-import { MAX_METAMASK_MOBILE_DECIMALS } from "config/ui";
 import { TokenData, convertToTokenAmount } from "domain/synthetics/tokens";
 import { useChainId } from "lib/chains";
 import { absDiffBps, formatAmountFree, formatBalanceAmount } from "lib/numbers";
-import useIsMetamaskMobile from "lib/wallets/useIsMetamaskMobile";
 import { ContractsChainId, SourceChainId } from "sdk/configs/chains";
 import { getResidualGasUsd, RESIDUAL_GAS_AMOUNT_MULTIPLIER } from "sdk/configs/fees";
 import { bigMath } from "sdk/utils/bigmath";
@@ -185,7 +183,6 @@ export function useMaxAvailableAmount({
   gasPaymentTokenWarningContent: string | undefined;
 } {
   const { chainId } = useChainId();
-  const isMetamaskMobile = useIsMetamaskMobile();
 
   const { maxAvailableAmount, safeMaxAvailableAmount } = getMaxAvailableTokenAmount({
     chainId,
@@ -250,11 +247,7 @@ export function useMaxAvailableAmount({
     });
   }
 
-  const formattedMaxAvailableAmount = formatAmountFree(
-    maxAvailableAmount,
-    decimals,
-    isMetamaskMobile ? MAX_METAMASK_MOBILE_DECIMALS : undefined
-  );
+  const formattedMaxAvailableAmount = formatAmountFree(maxAvailableAmount, decimals);
 
   const isFromTokenInputValueNearMax = absDiffBps(fromTokenAmount, maxAvailableAmount) < 100n; /* 1% */
 

--- a/src/domain/tokens/useTokenApproval.spec.tsx
+++ b/src/domain/tokens/useTokenApproval.spec.tsx
@@ -1,0 +1,230 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTokenApproval } from "./useTokenApproval";
+
+const mocks = vi.hoisted(() => ({
+  CHAIN_ID: 42161,
+  TOKEN: "0x0000000000000000000000000000000000000001",
+  SPENDER: "0x0000000000000000000000000000000000000002",
+  OWNER: "0x0000000000000000000000000000000000000003",
+  HASH: "0xabc" as `0x${string}`,
+  allowanceData: undefined as Record<string, bigint> | undefined,
+  approveTokens: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  readContract: vi.fn(),
+  toastError: vi.fn(),
+  toastContent: vi.fn(),
+}));
+
+vi.mock("domain/synthetics/tokens", () => ({
+  getNeedTokenApprove: (
+    allowanceData: Record<string, bigint> | undefined,
+    tokenAddress: string,
+    amount: bigint | undefined
+  ) => {
+    if (amount === undefined || amount <= 0n) {
+      return false;
+    }
+
+    const allowance = allowanceData?.[tokenAddress];
+
+    return allowance === undefined || amount > allowance;
+  },
+  useTokensAllowanceData: () => ({
+    tokensAllowanceData: mocks.allowanceData,
+    isLoading: mocks.allowanceData === undefined,
+    isLoaded: mocks.allowanceData !== undefined,
+  }),
+}));
+
+vi.mock("./approveTokens", () => ({ approveTokens: mocks.approveTokens }));
+
+vi.mock("./insufficientApproval", () => ({ getInsufficientApprovalToastContent: mocks.toastContent }));
+
+vi.mock("lib/helperToast", () => ({
+  helperToast: { error: mocks.toastError, success: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("lib/wallets/walletConfig", () => ({
+  getPublicClientWithRpc: () => ({
+    waitForTransactionReceipt: mocks.waitForTransactionReceipt,
+    readContract: mocks.readContract,
+  }),
+}));
+
+vi.mock("context/TokenPermitsContext/TokenPermitsContextProvider", () => ({
+  useTokenPermitsContext: () => ({
+    tokenPermits: [],
+    addTokenPermit: vi.fn(),
+    isPermitsDisabled: true,
+    setIsPermitsDisabled: vi.fn(),
+  }),
+}));
+
+vi.mock("context/GmxAccountContext/hooks", () => ({
+  useGmxAccountSettlementChainId: () => [mocks.CHAIN_ID, vi.fn()],
+}));
+
+vi.mock("components/GmxAccountModal/wrapChainAction", () => ({
+  wrapChainAction: (_chainId: number, _setChainId: unknown, action: (signer: unknown) => Promise<void>) => action({}),
+}));
+
+type HookResult = ReturnType<typeof useTokenApproval>;
+
+let latestResult: HookResult | undefined;
+
+function TestComponent({ amount }: { amount: bigint }) {
+  latestResult = useTokenApproval({
+    chainId: mocks.CHAIN_ID as 42161,
+    spenderAddress: mocks.SPENDER,
+    tokens: [{ tokenAddress: mocks.TOKEN, amount }],
+  });
+  return null;
+}
+
+function setup(amount: bigint) {
+  const view = render(<TestComponent amount={amount} />);
+
+  return {
+    get result() {
+      return latestResult!;
+    },
+    rerender: (nextAmount: bigint = amount) => view.rerender(<TestComponent amount={nextAmount} />),
+  };
+}
+
+async function flushAsync() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function approve(view: ReturnType<typeof setup>) {
+  await act(async () => {
+    view.result.handleApprove();
+  });
+  await flushAsync();
+}
+
+describe("useTokenApproval", () => {
+  beforeEach(() => {
+    mocks.allowanceData = { [mocks.TOKEN]: 0n };
+    mocks.approveTokens.mockResolvedValue({ hash: mocks.HASH });
+    mocks.waitForTransactionReceipt.mockResolvedValue({ status: "success", blockNumber: 105n, from: mocks.OWNER });
+    mocks.readContract.mockResolvedValue(900n);
+    mocks.toastContent.mockImplementation((params) => params);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    latestResult = undefined;
+  });
+
+  it("releases the button and reports the shortfall when the mined allowance is below the amount", async () => {
+    const view = setup(1000n);
+    expect(view.result.needsApproval).toBe(true);
+
+    await approve(view);
+
+    expect(mocks.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: mocks.TOKEN,
+        functionName: "allowance",
+        args: [mocks.OWNER, mocks.SPENDER],
+      })
+    );
+    expect(view.result.isApproving).toBe(false);
+    expect(view.result.needsApproval).toBe(true);
+    expect(mocks.toastContent).toHaveBeenCalledWith({
+      chainId: mocks.CHAIN_ID,
+      tokenAddress: mocks.TOKEN,
+      approvedAmount: 900n,
+      requiredAmount: 1000n,
+    });
+    expect(mocks.toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the spinner until the allowance data catches up when the mined allowance covers the amount", async () => {
+    mocks.readContract.mockResolvedValue(1000n);
+
+    const view = setup(1000n);
+    await approve(view);
+
+    expect(view.result.isApproving).toBe(true);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+
+    mocks.allowanceData = { [mocks.TOKEN]: 1000n };
+    await act(async () => {
+      view.rerender();
+    });
+
+    expect(view.result.isApproving).toBe(false);
+    expect(view.result.needsApproval).toBe(false);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("checks the mined allowance against the amount entered by the time it is mined", async () => {
+    let resolveAllowance!: (value: bigint) => void;
+    mocks.readContract.mockReturnValue(
+      new Promise<bigint>((resolve) => {
+        resolveAllowance = resolve;
+      })
+    );
+
+    const view = setup(1000n);
+    await approve(view);
+    expect(view.result.isApproving).toBe(true);
+
+    await act(async () => {
+      view.rerender(2000n);
+    });
+    await act(async () => {
+      resolveAllowance(1500n);
+    });
+    await flushAsync();
+
+    expect(view.result.isApproving).toBe(false);
+    expect(mocks.toastContent).toHaveBeenCalledWith({
+      chainId: mocks.CHAIN_ID,
+      tokenAddress: mocks.TOKEN,
+      approvedAmount: 1500n,
+      requiredAmount: 2000n,
+    });
+  });
+
+  it("releases the button when the approve transaction reverts", async () => {
+    mocks.waitForTransactionReceipt.mockResolvedValue({ status: "reverted", blockNumber: 105n, from: mocks.OWNER });
+
+    const view = setup(1000n);
+    await approve(view);
+
+    expect(mocks.readContract).not.toHaveBeenCalled();
+    expect(view.result.isApproving).toBe(false);
+    expect(view.result.needsApproval).toBe(true);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("releases the button when the receipt cannot be fetched", async () => {
+    mocks.waitForTransactionReceipt.mockRejectedValue(new Error("timeout"));
+
+    const view = setup(1000n);
+    await approve(view);
+
+    expect(view.result.isApproving).toBe(false);
+    expect(view.result.needsApproval).toBe(true);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("releases the button when the mined allowance cannot be read", async () => {
+    mocks.readContract.mockRejectedValue(new Error("rpc"));
+
+    const view = setup(1000n);
+    await approve(view);
+
+    expect(view.result.isApproving).toBe(false);
+    expect(view.result.needsApproval).toBe(true);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/domain/tokens/useTokenApproval.ts
+++ b/src/domain/tokens/useTokenApproval.ts
@@ -1,16 +1,21 @@
 import noop from "lodash/noop";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Address } from "viem";
 
 import { useGmxAccountSettlementChainId } from "context/GmxAccountContext/hooks";
 import { useTokenPermitsContext } from "context/TokenPermitsContext/TokenPermitsContextProvider";
 import { getNeedTokenApprove, useTokensAllowanceData } from "domain/synthetics/tokens";
+import { helperToast } from "lib/helperToast";
 import { EMPTY_ARRAY } from "lib/objects";
 import type { WalletSigner } from "lib/wallets";
+import { getPublicClientWithRpc } from "lib/wallets/walletConfig";
+import { abis } from "sdk/abis";
 import type { AnyChainId } from "sdk/configs/chains";
 
 import { wrapChainAction } from "components/GmxAccountModal/wrapChainAction";
 
 import { approveTokens } from "./approveTokens";
+import { getInsufficientApprovalToastContent } from "./insufficientApproval";
 
 interface TokenToApprove {
   tokenAddress: string;
@@ -30,6 +35,11 @@ export interface HandleApproveOptions {
   onApproveFail?: () => void;
 }
 
+type MinedApproval = {
+  tokenAddress: string;
+  allowance: bigint;
+};
+
 interface UseTokenApprovalReturn {
   tokensToApprove: string[];
   needsApproval: boolean;
@@ -48,6 +58,7 @@ export function useTokenApproval({
   allowPermit = false,
 }: UseTokenApprovalParams): UseTokenApprovalReturn {
   const [approvingToken, setApprovingToken] = useState<string | undefined>();
+  const [minedApproval, setMinedApproval] = useState<MinedApproval | undefined>();
   const { tokenPermits, addTokenPermit, isPermitsDisabled, setIsPermitsDisabled } = useTokenPermitsContext();
   const [, setSettlementChainId] = useGmxAccountSettlementChainId();
 
@@ -101,6 +112,55 @@ export function useTokenApproval({
     }
   }, [approvingToken, tokensToApprove]);
 
+  useEffect(() => {
+    if (minedApproval === undefined || chainId === undefined) {
+      return;
+    }
+
+    setMinedApproval(undefined);
+
+    const { tokenAddress, allowance } = minedApproval;
+    const requiredAmount = mergedTokens.find((token) => token.tokenAddress === tokenAddress)?.amount;
+
+    if (
+      requiredAmount === undefined ||
+      !getNeedTokenApprove({ [tokenAddress]: allowance }, tokenAddress, requiredAmount, permitsOrEmpty)
+    ) {
+      return;
+    }
+
+    setApprovingToken((current) => (current === tokenAddress ? undefined : current));
+    helperToast.error(
+      getInsufficientApprovalToastContent({ chainId, tokenAddress, approvedAmount: allowance, requiredAmount })
+    );
+  }, [chainId, mergedTokens, minedApproval, permitsOrEmpty]);
+
+  const watchApprovalReceipt = useCallback(
+    async (approvalChainId: AnyChainId, tokenAddress: string, spender: string, hash: `0x${string}`) => {
+      const client = getPublicClientWithRpc(approvalChainId);
+      const receipt = await client.waitForTransactionReceipt({ hash }).catch(() => undefined);
+      const allowance =
+        receipt?.status === "success"
+          ? await client
+              .readContract({
+                address: tokenAddress as Address,
+                abi: abis.ERC20,
+                functionName: "allowance",
+                args: [receipt.from, spender as Address],
+              })
+              .catch(() => undefined)
+          : undefined;
+
+      if (allowance === undefined) {
+        setApprovingToken((current) => (current === tokenAddress ? undefined : current));
+        return;
+      }
+
+      setMinedApproval({ tokenAddress, allowance });
+    },
+    []
+  );
+
   const handleApprove = useCallback(
     async (options?: HandleApproveOptions) => {
       const tokenAddress = tokensToApprove[0];
@@ -110,7 +170,7 @@ export function useTokenApproval({
 
       const doApprove = async (signerToUse: WalletSigner) => {
         setApprovingToken(tokenAddress);
-        await approveTokens({
+        const result = await approveTokens({
           setIsApproving: noop,
           signer: signerToUse,
           tokenAddress,
@@ -123,6 +183,10 @@ export function useTokenApproval({
             options?.onApproveFail?.();
           },
         });
+
+        if (result) {
+          watchApprovalReceipt(chainId, tokenAddress, spenderAddress, result.hash);
+        }
       };
 
       try {
@@ -143,6 +207,7 @@ export function useTokenApproval({
       setSettlementChainId,
       spenderAddress,
       tokensToApprove,
+      watchApprovalReceipt,
     ]
   );
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -7823,6 +7823,10 @@ msgstr "Validierung für Tests deaktivieren"
 msgid "GMX icon"
 msgstr "GMX-Symbol"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "Der genehmigte Betrag ist niedriger als der erforderliche Betrag. Genehmigen Sie erneut oder verringern Sie den Betrag."
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "Preiseinfluss übersteigt Ordergröße"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Staken ist nur auf {chainNames} oder {lastChainName} verfügbar. Wechseln Sie das Netzwerk, um fortzufahren."
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "{approved} genehmigt, aber {required} erforderlich. Genehmigen Sie erneut oder verringern Sie den Betrag."
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -7823,6 +7823,10 @@ msgstr "Disable validation for testing"
 msgid "GMX icon"
 msgstr "GMX icon"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "The approved amount is lower than the required amount. Approve again or reduce the amount."
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "Price impact exceeds order size"
@@ -8496,6 +8500,10 @@ msgstr "No, keep {currentLabel} as default"
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "Approved {approved}, but {required} is required. Approve again or reduce the amount."
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -7823,6 +7823,10 @@ msgstr "Desactivar la validación para pruebas"
 msgid "GMX icon"
 msgstr "Icono de GMX"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "El importe aprobado es inferior al importe requerido. Apruebe de nuevo o reduzca el importe."
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "El impacto en el precio supera el tamaño de la orden"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "El staking solo está disponible en {chainNames} o {lastChainName}. Cambie de red para continuar."
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "Se aprobó {approved}, pero se requiere {required}. Apruebe de nuevo o reduzca el importe."
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -7823,6 +7823,10 @@ msgstr "Désactiver la validation pour les tests"
 msgid "GMX icon"
 msgstr "Icône GMX"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "Le montant approuvé est inférieur au montant requis. Approuvez à nouveau ou réduisez le montant."
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "L'impact sur le prix dépasse la taille de l'ordre"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Le staking est disponible uniquement sur {chainNames} ou {lastChainName}. Changez de réseau pour continuer."
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "{approved} approuvé, mais {required} est requis. Approuvez à nouveau ou réduisez le montant."
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -7823,6 +7823,10 @@ msgstr "テスト用にバリデーションを無効化"
 msgid "GMX icon"
 msgstr "GMXアイコン"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "承認された数量が必要な数量を下回っています。再度承認するか、数量を減らしてください。"
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "価格への影響が注文サイズを超えています"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "ステークは{chainNames}または{lastChainName}でのみ利用可能です。続行するにはネットワークを切り替えてください。"
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "{approved} が承認されましたが、{required} が必要です。再度承認するか、数量を減らしてください。"
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -7823,6 +7823,10 @@ msgstr "테스트를 위한 유효성 검사 비활성화"
 msgid "GMX icon"
 msgstr "GMX 아이콘"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "승인된 수량이 필요한 수량보다 적습니다. 다시 승인하거나 수량을 줄이세요."
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "가격 영향이 주문 크기를 초과합니다"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "스테이킹은 {chainNames} 또는 {lastChainName}에서만 가능합니다. 계속하려면 네트워크를 전환하십시오."
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "{approved}이(가) 승인되었지만 {required}이(가) 필요합니다. 다시 승인하거나 수량을 줄이세요."
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -7823,6 +7823,10 @@ msgstr ""
 msgid "GMX icon"
 msgstr ""
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr ""
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr ""
@@ -8495,6 +8499,10 @@ msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
+msgstr ""
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
 msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -7823,6 +7823,10 @@ msgstr "Отключить валидацию для тестирования"
 msgid "GMX icon"
 msgstr "Иконка GMX"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "Одобренная сумма меньше требуемой. Одобрите ещё раз или уменьшите сумму."
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "Влияние на цену превышает размер ордера"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Стейкинг доступен только на {chainNames} или {lastChainName}. Переключите сеть, чтобы продолжить."
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "Одобрено {approved}, но требуется {required}. Одобрите ещё раз или уменьшите сумму."
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -7823,6 +7823,10 @@ msgstr "停用驗證以進行測試"
 msgid "GMX icon"
 msgstr "GMX 圖示"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "已批准的數量低於所需數量。請重新授權或減少數量。"
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "價格影響超過訂單規模"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "質押僅在 {chainNames} 或 {lastChainName} 上可用。請切換網路以繼續。"
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "已批准 {approved}，但需要 {required}。請重新授權或減少數量。"
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -7823,6 +7823,10 @@ msgstr "禁用验证以进行测试"
 msgid "GMX icon"
 msgstr "GMX 图标"
 
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "The approved amount is lower than the required amount. Approve again or reduce the amount."
+msgstr "已批准的数量低于所需数量。请重新授权或减少数量。"
+
 #: src/components/Errors/getContractErrorMessage.ts
 msgid "Price impact exceeds order size"
 msgstr "价格影响超过订单规模"
@@ -8496,6 +8500,10 @@ msgstr ""
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Staking only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "质押仅在 {chainNames} 或 {lastChainName} 上可用。请切换网络以继续。"
+
+#: src/domain/tokens/insufficientApproval.tsx
+msgid "Approved {approved}, but {required} is required. Approve again or reduce the amount."
+msgstr "已批准 {approved}，但需要 {required}。请重新授权或减少数量。"
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Claiming rewards only available on {settlementChainName}. Switch networks to claim referral rewards."


### PR DESCRIPTION
## Summary
- Max fills the full token precision on every Max button: trade box Pay, Edit position deposit, GM/GLV buy/sell, GMX Account deposit/withdraw/send, both bridge modals, Earn Stake GMX. The 5-decimal cap for MetaMask mobile (`MAX_METAMASK_MOBILE_DECIMALS`, introduced in PR #589) is removed. The native-token gas buffer and manual input are unchanged.
- Why the cap existed: the MAX button in MetaMask mobile's spending-cap editor used to round the allowance down to 5 decimals, so the allowance ended up below the amount and the approve button spun forever. That MAX button is gone, but the hang was still reachable with any manually lowered spending cap, on desktop too.
- After an approve is submitted, `useTokenApproval` waits for the receipt through our RPC, reads `allowance(owner, spender)` and compares it with the amount required at that moment. If it is still short, the button is released and a toast explains it: "Approved 0.0005 WETH, but 0.001 WETH is required. Approve again or reduce the amount." A reverted transaction, a receipt not available within 3 minutes, or a failed allowance read also release the button, without a toast.
- The check does not rely on block numbers: on Arbitrum `Multicall.getBlockNumber()` returns the L1 block while receipts and Approval events carry L2 blocks, so a block-based freshness comparison never passes there.
- Toast symbol and decimals are resolved for regular tokens, GM/GLV and source-chain tokens, with a generic message as a fallback. Translations added for all locales.
- Tests: `useTokenApproval.spec.tsx` (6 cases), `insufficientApproval.spec.tsx` (7 cases).

Known and pre-existing, not touched here: `useTokensAllowanceData` compares the Approval event with the multicall result by block number, and on Arbitrum `Multicall.getBlockNumber()` returns the L1 block, so the event always wins there. On Arbitrum this hook only receives events in the multichain flows (source-chain approvals to Stargate), so the trade box is not affected. Draft with the fix: https://github.com/gmx-io/gmx-interface/pull/2822

Linear: https://linear.app/gmx-io/issue/FEDEV-4268/bug-max-fills-only-5-decimals-in-mobile-wallet-browsers-leaving
