### PR TITLE
Fix filtered market search empty states FEDEV-4232

### DIFF
--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -400,7 +400,7 @@ function MarketsList() {
   }, [isSwap]);
 
   const availableLiquidityLabel = isMobile ? (isSmallMobile ? t`LIQ.` : t`AVAIL. LIQ.`) : t`AVAILABLE LIQUIDITY`;
-  const shouldSearchAllPerpMarkets = !isSwap && topLevelTab !== "all";
+  const shouldSearchAllMarkets = topLevelTab !== "all";
 
   return (
     <>
@@ -556,12 +556,14 @@ function MarketsList() {
                   <Button
                     type="button"
                     variant="secondary"
-                    onClick={() =>
-                      shouldSearchAllPerpMarkets ? setTopLevelTab("all") : setMode(isSwap ? "perp" : "swap")
-                    }
+                    onClick={() => (shouldSearchAllMarkets ? setTopLevelTab("all") : setMode(isSwap ? "perp" : "swap"))}
                   >
-                    {shouldSearchAllPerpMarkets ? (
-                      <Trans>Search in all perpetual markets</Trans>
+                    {shouldSearchAllMarkets ? (
+                      isSwap ? (
+                        <Trans>Search in all swap markets</Trans>
+                      ) : (
+                        <Trans>Search in all perpetual markets</Trans>
+                      )
                     ) : isSwap ? (
                       <Trans>Search in perpetuals markets</Trans>
                     ) : (

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -606,8 +606,8 @@ function MarketsList() {
                     </Button>
                   )}
                   {shouldOfferOtherMode && (
-                    <div className="flex flex-col items-center gap-4 text-12">
-                      <span>
+                    <>
+                      <span className="text-12 text-typography-secondary">
                         {isSwap ? (
                           <Trans>Results are available in Perpetuals.</Trans>
                         ) : (
@@ -616,13 +616,13 @@ function MarketsList() {
                       </span>
                       <Button
                         type="button"
-                        variant="link"
-                        className="!min-h-0 !p-0"
+                        variant="secondary"
                         onClick={() => setModeAndResetFilters(isSwap ? "perp" : "swap")}
                       >
                         {isSwap ? <Trans>View results in Perpetuals</Trans> : <Trans>View results in Swap</Trans>}
+                        <SearchIconComponent className="size-16" />
                       </Button>
-                    </div>
+                    </>
                   )}
                 </div>
               ) : (

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -81,6 +81,7 @@ type Props = {
 };
 
 const SWAP_EXCLUDED_TOP_LEVEL_TABS: TopLevelTab[] = ["tradfi", "recently-listed"];
+const MAX_MARKET_SEARCH_QUERY_LENGTH = 100;
 
 function getSearchMatchedTokens(options: Token[] | undefined, searchKeyword: string, isSwap: boolean) {
   if (!options) return undefined;
@@ -451,6 +452,7 @@ function MarketsList() {
             setValue={setSearchKeyword}
             onKeyDown={handleKeyDown}
             placeholder={placeholder}
+            maxLength={MAX_MARKET_SEARCH_QUERY_LENGTH}
           />
         </div>
 
@@ -586,8 +588,8 @@ function MarketsList() {
             isEmpty={true}
             emptyText={
               query ? (
-                <div className="flex flex-col items-center gap-12">
-                  <span className="text-12 text-typography-secondary">
+                <div className="flex w-full flex-col items-center gap-12 px-16">
+                  <span className="w-full min-w-0 text-center text-12 text-typography-secondary [overflow-wrap:anywhere]">
                     {shouldOfferSearchAll ? (
                       <Trans>No results with the selected filters.</Trans>
                     ) : (

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -68,6 +68,7 @@ import { ArbitrumRecommendation } from "./ArbitrumRecommendation";
 import {
   applySubCategoryFilter,
   applyTopLevelFilter,
+  getMarketSearchEmptyStateActions,
   getRecentlyListedTokenAddresses,
   isMarketRecentlyListed,
 } from "./marketFilters";
@@ -80,6 +81,22 @@ type Props = {
 };
 
 const SWAP_EXCLUDED_TOP_LEVEL_TABS: TopLevelTab[] = ["tradfi", "recently-listed"];
+
+function getSearchMatchedTokens(options: Token[] | undefined, searchKeyword: string, isSwap: boolean) {
+  if (!options) return undefined;
+  const query = searchKeyword.trim();
+  if (!query) return options;
+
+  return searchBy(
+    options,
+    [
+      (item) => stripBlacklistedWords(item.name),
+      (item) => (isSwap ? item.symbol : `${getTokenVisualMultiplier(item)}${item.symbol}`),
+      (item) => (item.searchAliases ?? []).join(" "),
+    ],
+    query
+  );
+}
 
 export default function ChartTokenSelector(props: Props) {
   const { selectedToken, oneRowLabels } = props;
@@ -190,7 +207,7 @@ function MarketsList() {
     subCategoryTab: storedSubCategoryTab,
     mode,
     setMode,
-    setTopLevelTab,
+    setModeAndResetFilters,
     setSubCategoryTab,
     favoriteTokens,
     toggleFavoriteToken,
@@ -217,6 +234,7 @@ function MarketsList() {
 
   const isSwap = mode === "swap";
   const availableTokens = isSwap ? swapTokens : perpTokens;
+  const otherModeAvailableTokens = isSwap ? perpTokens : swapTokens;
 
   const { availableChartTokens: options, availableChartTokenAddresses } = useMemo(() => {
     const availableChartTokens = availableTokens?.filter((token) => isChartAvailableForToken(chainId, token.symbol));
@@ -227,6 +245,11 @@ function MarketsList() {
       availableChartTokenAddresses,
     };
   }, [availableTokens, chainId]);
+
+  const otherModeOptions = useMemo(
+    () => otherModeAvailableTokens?.filter((token) => isChartAvailableForToken(chainId, token.symbol)),
+    [chainId, otherModeAvailableTokens]
+  );
 
   const recentlyListedCount = useMemo(() => {
     if (!options || recentlyListedAddressesSet.size === 0) return 0;
@@ -299,11 +322,21 @@ function MarketsList() {
   );
 
   const [searchKeyword, setSearchKeyword] = useState("");
+  const query = searchKeyword.trim();
+
+  const currentModeSearchResults = useMemo(
+    () => getSearchMatchedTokens(options, searchKeyword, isSwap),
+    [isSwap, options, searchKeyword]
+  );
+
+  const otherModeSearchResults = useMemo(() => {
+    if (!query || currentModeSearchResults === undefined || currentModeSearchResults.length > 0) return undefined;
+    return getSearchMatchedTokens(otherModeOptions, query, !isSwap);
+  }, [currentModeSearchResults, isSwap, otherModeOptions, query]);
 
   const sortedTokens = useFilterSortTokens({
     chainId,
-    options,
-    searchKeyword,
+    textMatchedTokens: currentModeSearchResults,
     topLevelTab,
     subCategoryTab,
     recentlyListedAddressesSet,
@@ -314,7 +347,6 @@ function MarketsList() {
     dayPriceDeltaMap,
     dayVolumes,
     indexTokenStatsMap,
-    isSwap,
   });
 
   const sortedDetails = useMemo(() => {
@@ -338,7 +370,7 @@ function MarketsList() {
 
   useMissedCoinsSearch({
     searchText: searchKeyword,
-    isEmpty: !sortedTokens?.length && topLevelTab === "all",
+    isEmpty: !currentModeSearchResults?.length,
     isLoaded: Boolean(options?.length),
     place: MissedCoinsPlace.marketDropdown,
     mode,
@@ -400,7 +432,11 @@ function MarketsList() {
   }, [isSwap]);
 
   const availableLiquidityLabel = isMobile ? (isSmallMobile ? t`LIQ.` : t`AVAIL. LIQ.`) : t`AVAILABLE LIQUIDITY`;
-  const shouldSearchAllMarkets = topLevelTab !== "all";
+  const { shouldOfferSearchAll, shouldOfferOtherMode } = getMarketSearchEmptyStateActions({
+    hasActiveFilter: topLevelTab !== "all",
+    hasCurrentModeMatches: Boolean(currentModeSearchResults?.length),
+    hasOtherModeMatches: Boolean(otherModeSearchResults?.length),
+  });
 
   return (
     <>
@@ -548,29 +584,46 @@ function MarketsList() {
             isLoading={false}
             isEmpty={true}
             emptyText={
-              searchKeyword.trim() ? (
+              query ? (
                 <div className="flex flex-col items-center gap-12">
-                  <span className="text-12">
-                    <Trans>No markets matched.</Trans>
+                  <span className="text-12 text-typography-secondary">
+                    {shouldOfferSearchAll ? (
+                      <Trans>No results with the selected filters.</Trans>
+                    ) : isSwap ? (
+                      <Trans>No Swap tokens match "{query}".</Trans>
+                    ) : (
+                      <Trans>No perpetual markets match "{query}".</Trans>
+                    )}
                   </span>
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={() => (shouldSearchAllMarkets ? setTopLevelTab("all") : setMode(isSwap ? "perp" : "swap"))}
-                  >
-                    {shouldSearchAllMarkets ? (
-                      isSwap ? (
-                        <Trans>Search in all swap markets</Trans>
+                  {shouldOfferSearchAll && (
+                    <Button type="button" variant="secondary" onClick={() => setModeAndResetFilters(mode)}>
+                      {isSwap ? (
+                        <Trans>Search in all Swap tokens</Trans>
                       ) : (
                         <Trans>Search in all perpetual markets</Trans>
-                      )
-                    ) : isSwap ? (
-                      <Trans>Search in perpetuals markets</Trans>
-                    ) : (
-                      <Trans>Search in swap markets</Trans>
-                    )}
-                    <SearchIconComponent className="size-16" />
-                  </Button>
+                      )}
+                      <SearchIconComponent className="size-16" />
+                    </Button>
+                  )}
+                  {shouldOfferOtherMode && (
+                    <div className="flex flex-col items-center gap-4 text-12">
+                      <span>
+                        {isSwap ? (
+                          <Trans>Results are available in Perpetuals.</Trans>
+                        ) : (
+                          <Trans>Results are available in Swap.</Trans>
+                        )}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="link"
+                        className="!min-h-0 !p-0"
+                        onClick={() => setModeAndResetFilters(isSwap ? "perp" : "swap")}
+                      >
+                        {isSwap ? <Trans>View results in Perpetuals</Trans> : <Trans>View results in Swap</Trans>}
+                      </Button>
+                    </div>
+                  )}
                 </div>
               ) : (
                 <Trans>No markets matched.</Trans>
@@ -585,8 +638,7 @@ function MarketsList() {
 
 function useFilterSortTokens({
   chainId,
-  options,
-  searchKeyword,
+  textMatchedTokens,
   topLevelTab,
   subCategoryTab,
   recentlyListedAddressesSet,
@@ -597,11 +649,9 @@ function useFilterSortTokens({
   dayPriceDeltaMap,
   dayVolumes,
   indexTokenStatsMap,
-  isSwap,
 }: {
   chainId: number;
-  options: Token[] | undefined;
-  searchKeyword: string;
+  textMatchedTokens: Token[] | undefined;
   topLevelTab: TopLevelTab;
   subCategoryTab: SubCategoryTab;
   recentlyListedAddressesSet: Set<string>;
@@ -612,31 +662,18 @@ function useFilterSortTokens({
   dayPriceDeltaMap: PriceDeltaMap | undefined;
   dayVolumes: Record<Address, bigint> | undefined;
   indexTokenStatsMap: Partial<IndexTokensStats> | undefined;
-  isSwap: boolean;
 }) {
   const filteredTokens: Token[] | undefined = useMemo(() => {
-    if (!options) return undefined;
+    if (!textMatchedTokens) return undefined;
 
-    const textMatched = searchKeyword.trim()
-      ? searchBy(
-          options,
-          [
-            (item) => stripBlacklistedWords(item.name),
-            (item) => (isSwap ? item.symbol : `${getTokenVisualMultiplier(item)}${item.symbol}`),
-            (item) => (item.searchAliases ?? []).join(" "),
-          ],
-          searchKeyword
-        )
-      : options;
-
-    const afterTopLevel = applyTopLevelFilter(textMatched ?? [], {
+    const afterTopLevel = applyTopLevelFilter(textMatchedTokens, {
       topLevelTab,
       favoriteAddresses: favoriteTokens,
       recentlyListedAddresses: recentlyListedAddressesSet,
     });
 
     return applySubCategoryFilter(afterTopLevel, { topLevelTab, subCategoryTab });
-  }, [options, searchKeyword, isSwap, topLevelTab, subCategoryTab, favoriteTokens, recentlyListedAddressesSet]);
+  }, [textMatchedTokens, topLevelTab, subCategoryTab, favoriteTokens, recentlyListedAddressesSet]);
 
   const getMaxLongShortLiquidityPool = useSelector(selectTradeboxGetMaxLongShortLiquidityPool);
 

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -190,6 +190,7 @@ function MarketsList() {
     subCategoryTab: storedSubCategoryTab,
     mode,
     setMode,
+    setTopLevelTab,
     setSubCategoryTab,
     favoriteTokens,
     toggleFavoriteToken,
@@ -399,6 +400,7 @@ function MarketsList() {
   }, [isSwap]);
 
   const availableLiquidityLabel = isMobile ? (isSmallMobile ? t`LIQ.` : t`AVAIL. LIQ.`) : t`AVAILABLE LIQUIDITY`;
+  const shouldSearchAllPerpMarkets = !isSwap && topLevelTab !== "all";
 
   return (
     <>
@@ -551,8 +553,20 @@ function MarketsList() {
                   <span className="text-12">
                     <Trans>No markets matched.</Trans>
                   </span>
-                  <Button type="button" variant="secondary" onClick={() => setMode(isSwap ? "perp" : "swap")}>
-                    {isSwap ? <Trans>Search in perpetuals markets</Trans> : <Trans>Search in swap markets</Trans>}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() =>
+                      shouldSearchAllPerpMarkets ? setTopLevelTab("all") : setMode(isSwap ? "perp" : "swap")
+                    }
+                  >
+                    {shouldSearchAllPerpMarkets ? (
+                      <Trans>Search in all perpetual markets</Trans>
+                    ) : isSwap ? (
+                      <Trans>Search in perpetuals markets</Trans>
+                    ) : (
+                      <Trans>Search in swap markets</Trans>
+                    )}
                     <SearchIconComponent className="size-16" />
                   </Button>
                 </div>

--- a/src/components/ChartTokenSelector/ChartTokenSelector.tsx
+++ b/src/components/ChartTokenSelector/ChartTokenSelector.tsx
@@ -432,6 +432,7 @@ function MarketsList() {
   }, [isSwap]);
 
   const availableLiquidityLabel = isMobile ? (isSmallMobile ? t`LIQ.` : t`AVAIL. LIQ.`) : t`AVAILABLE LIQUIDITY`;
+  const marketTypeLabel = isSwap ? t`Swap tokens` : t`perpetual markets`;
   const { shouldOfferSearchAll, shouldOfferOtherMode } = getMarketSearchEmptyStateActions({
     hasActiveFilter: topLevelTab !== "all",
     hasCurrentModeMatches: Boolean(currentModeSearchResults?.length),
@@ -589,19 +590,15 @@ function MarketsList() {
                   <span className="text-12 text-typography-secondary">
                     {shouldOfferSearchAll ? (
                       <Trans>No results with the selected filters.</Trans>
-                    ) : isSwap ? (
-                      <Trans>No Swap tokens match "{query}".</Trans>
                     ) : (
-                      <Trans>No perpetual markets match "{query}".</Trans>
+                      <Trans>
+                        No {marketTypeLabel} match "{query}".
+                      </Trans>
                     )}
                   </span>
                   {shouldOfferSearchAll && (
                     <Button type="button" variant="secondary" onClick={() => setModeAndResetFilters(mode)}>
-                      {isSwap ? (
-                        <Trans>Search in all Swap tokens</Trans>
-                      ) : (
-                        <Trans>Search in all perpetual markets</Trans>
-                      )}
+                      <Trans>Search in all {marketTypeLabel}</Trans>
                       <SearchIconComponent className="size-16" />
                     </Button>
                   )}

--- a/src/components/ChartTokenSelector/__tests__/marketFilters.spec.ts
+++ b/src/components/ChartTokenSelector/__tests__/marketFilters.spec.ts
@@ -6,6 +6,7 @@ import {
   applySubCategoryFilter,
   applyTopLevelFilter,
   getRecentlyListedTokenAddresses,
+  getMarketSearchEmptyStateActions,
   isMarketRecentlyListed,
 } from "../marketFilters";
 
@@ -103,6 +104,58 @@ describe("applySubCategoryFilter", () => {
 
   it("ignores sub-cat when parent is not crypto/tradfi", () => {
     expect(applySubCategoryFilter(tokens, { topLevelTab: "all", subCategoryTab: "ai" })).toEqual(tokens);
+  });
+});
+
+describe("getMarketSearchEmptyStateActions", () => {
+  it("offers search in All when the current mode has matches outside the active filter", () => {
+    expect(
+      getMarketSearchEmptyStateActions({
+        hasActiveFilter: true,
+        hasCurrentModeMatches: true,
+        hasOtherModeMatches: true,
+      })
+    ).toEqual({ shouldOfferSearchAll: true, shouldOfferOtherMode: false });
+  });
+
+  it("offers the other mode only when the current mode has no matches", () => {
+    expect(
+      getMarketSearchEmptyStateActions({
+        hasActiveFilter: true,
+        hasCurrentModeMatches: false,
+        hasOtherModeMatches: true,
+      })
+    ).toEqual({ shouldOfferSearchAll: false, shouldOfferOtherMode: true });
+  });
+
+  it("offers the other mode from All when only the other mode has matches", () => {
+    expect(
+      getMarketSearchEmptyStateActions({
+        hasActiveFilter: false,
+        hasCurrentModeMatches: false,
+        hasOtherModeMatches: true,
+      })
+    ).toEqual({ shouldOfferSearchAll: false, shouldOfferOtherMode: true });
+  });
+
+  it("offers no action when neither mode has matches", () => {
+    expect(
+      getMarketSearchEmptyStateActions({
+        hasActiveFilter: true,
+        hasCurrentModeMatches: false,
+        hasOtherModeMatches: false,
+      })
+    ).toEqual({ shouldOfferSearchAll: false, shouldOfferOtherMode: false });
+  });
+
+  it("does not offer search in All when All is already active", () => {
+    expect(
+      getMarketSearchEmptyStateActions({
+        hasActiveFilter: false,
+        hasCurrentModeMatches: true,
+        hasOtherModeMatches: true,
+      })
+    ).toEqual({ shouldOfferSearchAll: false, shouldOfferOtherMode: false });
   });
 });
 

--- a/src/components/ChartTokenSelector/marketFilters.ts
+++ b/src/components/ChartTokenSelector/marketFilters.ts
@@ -44,6 +44,21 @@ export function applySubCategoryFilter(
   return tokens.filter((t) => t.categories?.includes(args.subCategoryTab as TokenCategory));
 }
 
+export function getMarketSearchEmptyStateActions({
+  hasActiveFilter,
+  hasCurrentModeMatches,
+  hasOtherModeMatches,
+}: {
+  hasActiveFilter: boolean;
+  hasCurrentModeMatches: boolean;
+  hasOtherModeMatches: boolean;
+}) {
+  return {
+    shouldOfferSearchAll: hasActiveFilter && hasCurrentModeMatches,
+    shouldOfferOtherMode: !hasCurrentModeMatches && hasOtherModeMatches,
+  };
+}
+
 export function isMarketRecentlyListed(listingDate: number | undefined, now: number): boolean {
   if (listingDate === undefined) return false;
   return now - listingDate < RECENTLY_LISTED_WINDOW_MS;

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -22,6 +22,7 @@ type Props = {
   autoFocus?: boolean;
   qa?: string;
   noBorder?: boolean;
+  maxLength?: number;
 };
 
 export default function SearchInput({
@@ -33,6 +34,7 @@ export default function SearchInput({
   autoFocus,
   qa = "token-search-input",
   noBorder,
+  maxLength,
 }: Props) {
   const isSmallerScreen = useMedia("(max-width: 700px)");
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -86,6 +88,7 @@ export default function SearchInput({
         onKeyDown={onKeyDown}
         onFocus={handleFocus}
         autoFocus={autoFocus ?? !isSmallerScreen}
+        maxLength={maxLength}
         className={cx(
           "block h-full w-full rounded-8 bg-slate-800 p-[6.5px] pl-32 pr-32 text-[13px] leading-1 placeholder-slate-100 hover:bg-fill-surfaceElevatedHover",
           {

--- a/src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
+++ b/src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
@@ -96,6 +96,7 @@ type TokensFavoritesContextType = TokensFavoritesStore & {
   setTopLevelTab: (key: TokenFavoriteKey, tab: TopLevelTab) => void;
   setSubCategoryTab: (key: TokenFavoriteKey, parent: "crypto" | "tradfi", tab: SubCategoryTab) => void;
   setMode: (key: TokenFavoriteKey, mode: TradeMode) => void;
+  setModeAndResetFilters: (key: TokenFavoriteKey, mode: TradeMode) => void;
   toggleFavoriteToken: (type: TokenFavoritesType, address: string) => void;
 };
 
@@ -107,6 +108,7 @@ export type TokenFavoritesState = {
   setTopLevelTab: (tab: TopLevelTab) => void;
   setSubCategoryTab: (tab: SubCategoryTab) => void;
   setMode: (mode: TradeMode) => void;
+  setModeAndResetFilters: (mode: TradeMode) => void;
   toggleFavoriteToken: (address: string) => void;
 };
 
@@ -119,6 +121,7 @@ const context = createContext<TokensFavoritesContextType>({
   setTopLevelTab: noop,
   setSubCategoryTab: noop,
   setMode: noop,
+  setModeAndResetFilters: noop,
   toggleFavoriteToken: noop,
 });
 
@@ -182,6 +185,21 @@ export function TokensFavoritesContextProvider({ children }: PropsWithChildren) 
     [setSettings]
   );
 
+  const setModeAndResetFilters = useCallback(
+    (key: TokenFavoriteKey, mode: TradeMode) => {
+      setSettings((prev) => ({
+        ...prev,
+        topLevelTabs: { ...(prev.topLevelTabs ?? {}), [key]: "all" },
+        subCategoryTabs: {
+          ...(prev.subCategoryTabs ?? {}),
+          [key]: { crypto: "all", tradfi: "all" },
+        },
+        modes: { ...(prev.modes ?? {}), [key]: mode },
+      }));
+    },
+    [setSettings]
+  );
+
   const toggleFavoriteToken = useCallback(
     (type: TokenFavoritesType, address: string) => {
       setSettings((prev) => {
@@ -208,9 +226,10 @@ export function TokensFavoritesContextProvider({ children }: PropsWithChildren) 
       setTopLevelTab,
       setSubCategoryTab,
       setMode,
+      setModeAndResetFilters,
       toggleFavoriteToken,
     }),
-    [normalized, setTopLevelTab, setSubCategoryTab, setMode, toggleFavoriteToken]
+    [normalized, setTopLevelTab, setSubCategoryTab, setMode, setModeAndResetFilters, toggleFavoriteToken]
   );
 
   return <Provider value={value}>{children}</Provider>;
@@ -243,6 +262,8 @@ export function useTokensFavorites(key: TokenFavoriteKey): TokenFavoritesState {
 
   const setMode = useCallback((m: TradeMode) => ctx.setMode(key, m), [ctx, key]);
 
+  const setModeAndResetFilters = useCallback((m: TradeMode) => ctx.setModeAndResetFilters(key, m), [ctx, key]);
+
   const toggleFavoriteToken = useCallback((address: string) => ctx.toggleFavoriteToken(type, address), [ctx, type]);
 
   return {
@@ -253,6 +274,7 @@ export function useTokensFavorites(key: TokenFavoriteKey): TokenFavoritesState {
     setTopLevelTab,
     setSubCategoryTab,
     setMode,
+    setModeAndResetFilters,
     toggleFavoriteToken,
   };
 }

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -5395,6 +5395,10 @@ msgstr "Argumente"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Sie benötigen USDC und {0} auf {1}, um einen Empfehlungscode über das GMX-Konto zu erstellen. Zahlen Sie Geld ein oder wechseln Sie zu einem anderen Netzwerk."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "In allen Swap-Märkten suchen"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero Scan"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "Insgesamt verdient"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "In allen Perpetual-Märkten suchen"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading aktiviert. Deaktivieren Sie es in den <0>Einstellungen</0>"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -523,10 +523,6 @@ msgstr "Doppeltes {indexSymbol}-Exposure durch Position und Sicherheit. Höherer
 msgid "GMX Account balance"
 msgstr "GMX Account Guthaben"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "In Perpetual-Märkten suchen"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "Adresse kopiert!"
@@ -1542,6 +1538,10 @@ msgstr "Insgesamt eingezahlte Margin"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "Um GMX auf {0} zu kaufen, <0>wechseln Sie Ihr Netzwerk</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "Ergebnisse sind unter „Perpetuals“ verfügbar."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade (ehemals GMX Solana) wird auf einer anderen Website gehostet und
 msgid "You have not traded during the selected period"
 msgstr "Sie haben im ausgewählten Zeitraum nicht gehandelt"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "Keine Perpetual-Märkte entsprechen „{query}“."
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Standardanzahl der Teile für TWAP-Orders"
@@ -3137,6 +3141,10 @@ msgstr "System"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "Verdienen Sie Belohnungen, indem Sie Ihren Empfehlungscode teilen"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "Ergebnisse sind im Swap verfügbar."
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "Long-Positionen"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "Ergebnisse in Perpetuals anzeigen"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "Argumente"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Sie benötigen USDC und {0} auf {1}, um einen Empfehlungscode über das GMX-Konto zu erstellen. Zahlen Sie Geld ein oder wechseln Sie zu einem anderen Netzwerk."
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "In allen Swap-Märkten suchen"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero Scan"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Kaufen Sie GMX-Bonds auf Bond Protocol mit einem Rabatt und einer kurzen Sperrfrist"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "Keine Ergebnisse mit den ausgewählten Filtern."
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "Größe, $"
 msgid "Wallet received before close"
 msgstr "Wallet-Eingang vor dem Schließen"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "Ergebnisse im Swap anzeigen"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "Garantierte Liquidität"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "Keine Swap-Tokens entsprechen „{query}“."
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Ohne beanspruchte Funding-Gebühren, Preiseinfluss-Rückerstattungen und Ausführungsgebühren."
@@ -9628,6 +9648,10 @@ msgstr "Sprache auswählen"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Unbekannter Wert"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "Alle Swap-Tokens durchsuchen"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "Vermeiden Sie Preisdochte mit transparenten Chainlink-Preisfeeds unter einer Sekunde, maßgeschneidert für GMX"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "Keine passenden Märkte."
 
@@ -11835,10 +11858,6 @@ msgstr "Mehr traden, weniger zahlen.<0/>Empfehlen und verdienen."
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "Keine Pools passen"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "In Swap-Märkten suchen"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -932,6 +932,10 @@ msgstr "Konvertieren Sie esGMX in GMX-Token. Lesen Sie die Vesting-Details, bevo
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "Keine Treffer für „{query}“ in {marketTypeLabel}."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "Negativer Wert: Händler zahlen Finanzierung"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "Dieser Swap benötigt externes Routing, das nicht verfügbar ist, solange der Gas-Token dem Token entspricht, den Sie erhalten, und kein anderer Gas-Token über ausreichend Guthaben verfügt."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "Alle {marketTypeLabel} durchsuchen"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "Dezentrales Handelsprotokoll"
@@ -3040,6 +3048,10 @@ msgstr "Helfen Sie uns, GMX zu verbessern. Aus Sicherheitsgründen werden wir Si
 msgid "Cancel margin deposit"
 msgstr "Margin-Einzahlung stornieren"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "Swap-Tokens"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "Globales Netzwerk"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade (ehemals GMX Solana) wird auf einer anderen Website gehostet und
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "Sie haben im ausgewählten Zeitraum nicht gehandelt"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "Keine Perpetual-Märkte entsprechen „{query}“."
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "Staking"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "Dezentralisierte Perpetual-Börse | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "Perpetual-Märkte"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "Keine Swap-Tokens entsprechen „{query}“."
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Ohne beanspruchte Funding-Gebühren, Preiseinfluss-Rückerstattungen und Ausführungsgebühren."
@@ -9648,10 +9656,6 @@ msgstr "Sprache auswählen"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Unbekannter Wert"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "Alle Swap-Tokens durchsuchen"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "Insgesamt verdient"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "In allen Perpetual-Märkten suchen"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "Total lifetime earned"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "Search in all perpetual markets"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -5395,6 +5395,10 @@ msgstr "Arguments"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "Search in all swap markets"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -932,6 +932,10 @@ msgstr "Convert esGMX to GMX tokens. Read the vesting details before using the v
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr "Sender has withdrawn all tokens from the Affiliate vesting vault"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "No {marketTypeLabel} match \"{query}\"."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "Negative value: traders pay funding"
@@ -2241,6 +2245,10 @@ msgstr "Short net rate"
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "Search in all {marketTypeLabel}"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "Decentralized trading protocol"
@@ -3040,6 +3048,10 @@ msgstr "Help us improve GMX. For security, we won't contact you first. Send \"I 
 msgid "Cancel margin deposit"
 msgstr "Cancel margin deposit"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "Swap tokens"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "Global network"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade (previously GMX Solana) is hosted on another website and run by 
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "You have not traded during the selected period"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "No perpetual markets match \"{query}\"."
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "Staking"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "Decentralized perpetual exchange | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "perpetual markets"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr "Fetching swap route ({0}/{1})..."
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr "Depositing {amountText} to {indexTokenText} Short..."
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "No Swap tokens match \"{query}\"."
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Excludes claimed funding, price impact rebates and execution fees."
@@ -9648,10 +9656,6 @@ msgstr "Select language"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Unknown value"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "Search in all Swap tokens"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "Total lifetime earned"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "Search in all perpetual markets"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -523,10 +523,6 @@ msgstr "Double {indexSymbol} exposure from position and collateral. Higher liqui
 msgid "GMX Account balance"
 msgstr "GMX Account balance"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "Search in perpetuals markets"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "Address copied!"
@@ -1542,6 +1538,10 @@ msgstr "Total margin funded"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "To buy GMX on {0}, <0>change your network</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "Results are available in Perpetuals."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade (previously GMX Solana) is hosted on another website and run by 
 msgid "You have not traded during the selected period"
 msgstr "You have not traded during the selected period"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "No perpetual markets match \"{query}\"."
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Default parts for TWAP orders"
@@ -3137,6 +3141,10 @@ msgstr "System"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "Earn rewards by sharing your referral code"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "Results are available in Swap."
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "Long positions"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr "Share your code"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "View results in Perpetuals"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "Arguments"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "Search in all swap markets"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"
@@ -5782,6 +5790,10 @@ msgstr "Your {symbol} margin exceeds the {indexName} short position size. Margin
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "No results with the selected filters."
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "Size, $"
 msgid "Wallet received before close"
 msgstr "Wallet received before close"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "View results in Swap"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "Guaranteed liquidity"
@@ -9294,6 +9310,10 @@ msgstr "Fetching swap route ({0}/{1})..."
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr "Depositing {amountText} to {indexTokenText} Short..."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "No Swap tokens match \"{query}\"."
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Excludes claimed funding, price impact rebates and execution fees."
@@ -9628,6 +9648,10 @@ msgstr "Select language"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Unknown value"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "Search in all Swap tokens"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "Avoid price wicks with transparent, sub-second Chainlink price feeds tailor-made for GMX"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "No markets matched."
 
@@ -11835,10 +11858,6 @@ msgstr "Trade more, pay less.<0/>Refer, and earn."
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "No pools matched"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "Search in swap markets"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -932,6 +932,10 @@ msgstr "Convierta esGMX en tokens GMX. Lea los detalles del periodo de consolida
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "No hay coincidencias para \"{query}\" en {marketTypeLabel}."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "Valor negativo: los operadores pagan financiación"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "Este swap requiere enrutamiento externo, que no está disponible mientras el token de pago de gas coincida con el token que recibirá, y ningún otro token de gas tiene saldo suficiente."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "Buscar en todos los {marketTypeLabel}"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "Protocolo de negociación descentralizado"
@@ -3040,6 +3048,10 @@ msgstr "Ayúdenos a mejorar GMX. Por seguridad, no le contactaremos primero. Env
 msgid "Cancel margin deposit"
 msgstr "Cancelar depósito de margen"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "tokens de Swap"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "Red global"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade (anteriormente GMX Solana) está alojado en otro sitio web y ges
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "No ha operado durante el período seleccionado"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "Ningún mercado perpetuo coincide con \"{query}\"."
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "Staking"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "Plataforma de intercambio perpetuo descentralizada | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "mercados perpetuos"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "Ningún token de Swap coincide con \"{query}\"."
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Excluye el financiamiento reclamado, los reembolsos por impacto en el precio y las comisiones de ejecución."
@@ -9648,10 +9656,6 @@ msgstr "Seleccionar idioma"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Valor desconocido"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "Buscar en todos los tokens de Swap"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "Total ganado histórico"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "Buscar en todos los mercados perpetuos"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "Total ganado histórico"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "Buscar en todos los mercados perpetuos"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading activado. Desactivar en <0>configuración</0>"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -5395,6 +5395,10 @@ msgstr "Argumentos"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Necesitas USDC y {0} en {1} para crear un código de referido a través de la Cuenta GMX. Deposita fondos o cambia a una red diferente."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "Buscar en todos los mercados swap"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -523,10 +523,6 @@ msgstr "Doble exposición a {indexSymbol} por posición y garantía. Precio de l
 msgid "GMX Account balance"
 msgstr "Saldo de GMX Account"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "Buscar en mercados perpetuos"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "¡Dirección copiada!"
@@ -1542,6 +1538,10 @@ msgstr "Margen total aportado"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "Para comprar GMX en {0}, <0>cambie su red</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "Hay resultados disponibles en Perpetuos."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade (anteriormente GMX Solana) está alojado en otro sitio web y ges
 msgid "You have not traded during the selected period"
 msgstr "No ha operado durante el período seleccionado"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "Ningún mercado perpetuo coincide con \"{query}\"."
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Partes predeterminadas para órdenes TWAP"
@@ -3137,6 +3141,10 @@ msgstr "Sistema"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "Obtenga recompensas compartiendo su código de referencia"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "Hay resultados disponibles en Swap."
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "Posiciones largas"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "Ver resultados en Perpetuos"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "Argumentos"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Necesitas USDC y {0} en {1} para crear un código de referido a través de la Cuenta GMX. Deposita fondos o cambia a una red diferente."
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "Buscar en todos los mercados swap"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Compre bonos GMX en Bond Protocol con descuento y un periodo de consolidación corto"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "No hay resultados con los filtros seleccionados."
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "Tamaño, $"
 msgid "Wallet received before close"
 msgstr "Recibido en la cartera antes del cierre"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "Ver resultados en Swap"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "Liquidez garantizada"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "Ningún token de Swap coincide con \"{query}\"."
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Excluye el financiamiento reclamado, los reembolsos por impacto en el precio y las comisiones de ejecución."
@@ -9628,6 +9648,10 @@ msgstr "Seleccionar idioma"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Valor desconocido"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "Buscar en todos los tokens de Swap"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "Evite mechas de precio con feeds de precios de Chainlink transparentes y en menos de un segundo, diseñados a medida para GMX"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "No hay mercados coincidentes."
 
@@ -11835,10 +11858,6 @@ msgstr "Opere más, pague menos.<0/>Refiera y gane."
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "No hay pools coincidentes"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "Buscar en mercados swap"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -932,6 +932,10 @@ msgstr "Convertissez les esGMX en tokens GMX. Consultez les détails de l'acquis
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "Aucun résultat pour « {query} » dans {marketTypeLabel}."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "Valeur négative : les traders paient le financement"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "Ce swap nécessite un routage externe, qui n'est pas disponible tant que le jeton de paiement du gaz correspond au jeton que vous recevez, et aucun autre jeton de gaz ne dispose d'un solde suffisant."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "Rechercher dans tous les {marketTypeLabel}"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "Protocole de trading décentralisé"
@@ -3040,6 +3048,10 @@ msgstr "Aidez-nous à améliorer GMX. Pour des raisons de sécurité, nous ne vo
 msgid "Cancel margin deposit"
 msgstr "Annuler le dépôt de marge"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "jetons Swap"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "Réseau global"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade (anciennement GMX Solana) est hébergé sur un autre site web et
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "Vous n'avez pas effectué de transactions durant la période sélectionnée"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "Aucun marché perpétuel ne correspond à « {query} »."
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "Staking"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "Plateforme d'échange perpétuel décentralisée | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "marchés perpétuels"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "Aucun jeton Swap ne correspond à « {query} »."
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Hors financement réclamé, remises d'impact sur le prix et frais d'exécution."
@@ -9648,10 +9656,6 @@ msgstr "Sélectionner la langue"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Valeur inconnue"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "Rechercher dans tous les jetons Swap"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "Total gagné cumulé"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "Rechercher dans tous les marchés perpétuels"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -523,10 +523,6 @@ msgstr "Double exposition {indexSymbol} liée à la position et à la garantie. 
 msgid "GMX Account balance"
 msgstr "Solde du GMX Account"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "Rechercher dans les marchés perpétuels"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "Adresse copiée !"
@@ -1542,6 +1538,10 @@ msgstr "Marge totale apportée"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "Pour acheter GMX sur {0}, <0>changez de réseau</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "Des résultats sont disponibles dans Perpétuels."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade (anciennement GMX Solana) est hébergé sur un autre site web et
 msgid "You have not traded during the selected period"
 msgstr "Vous n'avez pas effectué de transactions durant la période sélectionnée"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "Aucun marché perpétuel ne correspond à « {query} »."
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Nombre de parts par défaut pour les ordres TWAP"
@@ -3137,6 +3141,10 @@ msgstr "Système"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "Gagnez des récompenses en partageant votre code de parrainage"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "Des résultats sont disponibles dans Swap."
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "Positions long"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "Afficher les résultats dans Perpétuels"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "Arguments"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Vous avez besoin d'USDC et de {0} sur {1} pour créer un code de parrainage via le Compte GMX. Déposez des fonds ou changez de réseau."
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "Rechercher dans tous les marchés swap"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "Explorateur LayerZero"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Achetez des obligations GMX sur Bond Protocol avec une décote et une courte période d'acquisition progressive"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "Aucun résultat avec les filtres sélectionnés."
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "Taille, $"
 msgid "Wallet received before close"
 msgstr "Reçu sur le portefeuille avant la clôture"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "Afficher les résultats dans Swap"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "Liquidité garantie"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "Aucun jeton Swap ne correspond à « {query} »."
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Hors financement réclamé, remises d'impact sur le prix et frais d'exécution."
@@ -9628,6 +9648,10 @@ msgstr "Sélectionner la langue"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Valeur inconnue"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "Rechercher dans tous les jetons Swap"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "Évitez les mèches de prix grâce à des flux de prix Chainlink transparents et inférieurs à la seconde, conçus sur mesure pour GMX"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "Aucun marché correspondant."
 
@@ -11835,10 +11858,6 @@ msgstr "Tradez plus, payez moins.<0/>Parrainez et gagnez."
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "Aucun pool correspondant"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "Rechercher dans les marchés swap"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "Total gagné cumulé"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "Rechercher dans tous les marchés perpétuels"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading activé. Désactiver dans les <0>paramètres</0>"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -5395,6 +5395,10 @@ msgstr "Arguments"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Vous avez besoin d'USDC et de {0} sur {1} pour créer un code de parrainage via le Compte GMX. Déposez des fonds ou changez de réseau."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "Rechercher dans tous les marchés swap"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "Explorateur LayerZero"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -932,6 +932,10 @@ msgstr "esGMXをGMXトークンに変換します。ボールトを使用する�
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "{marketTypeLabel}に「{query}」と一致するものはありません。"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "マイナスの値：トレーダーがファンディングを支払います"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "このスワップには外部ルーティングが必要ですが、ガス支払いトークンが受け取るトークンと同じ間は利用できず、他のガストークンにも十分な残高がありません。"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "すべての{marketTypeLabel}を検索"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "分散型取引プロトコル"
@@ -3040,6 +3048,10 @@ msgstr "GMXの改善にご協力ください。セキュリティのため、こ
 msgid "Cancel margin deposit"
 msgstr "証拠金入金をキャンセル"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "スワップトークン"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "グローバルネットワーク"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade（旧GMX Solana）は別のウェブサイトでホストされ�
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "選択した期間中に取引はありませんでした"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "「{query}」に一致する無期限市場はありません。"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "ステーキング"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "分散型パーペチュアル取引所 | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "無期限市場"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "「{query}」に一致するスワップトークンはありません。"
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "請求済みのファンディング、価格影響リベート、執行手数料は含まれません。"
@@ -9648,10 +9656,6 @@ msgstr "言語を選択"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "不明な値"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "すべてのスワップトークンを検索"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "累計収益合計"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "すべての無期限先物市場を検索"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -5395,6 +5395,10 @@ msgstr "引数"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "GMX Accountを介して紹介コードを作成するには、{1}にUSDCと{0}が必要です。資金を入金するか、別のネットワークに切り替えてください。"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "すべてのスワップ市場を検索"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -523,10 +523,6 @@ msgstr "ポジションと担保による{indexSymbol}の二重エクスポー�
 msgid "GMX Account balance"
 msgstr "GMX Account残高"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "無期限市場を検索"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "アドレスがコピーされました！"
@@ -1542,6 +1538,10 @@ msgstr "拠出証拠金の合計"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "{0} で GMX を購入するには、<0>ネットワークを切り替えてください</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "無期限に検索結果があります。"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade（旧GMX Solana）は別のウェブサイトでホストされ�
 msgid "You have not traded during the selected period"
 msgstr "選択した期間中に取引はありませんでした"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "「{query}」に一致する無期限市場はありません。"
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP注文のデフォルト分割数"
@@ -3137,6 +3141,10 @@ msgstr "システム"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "紹介コードを共有して報酬を獲得しましょう"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "スワップに検索結果があります。"
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "ロングポジション"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "無期限の結果を表示"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "引数"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "GMX Accountを介して紹介コードを作成するには、{1}にUSDCと{0}が必要です。資金を入金するか、別のネットワークに切り替えてください。"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "すべてのスワップ市場を検索"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Bond ProtocolでGMXボンドを短いベスティング期間で割引購入します"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "選択したフィルターに一致する結果はありません。"
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "サイズ, $"
 msgid "Wallet received before close"
 msgstr "クローズ前のウォレット受取額"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "スワップの結果を表示"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "保証された流動性"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "「{query}」に一致するスワップトークンはありません。"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "請求済みのファンディング、価格影響リベート、執行手数料は含まれません。"
@@ -9628,6 +9648,10 @@ msgstr "言語を選択"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "不明な値"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "すべてのスワップトークンを検索"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "GMX向けに設計された透明性の高いサブセカンドChainlink価格フィードで、プライスウィックを回避できます"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "一致する市場がありません。"
 
@@ -11835,10 +11858,6 @@ msgstr "もっと取引して、もっと安く。<0/>紹介して、稼ぐ。"
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "一致するプールなし"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "スワップ市場を検索"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "累計収益合計"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "すべての無期限先物市場を検索"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Tradingが有効になりました。<0>設定</0>で無効にできます"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -932,6 +932,10 @@ msgstr "esGMX를 GMX 토큰으로 전환합니다. 금고를 사용하기 전에
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "{marketTypeLabel}에서 \"{query}\"와 일치하는 항목이 없습니다."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "음수 값: 트레이더가 펀딩을 지불합니다"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "이 스왑에는 외부 라우팅이 필요하지만 가스 결제 토큰이 수령할 토큰과 같은 동안에는 사용할 수 없으며, 잔액이 충분한 다른 가스 토큰도 없습니다."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "모든 {marketTypeLabel} 검색"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "탈중앙화 거래 프로토콜"
@@ -3040,6 +3048,10 @@ msgstr "GMX 개선에 도움을 주십시오. 보안을 위해 먼저 연락드�
 msgid "Cancel margin deposit"
 msgstr "증거금 예치 취소"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "스왑 토큰"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "글로벌 네트워크"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade(이전 GMX Solana)는 다른 웹사이트에서 호스팅되며 
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "선택한 기간 동안 거래 내역이 없습니다"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "\"{query}\"와 일치하는 무기한 시장이 없습니다."
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "스테이킹"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "탈중앙화 무기한 거래소 | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "무기한 시장"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "\"{query}\"와 일치하는 스왑 토큰이 없습니다."
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "청구된 펀딩비, 가격 영향 리베이트 및 실행 수수료는 제외됩니다."
@@ -9648,10 +9656,6 @@ msgstr "언어 선택"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "알 수 없는 값"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "모든 스왑 토큰 검색"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "누적 총 수익"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "모든 무기한 시장 검색"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -523,10 +523,6 @@ msgstr "포지션과 담보에서 {indexSymbol}에 대한 이중 노출이 발�
 msgid "GMX Account balance"
 msgstr "GMX Account 잔액"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "무기한 시장 검색"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "주소가 복사되었습니다!"
@@ -1542,6 +1538,10 @@ msgstr "총 납입 증거금"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "{0}에서 GMX를 구매하려면 <0>네트워크를 변경하십시오</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "무기한에 검색 결과가 있습니다."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade(이전 GMX Solana)는 다른 웹사이트에서 호스팅되며 
 msgid "You have not traded during the selected period"
 msgstr "선택한 기간 동안 거래 내역이 없습니다"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "\"{query}\"와 일치하는 무기한 시장이 없습니다."
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP 주문의 기본 분할 수"
@@ -3137,6 +3141,10 @@ msgstr "시스템"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "추천 코드를 공유하여 보상을 받으십시오"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "스왑에 검색 결과가 있습니다."
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "롱 포지션"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "무기한 결과 보기"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "인수"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "GMX 계정을 통해 추천 코드를 생성하려면 {1}에서 USDC와 {0}이(가) 필요합니다. 자금을 입금하거나 다른 네트워크로 전환하세요."
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "모든 스왑 시장 검색"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Bond Protocol에서 짧은 베스팅 기간으로 GMX 채권을 할인 구매하십시오"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "선택한 필터와 일치하는 결과가 없습니다."
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "크기, $"
 msgid "Wallet received before close"
 msgstr "청산 전 지갑 수령액"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "스왑 결과 보기"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "보장된 유동성"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "\"{query}\"와 일치하는 스왑 토큰이 없습니다."
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "청구된 펀딩비, 가격 영향 리베이트 및 실행 수수료는 제외됩니다."
@@ -9628,6 +9648,10 @@ msgstr "언어 선택"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "알 수 없는 값"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "모든 스왑 토큰 검색"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "GMX 전용으로 설계된 투명하고 1초 미만의 Chainlink 가격 피드로 가격 위크를 방지합니다"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "일치하는 시장이 없습니다."
 
@@ -11835,10 +11858,6 @@ msgstr "더 많이 거래하고, 더 적게 내세요.<0/>추천하고 수익을
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "일치하는 풀 없음"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "스왑 시장 검색"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "누적 총 수익"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "모든 무기한 시장 검색"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading이 활성화되었습니다. <0>설정</0>에서 비활성화할 수 있습니다"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -5395,6 +5395,10 @@ msgstr "인수"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "GMX 계정을 통해 추천 코드를 생성하려면 {1}에서 USDC와 {0}이(가) 필요합니다. 자금을 입금하거나 다른 네트워크로 전환하세요."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "모든 스왑 시장 검색"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -932,6 +932,10 @@ msgstr ""
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "[!! No {marketTypeLabel} match \"{query}\". !!]"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr ""
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "[!! Search in all {marketTypeLabel} !!]"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr ""
@@ -3040,6 +3048,10 @@ msgstr ""
 msgid "Cancel margin deposit"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "[!! Swap tokens !!]"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr ""
@@ -3115,10 +3127,6 @@ msgstr ""
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr ""
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "[!! No perpetual markets match \"{query}\". !!]"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr ""
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "[!! perpetual markets !!]"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "[!! No Swap tokens match \"{query}\". !!]"
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr ""
@@ -9648,10 +9656,6 @@ msgstr ""
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr ""
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "[!! Search in all Swap tokens !!]"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr ""
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr ""
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "[!! Search in all perpetual markets !!]"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -12698,6 +12698,10 @@ msgstr ""
 msgid "Total lifetime earned"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "[!! Search in all perpetual markets !!]"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr ""

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -523,10 +523,6 @@ msgstr ""
 msgid "GMX Account balance"
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "[!! Search in perpetuals markets !!]"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr ""
@@ -1542,6 +1538,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "[!! Results are available in Perpetuals. !!]"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr ""
 msgid "You have not traded during the selected period"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "[!! No perpetual markets match \"{query}\". !!]"
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr ""
@@ -3137,6 +3141,10 @@ msgstr ""
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "[!! Results are available in Swap. !!]"
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr ""
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "[!! View results in Perpetuals !!]"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr ""
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "[!! Search in all swap markets !!]"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr ""
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "[!! No results with the selected filters. !!]"
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr ""
 msgid "Wallet received before close"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "[!! View results in Swap !!]"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr ""
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "[!! No Swap tokens match \"{query}\". !!]"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr ""
@@ -9628,6 +9648,10 @@ msgstr ""
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "[!! Search in all Swap tokens !!]"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr ""
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "[!! No markets matched. !!]"
 
@@ -11835,10 +11858,6 @@ msgstr ""
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr ""
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "[!! Search in swap markets !!]"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -5395,6 +5395,10 @@ msgstr ""
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "[!! Search in all swap markets !!]"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -523,10 +523,6 @@ msgstr "Двойная экспозиция {indexSymbol} от позиции и
 msgid "GMX Account balance"
 msgstr "Баланс GMX Account"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "Поиск на рынках бессрочных контрактов"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "Адрес скопирован!"
@@ -1542,6 +1538,10 @@ msgstr "Всего внесено маржи"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "Чтобы купить GMX в сети {0}, <0>смените сеть</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "Результаты доступны в разделе «Бессрочные контракты»."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade (ранее GMX Solana) размещён на другом са�
 msgid "You have not traded during the selected period"
 msgstr "Вы не совершали сделок за выбранный период"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "Нет бессрочных рынков, соответствующих запросу «{query}»."
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Количество частей по умолчанию для TWAP-ордеров"
@@ -3137,6 +3141,10 @@ msgstr "Система"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "Получайте вознаграждения, делясь своим реферальным кодом"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "Результаты доступны в разделе «Своп»."
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "Позиции лонг"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "Посмотреть результаты в разделе «Бессрочные контракты»"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "Аргументы"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Для создания реферального кода через GMX Account вам нужны USDC и {0} в сети {1}. Внесите средства или переключитесь на другую сеть."
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "Поиск по всем рынкам свопов"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Покупайте облигации GMX на Bond Protocol со скидкой и коротким периодом вестинга"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "Нет результатов с выбранными фильтрами."
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "Размер, $"
 msgid "Wallet received before close"
 msgstr "Получено на кошелёк до закрытия"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "Посмотреть результаты в разделе «Своп»"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "Гарантированная ликвидность"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "Нет токенов для свопа, соответствующих запросу «{query}»."
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Не включает полученное финансирование, компенсации за влияние на цену и комиссии за исполнение."
@@ -9628,6 +9648,10 @@ msgstr "Выберите язык"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Неизвестное значение"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "Искать среди всех токенов для свопа"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "Избегайте ценовых фитилей благодаря прозрачным ценовым потокам Chainlink с задержкой менее секунды, разработанным специально для GMX"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "Подходящие рынки не найдены."
 
@@ -11835,10 +11858,6 @@ msgstr "Торгуйте больше, платите меньше.<0/>Приг�
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "Нет совпадающих пулов"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "Поиск на рынках свопов"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -932,6 +932,10 @@ msgstr "Конвертируйте esGMX в токены GMX. Ознакомьт
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "В категории «{marketTypeLabel}» нет результатов по запросу «{query}»."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "Отрицательное значение: трейдеры выплачивают фондирование"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "Для этого свопа нужен внешний маршрут, который недоступен, пока токен оплаты газа совпадает с получаемым токеном, а у других газовых токенов недостаточно баланса."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "Искать во всей категории «{marketTypeLabel}»"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "Децентрализованный торговый протокол"
@@ -3040,6 +3048,10 @@ msgstr "Помогите нам улучшить GMX. В целях безопа
 msgid "Cancel margin deposit"
 msgstr "Отменить депозит маржи"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "Токены для свопа"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "Глобальная сеть"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade (ранее GMX Solana) размещён на другом са�
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "Вы не совершали сделок за выбранный период"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "Нет бессрочных рынков, соответствующих запросу «{query}»."
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "Стейкинг"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "Децентрализованная бессрочная биржа | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "Бессрочные рынки"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "Нет токенов для свопа, соответствующих запросу «{query}»."
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "Не включает полученное финансирование, компенсации за влияние на цену и комиссии за исполнение."
@@ -9648,10 +9656,6 @@ msgstr "Выберите язык"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "Неизвестное значение"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "Искать среди всех токенов для свопа"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "Всего заработано"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "Поиск по всем бессрочным рынкам"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -5395,6 +5395,10 @@ msgstr "Аргументы"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "Для создания реферального кода через GMX Account вам нужны USDC и {0} в сети {1}. Внесите средства или переключитесь на другую сеть."
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "Поиск по всем рынкам свопов"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "Всего заработано"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "Поиск по всем бессрочным рынкам"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading включён. Отключите в <0>настройках</0>"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -932,6 +932,10 @@ msgstr "將 esGMX 轉換為 GMX 代幣。使用金庫前請先閱讀歸屬詳情
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "{marketTypeLabel}中沒有與「{query}」相符的結果。"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "負值：交易者支付資金費用"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "此交換需要外部路由，但當 Gas 支付代幣與您接收的代幣相同時不可用，且沒有其他 Gas 代幣有足夠餘額。"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "搜尋所有{marketTypeLabel}"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "去中心化交易協議"
@@ -3040,6 +3048,10 @@ msgstr "幫助我們改善 GMX。為了安全，我們不會主動聯絡您。�
 msgid "Cancel margin deposit"
 msgstr "取消保證金存入"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "兌換代幣"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "全域網路"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade（前身為 GMX Solana）託管在另一個網站上，由不同
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "您在所選期間內未進行任何交易"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "沒有與「{query}」相符的永續合約市場。"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "質押"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "去中心化永續合約交易所 | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "永續合約市場"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "沒有與「{query}」相符的兌換代幣。"
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "不包括已領取的資金費、價格影響返還與執行費。"
@@ -9648,10 +9656,6 @@ msgstr "選擇語言"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "未知值"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "搜尋所有兌換代幣"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "做多池上限"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "累計總收益"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "搜尋所有永續合約市場"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -12698,6 +12698,10 @@ msgstr "做多池上限"
 msgid "Total lifetime earned"
 msgstr "累計總收益"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "搜尋所有永續合約市場"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading 已啟用。可在<0>設定</0>中停用"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -5395,6 +5395,10 @@ msgstr "參數"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "透過 GMX Account 建立推薦碼需要在 {1} 上擁有 USDC 和 {0}。請存入資金或切換至其他網路。"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "搜尋所有兌換市場"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -523,10 +523,6 @@ msgstr "倉位和抵押品帶來雙重 {indexSymbol} 曝險。清算價格高於
 msgid "GMX Account balance"
 msgstr "GMX Account 餘額"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "搜尋永續合約市場"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "地址已複製！"
@@ -1542,6 +1538,10 @@ msgstr "累計投入保證金"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "若要在 {0} 上購買 GMX，<0>請切換網路</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "永續合約中有可用結果。"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade（前身為 GMX Solana）託管在另一個網站上，由不同
 msgid "You have not traded during the selected period"
 msgstr "您在所選期間內未進行任何交易"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "沒有與「{query}」相符的永續合約市場。"
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP 訂單的預設分段數"
@@ -3137,6 +3141,10 @@ msgstr "系統"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "分享您的推薦碼即可賺取獎勵"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "兌換中有可用結果。"
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "做多倉位"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "查看永續合約中的結果"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "參數"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "透過 GMX Account 建立推薦碼需要在 {1} 上擁有 USDC 和 {0}。請存入資金或切換至其他網路。"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "搜尋所有兌換市場"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "在 Bond Protocol 上以折扣價購買 GMX 債券，享有短期歸屬期"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "所選篩選條件下沒有結果。"
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "規模, $"
 msgid "Wallet received before close"
 msgstr "平倉前錢包收到"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "查看兌換中的結果"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "保證流動性"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "沒有與「{query}」相符的兌換代幣。"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "不包括已領取的資金費、價格影響返還與執行費。"
@@ -9628,6 +9648,10 @@ msgstr "選擇語言"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "未知值"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "搜尋所有兌換代幣"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "透過 Chainlink 為 GMX 量身打造的透明、亞秒級價格饋送，避免價格插針"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "沒有相符的市場。"
 
@@ -11835,10 +11858,6 @@ msgstr "交易更多，費用更低。<0/>推薦好友，賺取收益。"
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "無符合的池"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "搜尋兌換市場"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -523,10 +523,6 @@ msgstr "仓位和抵押品带来双重 {indexSymbol} 敞口。清算价格高于
 msgid "GMX Account balance"
 msgstr "GMX Account 余额"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in perpetuals markets"
-msgstr "搜索永续合约市场"
-
 #: src/components/GmxAccountModal/WalletReceiveView.tsx
 msgid "Address copied!"
 msgstr "地址已复制！"
@@ -1542,6 +1538,10 @@ msgstr "累计投入保证金"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
 msgstr "要在 {0} 上买入 GMX，请<0>切换您的网络</0>"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Perpetuals."
+msgstr "永续合约中有可用结果。"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposited"
@@ -3116,6 +3116,10 @@ msgstr "GMTrade（前身为 GMX Solana）托管在另一个网站上，由另一
 msgid "You have not traded during the selected period"
 msgstr "您在所选时间段内没有交易记录"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No perpetual markets match \"{query}\"."
+msgstr "没有与“{query}”匹配的永续合约市场。"
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP 订单的默认份数"
@@ -3137,6 +3141,10 @@ msgstr "系统"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Earn rewards by sharing your referral code"
 msgstr "分享推荐码赚取奖励"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Results are available in Swap."
+msgstr "交换中有可用结果。"
 
 #: src/components/ShareModal/CreateReferralCode.tsx
 msgid "Earn rewards by sharing your code!"
@@ -3246,6 +3254,10 @@ msgstr "做多仓位"
 #: src/components/Referrals/affiliates/createCode/CreateAffiliateWizard.tsx
 msgid "Share your code"
 msgstr ""
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Perpetuals"
+msgstr "查看永续合约中的结果"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Buy fee"
@@ -5395,10 +5407,6 @@ msgstr "参数"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "通过 GMX 账户创建推荐码需要在 {1} 上拥有 USDC 和 {0}。请存入资金或切换到其他网络。"
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all swap markets"
-msgstr "搜索所有兑换市场"
-
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"
@@ -5782,6 +5790,10 @@ msgstr ""
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "在 Bond Protocol 上以折扣价购买 GMX 债券，归属期较短"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No results with the selected filters."
+msgstr "所选筛选条件下没有结果。"
 
 #: src/components/OrdersModal/OrdersModal.tsx
 msgid "{positionTitle} orders"
@@ -7976,6 +7988,10 @@ msgstr "大小，$"
 msgid "Wallet received before close"
 msgstr "平仓前钱包收到"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "View results in Swap"
+msgstr "查看交换中的结果"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Guaranteed liquidity"
 msgstr "保障流动性"
@@ -9294,6 +9310,10 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No Swap tokens match \"{query}\"."
+msgstr "没有与“{query}”匹配的交换代币。"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "不包括已领取的资金费、价格影响返还和执行费。"
@@ -9628,6 +9648,10 @@ msgstr "选择语言"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "未知值"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all Swap tokens"
+msgstr "搜索所有交换代币"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -11198,7 +11222,6 @@ msgid "Avoid price wicks with transparent, sub-second Chainlink price feeds tail
 msgstr "利用 Chainlink 为 GMX 量身定制的透明、亚秒级价格馈送，避免价格插针"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "No markets matched."
 msgstr "没有匹配的市场。"
 
@@ -11835,10 +11858,6 @@ msgstr "交易更多，费用更低。<0/>推荐好友，赚取收益。"
 #: src/components/MarketSelector/GmPoolsSelectorForGlvMarket.tsx
 msgid "No pools matched"
 msgstr "没有匹配的资金池"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in swap markets"
-msgstr "搜索兑换市场"
 
 #: landing/src/pages/Builders/SupportSection/SupportSection.tsx
 msgid "Going live or already live"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -5395,6 +5395,10 @@ msgstr "参数"
 msgid "You need USDC and {0} on {1} to create a referral code via GMX Account. Deposit funds or switch to a different network."
 msgstr "通过 GMX 账户创建推荐码需要在 {1} 上拥有 USDC 和 {0}。请存入资金或切换到其他网络。"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all swap markets"
+msgstr "搜索所有兑换市场"
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "LayerZero scan"
 msgstr "LayerZero scan"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -932,6 +932,10 @@ msgstr "将 esGMX 转换为 GMX 代币。使用金库前请阅读归属期详情
 msgid "Sender has withdrawn all tokens from the Affiliate vesting vault"
 msgstr ""
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "No {marketTypeLabel} match \"{query}\"."
+msgstr "{marketTypeLabel}中没有与“{query}”匹配的结果。"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Negative value: traders pay funding"
 msgstr "负值：交易者支付资金费用"
@@ -2241,6 +2245,10 @@ msgstr ""
 msgid "This swap requires external routing, which isn't available while the gas payment token matches the token you're receiving, and no other gas token has sufficient balance."
 msgstr "此交换需要外部路由，但当 Gas 支付代币与您接收的代币相同时不可用，且没有其他 Gas 代币有足够余额。"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all {marketTypeLabel}"
+msgstr "搜索所有{marketTypeLabel}"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized trading protocol"
 msgstr "去中心化交易协议"
@@ -3040,6 +3048,10 @@ msgstr "帮助我们改进 GMX。出于安全考虑，我们不会主动联系�
 msgid "Cancel margin deposit"
 msgstr "取消保证金存入"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Swap tokens"
+msgstr "交换代币"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Global network"
 msgstr "全球网络"
@@ -3115,10 +3127,6 @@ msgstr "GMTrade（前身为 GMX Solana）托管在另一个网站上，由另一
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "您在所选时间段内没有交易记录"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No perpetual markets match \"{query}\"."
-msgstr "没有与“{query}”匹配的永续合约市场。"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -4724,6 +4732,10 @@ msgstr "质押"
 #: src/lib/legacy.ts
 msgid "Decentralized perpetual exchange | GMX"
 msgstr "去中心化永续合约交易所 | GMX"
+
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "perpetual markets"
+msgstr "永续合约市场"
 
 #: src/components/Footer/constants.tsx
 msgid "V1"
@@ -9310,10 +9322,6 @@ msgstr ""
 msgid "Depositing {amountText} to {indexTokenText} Short..."
 msgstr ""
 
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "No Swap tokens match \"{query}\"."
-msgstr "没有与“{query}”匹配的交换代币。"
-
 #: src/components/TradeHistory/TradeHistoryRow/utils/lifecycleSettlement.ts
 msgid "Excludes claimed funding, price impact rebates and execution fees."
 msgstr "不包括已领取的资金费、价格影响返还和执行费。"
@@ -9648,10 +9656,6 @@ msgstr "选择语言"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
 msgstr "未知值"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all Swap tokens"
-msgstr "搜索所有交换代币"
 
 #: src/pages/AccountDashboard/dailyAndCumulativePnLDebug.tsx
 #: src/pages/AccountDashboard/generalPerformanceDetailsDebug.tsx
@@ -12720,10 +12724,6 @@ msgstr "POOL CAP LONG"
 #: src/components/Earn/Portfolio/EarningsOverview/EarningsBand.tsx
 msgid "Total lifetime earned"
 msgstr "累计总收益"
-
-#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
-msgid "Search in all perpetual markets"
-msgstr "搜索所有永续合约市场"
 
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -12698,6 +12698,10 @@ msgstr "POOL CAP LONG"
 msgid "Total lifetime earned"
 msgstr "累计总收益"
 
+#: src/components/ChartTokenSelector/ChartTokenSelector.tsx
+msgid "Search in all perpetual markets"
+msgstr "搜索所有永续合约市场"
+
 #: src/domain/multichain/toastEnableExpress.tsx
 msgid "Express Trading enabled. Disable in <0>settings</0>"
 msgstr "Express Trading 已启用。在<0>设置</0>中禁用"


### PR DESCRIPTION
## Summary

- implement availability-aware empty states for filtered and unfiltered searches in both Perpetuals and Swap
- offer Search in all only when the current mode has matches outside the active filter, and offer the other mode only when it has matches
- preserve the search query and page trading mode while atomically resetting selector filters during browse-mode changes
- reuse localized market type labels across empty-state copy and add translations for the new messages
- cap market searches at 100 characters and wrap long queries inside the empty state

Linear: https://linear.app/gmx-io/issue/FEDEV-4232/bug-fix-filtered-searches-and-empty-states-in-perpetuals-and-swap

## Testing

- `yarn test:ci --maxWorkers=3 --minWorkers=3` (1684 passed, 1 skipped)
- `yarn test:ct --workers=3` (199 passed)
- `yarn vitest run src/components/ChartTokenSelector/__tests__/marketFilters.spec.ts --maxWorkers=3 --minWorkers=3` (23 passed)
- `yarn eslint src/components/ChartTokenSelector/ChartTokenSelector.tsx src/components/SearchInput/SearchInput.tsx --max-warnings=0`
- `yarn tsc -p tsconfig.json --noEmit --incremental`
- SDK suite: 616 passed; one unrelated Arbitrum keeper-consistency check failed because current keeper data omits a configured market