### PR TITLE
Block settling funding on positions below min collateral FEDEV-4266

### DIFF
--- a/sdk/src/utils/positions/utils.ts
+++ b/sdk/src/utils/positions/utils.ts
@@ -171,6 +171,50 @@ export function getLeverage(p: {
   return bigMath.mulDiv(sizeInUsd, BASIS_POINTS_DIVISOR_BIGINT, remainingCollateralUsd);
 }
 
+export function getLiquidationPriceImpactDeltaUsd(p: {
+  marketInfo: MarketInfo;
+  sizeInUsd: bigint;
+  sizeInTokens: bigint;
+  pendingImpactAmount: bigint;
+  isLong: boolean;
+  useMaxPriceImpact?: boolean;
+}) {
+  const { marketInfo, sizeInUsd, sizeInTokens, pendingImpactAmount, isLong, useMaxPriceImpact } = p;
+
+  const maxNegativePriceImpactUsd = -1n * applyFactor(sizeInUsd, marketInfo.maxPositionImpactFactorForLiquidations);
+
+  if (useMaxPriceImpact) {
+    return maxNegativePriceImpactUsd;
+  }
+
+  let priceImpactDeltaUsd = getPriceImpactForPosition(marketInfo, -sizeInUsd, isLong, {
+    fallbackToZero: true,
+    sizeDeltaInTokens: sizeInTokens,
+  }).priceImpactDeltaUsd;
+
+  if (priceImpactDeltaUsd > 0) {
+    priceImpactDeltaUsd = capPositionImpactUsdByMaxPriceImpactFactor(marketInfo, sizeInUsd, priceImpactDeltaUsd);
+  }
+
+  const pendingImpactUsd = convertToUsd(
+    pendingImpactAmount,
+    marketInfo.indexToken.decimals,
+    pendingImpactAmount > 0 ? marketInfo.indexToken.prices.minPrice : marketInfo.indexToken.prices.maxPrice
+  )!;
+
+  priceImpactDeltaUsd = priceImpactDeltaUsd + pendingImpactUsd;
+
+  if (priceImpactDeltaUsd > 0) {
+    return 0n;
+  }
+
+  if (priceImpactDeltaUsd < maxNegativePriceImpactUsd) {
+    return maxNegativePriceImpactUsd;
+  }
+
+  return priceImpactDeltaUsd;
+}
+
 export function getLiquidationPrice(p: {
   sizeInUsd: bigint;
   sizeInTokens: bigint;
@@ -212,37 +256,14 @@ export function getLiquidationPrice(p: {
   const totalPendingFeesUsd = getPositionPendingFeesUsd({ pendingFundingFeesUsd, pendingBorrowingFeesUsd });
   const totalFeesUsd = totalPendingFeesUsd + closingFeeUsd;
 
-  const maxNegativePriceImpactUsd = -1n * applyFactor(sizeInUsd, marketInfo.maxPositionImpactFactorForLiquidations);
-
-  let priceImpactDeltaUsd = 0n;
-
-  if (useMaxPriceImpact) {
-    priceImpactDeltaUsd = maxNegativePriceImpactUsd;
-  } else {
-    const priceImpactForPosition = getPriceImpactForPosition(marketInfo, -sizeInUsd, isLong, {
-      fallbackToZero: true,
-      sizeDeltaInTokens: sizeInTokens,
-    });
-    priceImpactDeltaUsd = priceImpactForPosition.priceImpactDeltaUsd;
-
-    if (priceImpactDeltaUsd > 0) {
-      priceImpactDeltaUsd = capPositionImpactUsdByMaxPriceImpactFactor(marketInfo, sizeInUsd, priceImpactDeltaUsd);
-    }
-
-    const pendingImpactUsd = convertToUsd(
-      pendingImpactAmount,
-      marketInfo.indexToken.decimals,
-      pendingImpactAmount > 0 ? marketInfo.indexToken.prices.minPrice : marketInfo.indexToken.prices.maxPrice
-    )!;
-
-    priceImpactDeltaUsd = priceImpactDeltaUsd + pendingImpactUsd;
-
-    if (priceImpactDeltaUsd > 0) {
-      priceImpactDeltaUsd = 0n;
-    } else if (priceImpactDeltaUsd < maxNegativePriceImpactUsd) {
-      priceImpactDeltaUsd = maxNegativePriceImpactUsd;
-    }
-  }
+  const priceImpactDeltaUsd = getLiquidationPriceImpactDeltaUsd({
+    marketInfo,
+    sizeInUsd,
+    sizeInTokens,
+    pendingImpactAmount,
+    isLong,
+    useMaxPriceImpact,
+  });
 
   let liquidationCollateralUsd = applyFactor(sizeInUsd, marketInfo.minCollateralFactorForLiquidation);
   if (liquidationCollateralUsd < minCollateralUsd) {
@@ -317,30 +338,13 @@ export function getMinCollateralUsdForLiquidationPrice(p: {
 
   const closingFeeUsd = getPositionFee(marketInfo, sizeInUsd, false, userReferralInfo).positionFeeUsd;
 
-  const maxNegativePriceImpactUsd = -1n * applyFactor(sizeInUsd, marketInfo.maxPositionImpactFactorForLiquidations);
-
-  let priceImpactDeltaUsd = getPriceImpactForPosition(marketInfo, -sizeInUsd, isLong, {
-    fallbackToZero: true,
-    sizeDeltaInTokens: sizeInTokens,
-  }).priceImpactDeltaUsd;
-
-  if (priceImpactDeltaUsd > 0) {
-    priceImpactDeltaUsd = capPositionImpactUsdByMaxPriceImpactFactor(marketInfo, sizeInUsd, priceImpactDeltaUsd);
-  }
-
-  const pendingImpactUsd = convertToUsd(
+  const priceImpactDeltaUsd = getLiquidationPriceImpactDeltaUsd({
+    marketInfo,
+    sizeInUsd,
+    sizeInTokens,
     pendingImpactAmount,
-    marketInfo.indexToken.decimals,
-    pendingImpactAmount > 0 ? marketInfo.indexToken.prices.minPrice : marketInfo.indexToken.prices.maxPrice
-  )!;
-
-  priceImpactDeltaUsd = priceImpactDeltaUsd + pendingImpactUsd;
-
-  if (priceImpactDeltaUsd > 0) {
-    priceImpactDeltaUsd = 0n;
-  } else if (priceImpactDeltaUsd < maxNegativePriceImpactUsd) {
-    priceImpactDeltaUsd = maxNegativePriceImpactUsd;
-  }
+    isLong,
+  });
 
   let liquidationCollateralUsd = applyFactor(sizeInUsd, marketInfo.minCollateralFactorForLiquidation);
   if (liquidationCollateralUsd < minCollateralUsd) {
@@ -348,6 +352,51 @@ export function getMinCollateralUsdForLiquidationPrice(p: {
   }
 
   return liquidationCollateralUsd - pnl - priceImpactDeltaUsd + closingFeeUsd;
+}
+
+export function getIsPositionBelowMinCollateralForLeverage(position: PositionInfoLoaded, collateralDeltaAmount = 0n) {
+  const {
+    marketInfo,
+    sizeInUsd,
+    sizeInTokens,
+    isLong,
+    pendingImpactAmount,
+    pnl,
+    closingFeeUsd,
+    remainingCollateralUsd,
+    collateralAmount,
+    collateralToken,
+  } = position;
+
+  if (sizeInUsd <= 0 || sizeInTokens <= 0) {
+    return false;
+  }
+
+  if (collateralAmount < collateralDeltaAmount) {
+    return true;
+  }
+
+  const collateralUsdAfterDelta = convertToUsd(
+    collateralAmount - collateralDeltaAmount,
+    collateralToken.decimals,
+    collateralToken.prices.minPrice
+  )!;
+
+  if (collateralUsdAfterDelta < applyFactor(sizeInUsd, getMinCollateralFactorForPosition(position, 0n))) {
+    return true;
+  }
+
+  const priceImpactDeltaUsd = getLiquidationPriceImpactDeltaUsd({
+    marketInfo,
+    sizeInUsd,
+    sizeInTokens,
+    pendingImpactAmount,
+    isLong,
+  });
+
+  const marginUsd = remainingCollateralUsd + pnl + priceImpactDeltaUsd - closingFeeUsd;
+
+  return marginUsd <= 0n || marginUsd < applyFactor(sizeInUsd, marketInfo.minCollateralFactor);
 }
 
 export function getNetPriceImpactDeltaUsdForDecrease({

--- a/sdk/src/utils/positions/utils.ts
+++ b/sdk/src/utils/positions/utils.ts
@@ -386,6 +386,12 @@ export function getIsPositionBelowMinCollateralForLeverage(position: PositionInf
     return true;
   }
 
+  const collateralDeltaUsd = convertToUsd(
+    collateralDeltaAmount,
+    collateralToken.decimals,
+    collateralToken.prices.minPrice
+  )!;
+
   const priceImpactDeltaUsd = getLiquidationPriceImpactDeltaUsd({
     marketInfo,
     sizeInUsd,
@@ -394,7 +400,7 @@ export function getIsPositionBelowMinCollateralForLeverage(position: PositionInf
     isLong,
   });
 
-  const marginUsd = remainingCollateralUsd + pnl + priceImpactDeltaUsd - closingFeeUsd;
+  const marginUsd = remainingCollateralUsd - collateralDeltaUsd + pnl + priceImpactDeltaUsd - closingFeeUsd;
 
   return marginUsd <= 0n || marginUsd < applyFactor(sizeInUsd, marketInfo.minCollateralFactor);
 }

--- a/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
+++ b/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -43,7 +43,12 @@ import Tooltip from "components/Tooltip/Tooltip";
 import SpinnerIcon from "img/ic_spinner.svg?react";
 
 import { SettleAccruedFundingFeeRow } from "./SettleAccruedFundingFeeRow";
-import { getIsSettlementLikelyToFail, shouldPreSelectPosition } from "./utils";
+import {
+  SETTLEMENT_COLLATERAL_DELTA_AMOUNT,
+  getIsPositionSettleable,
+  getSettlementBlockReason,
+  shouldPreSelectPosition,
+} from "./utils";
 
 import "./SettleAccruedFundingFeeModal.scss";
 
@@ -97,13 +102,13 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
   }, [preCheckedPositionKeys, isUntouched]);
 
   const selectedPositions = useMemo(
-    () => positiveFeePositions.filter((position) => positionKeys.includes(position.key)),
+    () =>
+      positiveFeePositions.filter(
+        (position) => positionKeys.includes(position.key) && getIsPositionSettleable(position)
+      ),
     [positionKeys, positiveFeePositions]
   );
-  const hasSelectedPositionsLikelyToFail = useMemo(
-    () => selectedPositions.some(getIsSettlementLikelyToFail),
-    [selectedPositions]
-  );
+  const selectedPositionKeys = useMemo(() => selectedPositions.map((position) => position.key), [selectedPositions]);
   const total = useMemo(() => getTotalAccruedFundingUsd(selectedPositions), [selectedPositions]);
   const totalStr = formatDeltaUsd(total);
 
@@ -120,7 +125,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
           marketAddress: position.marketAddress,
           indexTokenAddress: position.indexToken.address,
           collateralTokenAddress: position.collateralTokenAddress,
-          collateralDeltaAmount: 1n,
+          collateralDeltaAmount: SETTLEMENT_COLLATERAL_DELTA_AMOUNT,
           receiveTokenAddress: position.collateralToken.address,
           sizeDeltaUsd: 0n,
           sizeDeltaInTokens: 0n,
@@ -201,7 +206,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
     if (hasOutdatedUi) return [getPageOutdatedError(), true];
     if (isMultichainSubmitDisabled) return [t`Loading network fees…`, true];
     if (isSubmitting) return [t`Settling...`, true];
-    if (positionKeys.length === 0) return [t`Select positions`, true];
+    if (selectedPositions.length === 0) return [t`Select positions`, true];
 
     if (!isAllowanceLoaded) return [t`Loading...`, true];
 
@@ -215,7 +220,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
     hasOutdatedUi,
     isMultichainSubmitDisabled,
     isSubmitting,
-    positionKeys.length,
+    selectedPositions.length,
     isAllowanceLoaded,
     tokensToApprove,
     isApproving,
@@ -354,22 +359,13 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
               key={position.key}
               position={position}
               isMarketDisabled={position.marketInfo?.isDisabled ?? false}
-              isSettlementLikelyToFail={getIsSettlementLikelyToFail(position)}
-              isSelected={positionKeys.includes(position.key)}
+              blockReason={getSettlementBlockReason(position)}
+              isSelected={selectedPositionKeys.includes(position.key)}
               onCheckboxChange={handleRowCheckboxChange}
             />
           ))}
         </div>
       </div>
-      {hasSelectedPositionsLikelyToFail && (
-        <AlertInfo type="warning" compact textColor="text-yellow-300">
-          <Trans>
-            Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is
-            likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce
-            or close enough of those positions for the realized profit to cover the shortfall.
-          </Trans>
-        </AlertInfo>
-      )}
       <AlertInfo type="info" compact>
         <Trans>Select positions where accrued funding fee exceeds the {formatUsd(feeUsd)} gas cost to settle</Trans>
       </AlertInfo>

--- a/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
+++ b/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { UI_FEE_RECEIVER_ACCOUNT } from "config/ui";
 import {
+  usePositionsConstants,
   usePositiveFeePositionsSortedByUsd,
   useTokensData,
   useUserReferralInfo,
@@ -86,13 +87,14 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
   }, [chainId, gasLimits, gasPrice, tokensData]);
 
   const positiveFeePositions = usePositiveFeePositionsSortedByUsd();
+  const { minCollateralUsd } = usePositionsConstants();
   const { makeOrderTxnCallback } = useOrderTxnCallbacks();
 
   const preCheckedPositionKeys = useMemo(() => {
     return positiveFeePositions
-      .filter((position) => shouldPreSelectPosition(position, feeUsd ?? 0n))
+      .filter((position) => shouldPreSelectPosition(position, feeUsd ?? 0n, minCollateralUsd))
       .map((position) => position.key);
-  }, [positiveFeePositions, feeUsd]);
+  }, [positiveFeePositions, feeUsd, minCollateralUsd]);
 
   const [positionKeys, setPositionKeys] = useState<string[]>([]);
 
@@ -104,9 +106,9 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
   const selectedPositions = useMemo(
     () =>
       positiveFeePositions.filter(
-        (position) => positionKeys.includes(position.key) && getIsPositionSettleable(position)
+        (position) => positionKeys.includes(position.key) && getIsPositionSettleable(position, minCollateralUsd)
       ),
-    [positionKeys, positiveFeePositions]
+    [minCollateralUsd, positionKeys, positiveFeePositions]
   );
   const selectedPositionKeys = useMemo(() => selectedPositions.map((position) => position.key), [selectedPositions]);
   const total = useMemo(() => getTotalAccruedFundingUsd(selectedPositions), [selectedPositions]);
@@ -359,7 +361,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
               key={position.key}
               position={position}
               isMarketDisabled={position.marketInfo?.isDisabled ?? false}
-              blockReason={getSettlementBlockReason(position)}
+              blockReason={getSettlementBlockReason(position, minCollateralUsd)}
               isSelected={selectedPositionKeys.includes(position.key)}
               onCheckboxChange={handleRowCheckboxChange}
             />

--- a/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+++ b/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
@@ -100,7 +100,7 @@ export const SettleAccruedFundingFeeRow = ({
             {position.isLong ? t`Long` : t`Short`} {indexName}
           </span>{" "}
           <span className="subtext">[{poolName}]</span>
-          {!isMarketDisabled && blockReason !== undefined && (
+          {blockedTooltipContent !== undefined && (
             <WarnIcon className="ml-4 self-center text-yellow-300" aria-label={t`Warning icon`} />
           )}
         </div>

--- a/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+++ b/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from "@lingui/macro";
-import { useCallback } from "react";
+import { ReactNode, useCallback } from "react";
 
 import { PositionInfo } from "domain/synthetics/positions";
 import { TokenData } from "domain/synthetics/tokens";
@@ -11,55 +11,55 @@ import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
 
 import WarnIcon from "img/ic_warn.svg?react";
 
+import { SettlementBlockReason } from "./utils";
+
 type Props = {
   position: PositionInfo;
   isMarketDisabled: boolean;
-  isSettlementLikelyToFail: boolean;
+  blockReason: SettlementBlockReason | undefined;
   isSelected: boolean;
   onCheckboxChange: (value: boolean, positionKey: string) => void;
 };
 
+function getBlockedTooltipContent(
+  isMarketDisabled: boolean,
+  blockReason: SettlementBlockReason | undefined
+): ReactNode {
+  if (isMarketDisabled) {
+    return <Trans>This market is disabled. Contact support to claim your remaining funding fees.</Trans>;
+  }
+
+  if (blockReason === "negativeMargin") {
+    return (
+      <Trans>
+        This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail:
+        positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the
+        position for the realized profit to cover the shortfall.
+      </Trans>
+    );
+  }
+
+  if (blockReason === "belowMinCollateral") {
+    return (
+      <Trans>
+        This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close
+        the position. Closing settles the funding automatically.
+      </Trans>
+    );
+  }
+
+  return undefined;
+}
+
 export const SettleAccruedFundingFeeRow = ({
   position,
   isMarketDisabled,
-  isSettlementLikelyToFail,
+  blockReason,
   isSelected,
   onCheckboxChange,
 }: Props) => {
   const { indexName, poolName } = position;
 
-  const labelContent = (
-    <div key={position.key} className="flex items-start">
-      <span className="ClaimSettleModal-row-text">
-        {position.isLong ? t`Long` : t`Short`} {indexName}
-      </span>{" "}
-      <span className="subtext">[{poolName}]</span>
-      {!isMarketDisabled && isSettlementLikelyToFail && (
-        <WarnIcon className="ml-4 self-center text-yellow-300" aria-label={t`Warning icon`} />
-      )}
-    </div>
-  );
-  const label = isMarketDisabled ? (
-    <TooltipWithPortal
-      position="top-start"
-      handle={labelContent}
-      content={<Trans>This market is disabled. Contact support to claim your remaining funding fees.</Trans>}
-    />
-  ) : isSettlementLikelyToFail ? (
-    <TooltipWithPortal
-      position="top-start"
-      handle={labelContent}
-      content={
-        <Trans>
-          This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail:
-          positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough
-          of the position for the realized profit to cover the shortfall.
-        </Trans>
-      }
-    />
-  ) : (
-    labelContent
-  );
   const handleCheckboxChange = useCallback(
     (value: boolean) => onCheckboxChange(value, position.key),
     [onCheckboxChange, position.key]
@@ -85,16 +85,42 @@ export const SettleAccruedFundingFeeRow = ({
     [longToken, position.claimableLongTokenAmount, position.claimableShortTokenAmount, shortToken]
   );
 
+  const blockedTooltipContent = getBlockedTooltipContent(isMarketDisabled, blockReason);
+
+  const checkbox = (
+    <Checkbox
+      isChecked={isSelected}
+      setIsChecked={handleCheckboxChange}
+      disabled={blockedTooltipContent !== undefined}
+      className="ClaimSettleModal-checkbox flex self-center"
+    >
+      <div className="Exchange-info-label ClaimSettleModal-checkbox-label">
+        <div className="flex items-start">
+          <span className="ClaimSettleModal-row-text">
+            {position.isLong ? t`Long` : t`Short`} {indexName}
+          </span>{" "}
+          <span className="subtext">[{poolName}]</span>
+          {!isMarketDisabled && blockReason !== undefined && (
+            <WarnIcon className="ml-4 self-center text-yellow-300" aria-label={t`Warning icon`} />
+          )}
+        </div>
+      </div>
+    </Checkbox>
+  );
+
   return (
     <div className="ClaimSettleModal-info-row">
-      <Checkbox
-        isChecked={isSelected}
-        setIsChecked={handleCheckboxChange}
-        disabled={isMarketDisabled}
-        className="ClaimSettleModal-checkbox flex self-center"
-      >
-        <div className="Exchange-info-label ClaimSettleModal-checkbox-label">{label}</div>
-      </Checkbox>
+      {blockedTooltipContent === undefined ? (
+        checkbox
+      ) : (
+        <TooltipWithPortal
+          position="top-start"
+          variant="none"
+          isHandlerDisabled
+          handle={checkbox}
+          content={blockedTooltipContent}
+        />
+      )}
       <div className="ClaimSettleModal-info-label-usd">
         <Tooltip
           className="ClaimSettleModal-tooltip"

--- a/src/components/SettleAccruedFundingFeeModal/utils.spec.ts
+++ b/src/components/SettleAccruedFundingFeeModal/utils.spec.ts
@@ -14,6 +14,9 @@ const MARKET_INFO = createMockMarketInfo(undefined, { minCollateralFactor: (PREC
 
 const SIZE_IN_USD = expandDecimals(50000, 30);
 
+// MIN_COLLATERAL_USD on Arbitrum and Avalanche: the absolute floor, independent of the position size
+const MIN_COLLATERAL_USD = expandDecimals(1, 30);
+
 function createPosition(overrides: Partial<PositionInfo> = {}): PositionInfo {
   const position = createMockPositionInfo({
     account: ACCOUNT,
@@ -28,7 +31,7 @@ function createPosition(overrides: Partial<PositionInfo> = {}): PositionInfo {
 
 describe("getSettlementBlockReason", () => {
   it("does not block a position with margin above the min collateral for its size", () => {
-    expect(getSettlementBlockReason(createPosition())).toBeUndefined();
+    expect(getSettlementBlockReason(createPosition(), MIN_COLLATERAL_USD)).toBeUndefined();
   });
 
   it("blocks a position whose margin is below the min collateral for its size", () => {
@@ -37,7 +40,7 @@ describe("getSettlementBlockReason", () => {
       remainingCollateralUsd: expandDecimals(900, 30),
     });
 
-    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(position, MIN_COLLATERAL_USD)).toBe("belowMinCollateral");
   });
 
   it("does not block a position just above the min collateral for its size", () => {
@@ -46,7 +49,7 @@ describe("getSettlementBlockReason", () => {
       remainingCollateralUsd: expandDecimals(1100, 30),
     });
 
-    expect(getSettlementBlockReason(position)).toBeUndefined();
+    expect(getSettlementBlockReason(position, MIN_COLLATERAL_USD)).toBeUndefined();
   });
 
   it("counts pending fees and unrealized pnl into the margin", () => {
@@ -59,8 +62,8 @@ describe("getSettlementBlockReason", () => {
       pnl: expandDecimals(300, 30),
     });
 
-    expect(getSettlementBlockReason(withLosses)).toBe("belowMinCollateral");
-    expect(getSettlementBlockReason(withProfit)).toBeUndefined();
+    expect(getSettlementBlockReason(withLosses, MIN_COLLATERAL_USD)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(withProfit, MIN_COLLATERAL_USD)).toBeUndefined();
   });
 
   it("counts the closing fee into the margin", () => {
@@ -69,7 +72,7 @@ describe("getSettlementBlockReason", () => {
       closingFeeUsd: expandDecimals(200, 30),
     });
 
-    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(position, MIN_COLLATERAL_USD)).toBe("belowMinCollateral");
   });
 
   it("blocks a position whose collateral alone is below the min collateral for its size, even in profit", () => {
@@ -80,7 +83,7 @@ describe("getSettlementBlockReason", () => {
       pnl: expandDecimals(300, 30),
     });
 
-    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(position, MIN_COLLATERAL_USD)).toBe("belowMinCollateral");
   });
 
   it("blocks a position whose collateral is exactly the min collateral, since the settlement withdraws 1 wei", () => {
@@ -92,8 +95,8 @@ describe("getSettlementBlockReason", () => {
     });
     const oneWeiAbove = { ...exact, collateralAmount: expandDecimals(1000, 6) + 1n };
 
-    expect(getSettlementBlockReason(exact)).toBe("belowMinCollateral");
-    expect(getSettlementBlockReason(oneWeiAbove)).toBeUndefined();
+    expect(getSettlementBlockReason(exact, MIN_COLLATERAL_USD)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(oneWeiAbove, MIN_COLLATERAL_USD)).toBeUndefined();
   });
 
   it("holds the collateral to the open-interest-based min collateral factor when it is stricter than the market's", () => {
@@ -110,8 +113,25 @@ describe("getSettlementBlockReason", () => {
       remainingCollateralUsd: expandDecimals(1500, 30),
     });
 
-    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
-    expect(getSettlementBlockReason({ ...position, marketInfo: MARKET_INFO })).toBeUndefined();
+    expect(getSettlementBlockReason(position, MIN_COLLATERAL_USD)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason({ ...position, marketInfo: MARKET_INFO }, MIN_COLLATERAL_USD)).toBeUndefined();
+  });
+
+  it("blocks a position whose collateral and pnl together fall below the absolute min collateral", () => {
+    // $10 long with $2 of collateral: the leverage floor is $0.20, so only the $1 absolute minimum can block it
+    const position = createPosition({
+      sizeInUsd: expandDecimals(10, 30),
+      sizeInTokens: expandDecimals(5, 15),
+      collateralAmount: expandDecimals(2, 6),
+      collateralUsd: expandDecimals(2, 30),
+      remainingCollateralUsd: expandDecimals(2, 30),
+      pnl: -expandDecimals(15, 29),
+    });
+    const smallerLoss = { ...position, pnl: -expandDecimals(5, 29) };
+
+    expect(getSettlementBlockReason(position, MIN_COLLATERAL_USD)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(smallerLoss, MIN_COLLATERAL_USD)).toBeUndefined();
+    expect(getSettlementBlockReason(position, undefined)).toBeUndefined();
   });
 
   it("blocks a position with a negative margin after pending fees", () => {
@@ -120,7 +140,7 @@ describe("getSettlementBlockReason", () => {
       pnl: expandDecimals(5000, 30),
     });
 
-    expect(getSettlementBlockReason(position)).toBe("negativeMargin");
+    expect(getSettlementBlockReason(position, MIN_COLLATERAL_USD)).toBe("negativeMargin");
   });
 });
 
@@ -133,9 +153,9 @@ describe("getIsPositionSettleable", () => {
       remainingCollateralUsd: expandDecimals(900, 30),
     });
 
-    expect(getIsPositionSettleable(createPosition())).toBe(true);
-    expect(getIsPositionSettleable(disabledMarketPosition)).toBe(false);
-    expect(getIsPositionSettleable(blockedPosition)).toBe(false);
+    expect(getIsPositionSettleable(createPosition(), MIN_COLLATERAL_USD)).toBe(true);
+    expect(getIsPositionSettleable(disabledMarketPosition, MIN_COLLATERAL_USD)).toBe(false);
+    expect(getIsPositionSettleable(blockedPosition, MIN_COLLATERAL_USD)).toBe(false);
   });
 });
 
@@ -145,7 +165,7 @@ describe("shouldPreSelectPosition", () => {
   it("pre-selects a healthy position whose accrued funding covers the network fee", () => {
     const position = createPosition({ pendingClaimableFundingFeesUsd: expandDecimals(20, 30) });
 
-    expect(shouldPreSelectPosition(position, networkFee)).toBe(true);
+    expect(shouldPreSelectPosition(position, networkFee, MIN_COLLATERAL_USD)).toBe(true);
   });
 
   it("does not pre-select a blocked position however large its accrued funding", () => {
@@ -158,7 +178,7 @@ describe("shouldPreSelectPosition", () => {
       remainingCollateralUsd: -expandDecimals(10, 30),
     });
 
-    expect(shouldPreSelectPosition(belowMinCollateral, networkFee)).toBe(false);
-    expect(shouldPreSelectPosition(negativeMargin, networkFee)).toBe(false);
+    expect(shouldPreSelectPosition(belowMinCollateral, networkFee, MIN_COLLATERAL_USD)).toBe(false);
+    expect(shouldPreSelectPosition(negativeMargin, networkFee, MIN_COLLATERAL_USD)).toBe(false);
   });
 });

--- a/src/components/SettleAccruedFundingFeeModal/utils.spec.ts
+++ b/src/components/SettleAccruedFundingFeeModal/utils.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockMarketInfo } from "domain/testUtils/mockMarketInfo";
+import { createMockPositionInfo } from "domain/testUtils/mockPositionInfo";
+import { expandDecimals, PRECISION } from "lib/numbers";
+import type { PositionInfo } from "sdk/utils/positions/types";
+
+import { getIsPositionSettleable, getSettlementBlockReason, shouldPreSelectPosition } from "./utils";
+
+const ACCOUNT = "0x1234567890123456789012345678901234567890";
+
+// 2% min collateral factor: a $50,000 position needs $1,000 of margin to stay open
+const MARKET_INFO = createMockMarketInfo(undefined, { minCollateralFactor: (PRECISION * 2n) / 100n });
+
+const SIZE_IN_USD = expandDecimals(50000, 30);
+
+function createPosition(overrides: Partial<PositionInfo> = {}): PositionInfo {
+  const position = createMockPositionInfo({
+    account: ACCOUNT,
+    marketInfo: MARKET_INFO,
+    sizeInUsd: SIZE_IN_USD,
+    sizeInTokens: expandDecimals(25, 18),
+    collateralUsd: expandDecimals(5000, 30),
+  });
+
+  return { ...position, ...overrides };
+}
+
+describe("getSettlementBlockReason", () => {
+  it("does not block a position with margin above the min collateral for its size", () => {
+    expect(getSettlementBlockReason(createPosition())).toBeUndefined();
+  });
+
+  it("blocks a position whose margin is below the min collateral for its size", () => {
+    const position = createPosition({
+      collateralUsd: expandDecimals(900, 30),
+      remainingCollateralUsd: expandDecimals(900, 30),
+    });
+
+    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
+  });
+
+  it("does not block a position just above the min collateral for its size", () => {
+    const position = createPosition({
+      collateralUsd: expandDecimals(1100, 30),
+      remainingCollateralUsd: expandDecimals(1100, 30),
+    });
+
+    expect(getSettlementBlockReason(position)).toBeUndefined();
+  });
+
+  it("counts pending fees and unrealized pnl into the margin", () => {
+    const withLosses = createPosition({
+      remainingCollateralUsd: expandDecimals(1100, 30),
+      pnl: -expandDecimals(300, 30),
+    });
+    const withProfit = createPosition({
+      remainingCollateralUsd: expandDecimals(900, 30),
+      pnl: expandDecimals(300, 30),
+    });
+
+    expect(getSettlementBlockReason(withLosses)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(withProfit)).toBeUndefined();
+  });
+
+  it("counts the closing fee into the margin", () => {
+    const position = createPosition({
+      remainingCollateralUsd: expandDecimals(1100, 30),
+      closingFeeUsd: expandDecimals(200, 30),
+    });
+
+    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
+  });
+
+  it("blocks a position whose collateral alone is below the min collateral for its size, even in profit", () => {
+    const position = createPosition({
+      collateralAmount: expandDecimals(900, 6),
+      collateralUsd: expandDecimals(900, 30),
+      remainingCollateralUsd: expandDecimals(900, 30),
+      pnl: expandDecimals(300, 30),
+    });
+
+    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
+  });
+
+  it("blocks a position whose collateral is exactly the min collateral, since the settlement withdraws 1 wei", () => {
+    const exact = createPosition({
+      collateralAmount: expandDecimals(1000, 6),
+      collateralUsd: expandDecimals(1000, 30),
+      remainingCollateralUsd: expandDecimals(1000, 30),
+      pnl: expandDecimals(300, 30),
+    });
+    const oneWeiAbove = { ...exact, collateralAmount: expandDecimals(1000, 6) + 1n };
+
+    expect(getSettlementBlockReason(exact)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason(oneWeiAbove)).toBeUndefined();
+  });
+
+  it("holds the collateral to the open-interest-based min collateral factor when it is stricter than the market's", () => {
+    // 4e-8 per dollar of long open interest: $1,000,000 on the long side makes the factor 4%, above the market's 2%
+    const marketInfo = createMockMarketInfo(undefined, {
+      minCollateralFactor: (PRECISION * 2n) / 100n,
+      minCollateralFactorForOpenInterestLong: (PRECISION * 4n) / 100n / 1_000_000n,
+      longInterestUsd: expandDecimals(1_000_000, 30),
+    });
+    const position = createPosition({
+      marketInfo,
+      collateralAmount: expandDecimals(1500, 6),
+      collateralUsd: expandDecimals(1500, 30),
+      remainingCollateralUsd: expandDecimals(1500, 30),
+    });
+
+    expect(getSettlementBlockReason(position)).toBe("belowMinCollateral");
+    expect(getSettlementBlockReason({ ...position, marketInfo: MARKET_INFO })).toBeUndefined();
+  });
+
+  it("blocks a position with a negative margin after pending fees", () => {
+    const position = createPosition({
+      remainingCollateralUsd: -expandDecimals(10, 30),
+      pnl: expandDecimals(5000, 30),
+    });
+
+    expect(getSettlementBlockReason(position)).toBe("negativeMargin");
+  });
+});
+
+describe("getIsPositionSettleable", () => {
+  it("is false for a blocked position and for a disabled market", () => {
+    const disabledMarketPosition = createPosition({
+      marketInfo: createMockMarketInfo(undefined, { isDisabled: true }),
+    });
+    const blockedPosition = createPosition({
+      remainingCollateralUsd: expandDecimals(900, 30),
+    });
+
+    expect(getIsPositionSettleable(createPosition())).toBe(true);
+    expect(getIsPositionSettleable(disabledMarketPosition)).toBe(false);
+    expect(getIsPositionSettleable(blockedPosition)).toBe(false);
+  });
+});
+
+describe("shouldPreSelectPosition", () => {
+  const networkFee = expandDecimals(1, 30);
+
+  it("pre-selects a healthy position whose accrued funding covers the network fee", () => {
+    const position = createPosition({ pendingClaimableFundingFeesUsd: expandDecimals(20, 30) });
+
+    expect(shouldPreSelectPosition(position, networkFee)).toBe(true);
+  });
+
+  it("does not pre-select a blocked position however large its accrued funding", () => {
+    const belowMinCollateral = createPosition({
+      pendingClaimableFundingFeesUsd: expandDecimals(20, 30),
+      remainingCollateralUsd: expandDecimals(900, 30),
+    });
+    const negativeMargin = createPosition({
+      pendingClaimableFundingFeesUsd: expandDecimals(20, 30),
+      remainingCollateralUsd: -expandDecimals(10, 30),
+    });
+
+    expect(shouldPreSelectPosition(belowMinCollateral, networkFee)).toBe(false);
+    expect(shouldPreSelectPosition(negativeMargin, networkFee)).toBe(false);
+  });
+});

--- a/src/components/SettleAccruedFundingFeeModal/utils.ts
+++ b/src/components/SettleAccruedFundingFeeModal/utils.ts
@@ -1,18 +1,40 @@
-import { PositionInfo } from "domain/synthetics/positions";
+import {
+  PositionInfo,
+  getIsPositionBelowMinCollateralForLeverage,
+  getIsPositionInfoLoaded,
+} from "domain/synthetics/positions";
 
 const PENDING_FUNDING_FEE_THRESHOLD = 10n * 10n ** 30n; // 10$
 const SETTLE_FEE_RATIO_THRESHOLD = 10n;
 
-export function getIsSettlementLikelyToFail({ remainingCollateralUsd }: PositionInfo) {
-  return remainingCollateralUsd < 0n;
+export const SETTLEMENT_COLLATERAL_DELTA_AMOUNT = 1n;
+
+export type SettlementBlockReason = "negativeMargin" | "belowMinCollateral";
+
+export function getSettlementBlockReason(position: PositionInfo): SettlementBlockReason | undefined {
+  if (position.remainingCollateralUsd < 0n) {
+    return "negativeMargin";
+  }
+
+  if (
+    getIsPositionInfoLoaded(position) &&
+    getIsPositionBelowMinCollateralForLeverage(position, SETTLEMENT_COLLATERAL_DELTA_AMOUNT)
+  ) {
+    return "belowMinCollateral";
+  }
+
+  return undefined;
+}
+
+export function getIsPositionSettleable(position: PositionInfo) {
+  return !position.marketInfo?.isDisabled && getSettlementBlockReason(position) === undefined;
 }
 
 export function shouldPreSelectPosition(position: PositionInfo, networkFee: bigint) {
-  const { pendingClaimableFundingFeesUsd, marketInfo } = position;
+  const { pendingClaimableFundingFeesUsd } = position;
 
   return (
-    !marketInfo?.isDisabled &&
-    !getIsSettlementLikelyToFail(position) &&
+    getIsPositionSettleable(position) &&
     pendingClaimableFundingFeesUsd > PENDING_FUNDING_FEE_THRESHOLD &&
     pendingClaimableFundingFeesUsd > networkFee * SETTLE_FEE_RATIO_THRESHOLD
   );

--- a/src/components/SettleAccruedFundingFeeModal/utils.ts
+++ b/src/components/SettleAccruedFundingFeeModal/utils.ts
@@ -3,6 +3,7 @@ import {
   getIsPositionBelowMinCollateralForLeverage,
   getIsPositionInfoLoaded,
 } from "domain/synthetics/positions";
+import { convertToUsd } from "domain/synthetics/tokens";
 
 const PENDING_FUNDING_FEE_THRESHOLD = 10n * 10n ** 30n; // 10$
 const SETTLE_FEE_RATIO_THRESHOLD = 10n;
@@ -11,30 +12,48 @@ export const SETTLEMENT_COLLATERAL_DELTA_AMOUNT = 1n;
 
 export type SettlementBlockReason = "negativeMargin" | "belowMinCollateral";
 
-export function getSettlementBlockReason(position: PositionInfo): SettlementBlockReason | undefined {
+export function getSettlementBlockReason(
+  position: PositionInfo,
+  minCollateralUsd: bigint | undefined
+): SettlementBlockReason | undefined {
   if (position.remainingCollateralUsd < 0n) {
     return "negativeMargin";
   }
 
-  if (
-    getIsPositionInfoLoaded(position) &&
-    getIsPositionBelowMinCollateralForLeverage(position, SETTLEMENT_COLLATERAL_DELTA_AMOUNT)
-  ) {
+  if (!getIsPositionInfoLoaded(position)) {
+    return undefined;
+  }
+
+  if (getIsPositionBelowMinCollateralForLeverage(position, SETTLEMENT_COLLATERAL_DELTA_AMOUNT)) {
+    return "belowMinCollateral";
+  }
+
+  const collateralUsdAfterSettlement = convertToUsd(
+    position.collateralAmount - SETTLEMENT_COLLATERAL_DELTA_AMOUNT,
+    position.collateralToken.decimals,
+    position.collateralToken.prices.minPrice
+  )!;
+
+  if (minCollateralUsd !== undefined && collateralUsdAfterSettlement + position.pnl < minCollateralUsd) {
     return "belowMinCollateral";
   }
 
   return undefined;
 }
 
-export function getIsPositionSettleable(position: PositionInfo) {
-  return !position.marketInfo?.isDisabled && getSettlementBlockReason(position) === undefined;
+export function getIsPositionSettleable(position: PositionInfo, minCollateralUsd: bigint | undefined) {
+  return !position.marketInfo?.isDisabled && getSettlementBlockReason(position, minCollateralUsd) === undefined;
 }
 
-export function shouldPreSelectPosition(position: PositionInfo, networkFee: bigint) {
+export function shouldPreSelectPosition(
+  position: PositionInfo,
+  networkFee: bigint,
+  minCollateralUsd: bigint | undefined
+) {
   const { pendingClaimableFundingFeesUsd } = position;
 
   return (
-    getIsPositionSettleable(position) &&
+    getIsPositionSettleable(position, minCollateralUsd) &&
     pendingClaimableFundingFeesUsd > PENDING_FUNDING_FEE_THRESHOLD &&
     pendingClaimableFundingFeesUsd > networkFee * SETTLE_FEE_RATIO_THRESHOLD
   );

--- a/src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+++ b/src/components/StatusNotification/FeesSettlementStatusNotification.tsx
@@ -14,7 +14,11 @@ import { isMarketOrderType } from "domain/synthetics/orders";
 import { tryDecodeCustomError } from "lib/errors";
 import { getByKey } from "lib/objects";
 
-import { getErrorTooltipTitle } from "components/TradeHistory/TradeHistoryRow/utils/shared";
+import { CustomErrorName } from "components/TradeHistory/TradeHistoryRow/utils/CustomErrorName";
+import {
+  getErrorTooltipTitle,
+  getMarginBelowMinimumErrorMessage,
+} from "components/TradeHistory/TradeHistoryRow/utils/shared";
 import { TransactionStatus, TransactionStatusType } from "components/TransactionStatus/TransactionStatus";
 
 import "./StatusNotification.scss";
@@ -34,7 +38,15 @@ function getCancellationReason(reasonBytes: string | undefined) {
 
   const error = tryDecodeCustomError(reasonBytes);
 
-  return error ? getErrorTooltipTitle(error.name, true, error.args) : undefined;
+  if (!error) {
+    return undefined;
+  }
+
+  if (error.name === CustomErrorName.UnableToWithdrawCollateral) {
+    return getMarginBelowMinimumErrorMessage();
+  }
+
+  return getErrorTooltipTitle(error.name, true, error.args);
 }
 
 export function FeesSettlementStatusNotification({ orders, toastTimestamp, marketsInfoData }: Props) {

--- a/src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+++ b/src/components/StatusNotification/FeesSettlementStatusNotification.tsx
@@ -11,8 +11,10 @@ import {
 } from "context/SyntheticsEvents";
 import { MarketInfo, MarketsInfoData, getMarketIndexName, getMarketPoolName } from "domain/synthetics/markets";
 import { isMarketOrderType } from "domain/synthetics/orders";
+import { tryDecodeCustomError } from "lib/errors";
 import { getByKey } from "lib/objects";
 
+import { getErrorTooltipTitle } from "components/TradeHistory/TradeHistoryRow/utils/shared";
 import { TransactionStatus, TransactionStatusType } from "components/TransactionStatus/TransactionStatus";
 
 import "./StatusNotification.scss";
@@ -24,6 +26,16 @@ type Props = {
   orders: PendingFundingFeeSettlementData["orders"];
   marketsInfoData: MarketsInfoData | undefined;
 };
+
+function getCancellationReason(reasonBytes: string | undefined) {
+  if (!reasonBytes) {
+    return undefined;
+  }
+
+  const error = tryDecodeCustomError(reasonBytes);
+
+  return error ? getErrorTooltipTitle(error.name, true, error.args) : undefined;
+}
 
 export function FeesSettlementStatusNotification({ orders, toastTimestamp, marketsInfoData }: Props) {
   const { orderStatuses: allOrderStatuses, setOrderStatusViewed } = useSyntheticsEvents();
@@ -167,7 +179,15 @@ export function FeesSettlementStatusNotification({ orders, toastTimestamp, marke
           }
 
           if (orderStatus?.cancelledTxnHash) {
-            text = <Trans>{positionName} failed to settle</Trans>;
+            const cancellationReason = getCancellationReason(orderStatus.cancellationReasonBytes);
+
+            text = cancellationReason ? (
+              <Trans>
+                {positionName} failed to settle: {cancellationReason}
+              </Trans>
+            ) : (
+              <Trans>{positionName} failed to settle</Trans>
+            );
             status = "error";
             txnHash = orderStatus?.cancelledTxnHash;
           }

--- a/src/components/StatusNotification/settleCancellationReason.spec.ts
+++ b/src/components/StatusNotification/settleCancellationReason.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { tryDecodeCustomError } from "sdk/utils/errors";
+
+import { getErrorTooltipTitle } from "components/TradeHistory/TradeHistoryRow/utils/shared";
+
+// captured on an Arbitrum fork: the revert of a settle order (zero-size MarketDecrease) on a
+// position below its market's min collateral — the bytes the keeper stores as OrderCancelled.reasonBytes
+const REASON_BYTES =
+  "0xbc121108000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000004c5b58096563d9b3bafb166f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004ee2d6d415b85acef8100000000000000000000000000000000000000000000000000000000000000000000001b6d696e20636f6c6c61746572616c20666f72206c657665726167650000000000";
+
+describe("settle cancellation reason from a real contract revert", () => {
+  it("decodes to the min-collateral copy the toast shows", () => {
+    const error = tryDecodeCustomError(REASON_BYTES);
+
+    expect(error?.name).toBe("LiquidatablePosition");
+    expect((error?.args as any).reason).toBe("min collateral for leverage");
+    expect(getErrorTooltipTitle(error!.name, true, error!.args)).toBe(
+      "Margin is below the minimum required for the position size"
+    );
+  });
+});

--- a/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils.spec.ts
@@ -55,6 +55,9 @@ describe("TradeHistoryRow helpers", () => {
     expect(getErrorTooltipTitle("LiquidatablePosition", false)).toBe(
       "Position would be liquidatable at current prices"
     );
+    expect(getErrorTooltipTitle("LiquidatablePosition", false, { reason: "min collateral for leverage" })).toBe(
+      "Margin is below the minimum required for the position size"
+    );
     expect(getErrorTooltipTitle("MaxPoolAmountForDepositExceeded", false)).toBe(
       "Max deposit capacity reached for this pool"
     );

--- a/src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
@@ -6,6 +6,7 @@ import { format } from "date-fns/format";
 import { formatRelative } from "date-fns/formatRelative";
 import { enUS as dateEn } from "date-fns/locale/en-US";
 
+import { getStringContractErrorArg } from "lib/errors";
 import { TradeActionType } from "sdk/utils/tradeHistory/types";
 
 import { LOCALE_DATE_LOCALE_MAP } from "components/DateRangeSelect/DateRangeSelect";
@@ -186,7 +187,7 @@ export function getErrorTooltipTitle(errorName: string, isMarketOrder: boolean, 
     return t`Insufficient liquidity`;
   }
 
-  const tradeHistoryErrorMessage = getTradeHistoryErrorMessage(errorName);
+  const tradeHistoryErrorMessage = getTradeHistoryErrorMessage(errorName, errorArgs);
 
   if (tradeHistoryErrorMessage) {
     return tradeHistoryErrorMessage;
@@ -206,7 +207,9 @@ export function getErrorTooltipTitle(errorName: string, isMarketOrder: boolean, 
   return t`Order failed due to a protocol validation error: ${errorName}`;
 }
 
-function getTradeHistoryErrorMessage(errorName: string) {
+const MIN_COLLATERAL_FOR_LEVERAGE_REASON = "min collateral for leverage";
+
+function getTradeHistoryErrorMessage(errorName: string, errorArgs?: unknown) {
   switch (errorName) {
     case CustomErrorName.DisabledFeature:
       return t`This action is currently disabled`;
@@ -242,7 +245,9 @@ function getTradeHistoryErrorMessage(errorName: string) {
     case CustomErrorName.InsufficientFundsToPayForCosts:
       return t`Insufficient collateral to cover order costs`;
     case CustomErrorName.LiquidatablePosition:
-      return t`Position would be liquidatable at current prices`;
+      return getStringContractErrorArg(errorArgs, 0, "reason") === MIN_COLLATERAL_FOR_LEVERAGE_REASON
+        ? t`Margin is below the minimum required for the position size`
+        : t`Position would be liquidatable at current prices`;
     default:
       return undefined;
   }

--- a/src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+++ b/src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
@@ -209,6 +209,10 @@ export function getErrorTooltipTitle(errorName: string, isMarketOrder: boolean, 
 
 const MIN_COLLATERAL_FOR_LEVERAGE_REASON = "min collateral for leverage";
 
+export function getMarginBelowMinimumErrorMessage() {
+  return t`Margin is below the minimum required for the position size`;
+}
+
 function getTradeHistoryErrorMessage(errorName: string, errorArgs?: unknown) {
   switch (errorName) {
     case CustomErrorName.DisabledFeature:
@@ -246,7 +250,7 @@ function getTradeHistoryErrorMessage(errorName: string, errorArgs?: unknown) {
       return t`Insufficient collateral to cover order costs`;
     case CustomErrorName.LiquidatablePosition:
       return getStringContractErrorArg(errorArgs, 0, "reason") === MIN_COLLATERAL_FOR_LEVERAGE_REASON
-        ? t`Margin is below the minimum required for the position size`
+        ? getMarginBelowMinimumErrorMessage()
         : t`Position would be liquidatable at current prices`;
     default:
       return undefined;

--- a/src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
+++ b/src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
@@ -368,10 +368,13 @@ export function SyntheticsEventsProvider({ children }: { children: ReactNode }) 
         return;
       }
 
+      const cancellationReasonBytes = eventData.bytesItems.items.reasonBytes;
+
       setOrderStatuses((old) => {
         if (old[key]) {
           return updateByKey(old, key, {
             cancelledTxnHash: txnParams.transactionHash,
+            cancellationReasonBytes,
             isViewed: false,
           });
         } else {
@@ -379,6 +382,7 @@ export function SyntheticsEventsProvider({ children }: { children: ReactNode }) 
             key,
             createdAt: Date.now(),
             cancelledTxnHash: txnParams.transactionHash,
+            cancellationReasonBytes,
           });
         }
       });

--- a/src/context/SyntheticsEvents/types.ts
+++ b/src/context/SyntheticsEvents/types.ts
@@ -353,7 +353,9 @@ export type PendingShiftData = {
   minMarketTokens: bigint;
 };
 
-export type OrderStatus = MultiTransactionStatus<OrderCreatedEventData>;
+export type OrderStatus = MultiTransactionStatus<OrderCreatedEventData> & {
+  cancellationReasonBytes?: string;
+};
 export type DepositStatus = MultiTransactionStatus<DepositCreatedEventData | GLVDepositCreatedEventData>;
 export type WithdrawalStatus = MultiTransactionStatus<WithdrawalCreatedEventData>;
 export type ShiftStatus = MultiTransactionStatus<ShiftCreatedEventData>;

--- a/src/domain/synthetics/positions/utils.ts
+++ b/src/domain/synthetics/positions/utils.ts
@@ -12,16 +12,11 @@ import {
   formatUsdPrice,
 } from "lib/numbers";
 import { bigMath } from "sdk/utils/bigmath";
+import { getLiquidationPriceImpactDeltaUsd } from "sdk/utils/positions";
 
-import {
-  capPositionImpactUsdByMaxPriceImpactFactor,
-  getBorrowingFeeRateUsd,
-  getFundingFeeRateUsd,
-  getPriceImpactForPosition,
-} from "../fees";
-import { OrderType } from "../orders/types";
-import { convertToUsd } from "../tokens";
+import { getBorrowingFeeRateUsd, getFundingFeeRateUsd } from "../fees";
 import { PositionInfo, PositionInfoLoaded } from "./types";
+import { OrderType } from "../orders/types";
 
 export * from "sdk/utils/positions";
 
@@ -97,30 +92,14 @@ export function getEstimatedLiquidationTimeInHours(
   }
   const borrowFeePerHour = getBorrowingFeeRateUsd(marketInfo, isLong, sizeInUsd, BigInt(CHART_PERIODS["1h"]));
   const fundingFeePerHour = getFundingFeeRateUsd(marketInfo, isLong, sizeInUsd, BigInt(CHART_PERIODS["1h"]));
-  const maxNegativePriceImpactUsd = -1n * applyFactor(sizeInUsd, marketInfo.maxPositionImpactFactorForLiquidations);
-  let { priceImpactDeltaUsd } = getPriceImpactForPosition(marketInfo, -sizeInUsd, isLong, {
-    fallbackToZero: true,
-    sizeDeltaInTokens: position.sizeInTokens,
+
+  const priceImpactDeltaUsd = getLiquidationPriceImpactDeltaUsd({
+    marketInfo,
+    sizeInUsd,
+    sizeInTokens: position.sizeInTokens,
+    pendingImpactAmount: position.pendingImpactAmount,
+    isLong,
   });
-
-  if (priceImpactDeltaUsd > 0) {
-    priceImpactDeltaUsd = capPositionImpactUsdByMaxPriceImpactFactor(marketInfo, sizeInUsd, priceImpactDeltaUsd);
-  }
-
-  const pendingImpactUsd = convertToUsd(
-    position.pendingImpactAmount,
-    marketInfo.indexToken.decimals,
-    position.pendingImpactAmount > 0 ? marketInfo.indexToken.prices.minPrice : marketInfo.indexToken.prices.maxPrice
-  )!;
-
-  priceImpactDeltaUsd = priceImpactDeltaUsd + pendingImpactUsd;
-
-  // Ignore positive price impact
-  if (priceImpactDeltaUsd > 0) {
-    priceImpactDeltaUsd = 0n;
-  } else if (priceImpactDeltaUsd < maxNegativePriceImpactUsd) {
-    priceImpactDeltaUsd = maxNegativePriceImpactUsd;
-  }
 
   const totalFeesPerHour =
     bigMath.abs(borrowFeePerHour) + (fundingFeePerHour < 0 ? bigMath.abs(fundingFeePerHour) : 0n);

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4114,6 +4114,10 @@ msgstr "Minimaler Finanzierungsfaktor (Long)"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "Was macht GMX kosteneffizienter als andere Perpetual-Plattformen?"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "Die Margin liegt unter dem für die Positionsgröße erforderlichen Minimum"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "Sicherheit kann nicht abgehoben werden. Verbleibende Sicherheit wäre un
 msgid "Approving..."
 msgstr "Genehmige…"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "Diese Position hat nach ausstehenden Leih- und Finanzierungsgebühren eine negative Margin, daher wird die Abwicklung wahrscheinlich fehlschlagen: Positive Finanzierungsgebühren werden erst nach einer erfolgreichen Abwicklung beanspruchbar. Fügen Sie Margin hinzu oder schließen Sie die Position so weit, dass der realisierte Gewinn den Fehlbetrag deckt."
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "Dienstunterbrechung"
@@ -7268,10 +7276,6 @@ msgstr "Erhalten Sie mindestens {toAmountText} bei Ausführung. Preis wird basie
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "Diese Position hat nach ausstehenden Leih- und Finanzierungsgebühren eine negative Margin, daher wird die Abwicklung wahrscheinlich fehlschlagen: Positive Finanzierungsgebühren werden erst nach einer erfolgreichen Abwicklung beanspruchbar. Fügen Sie Margin hinzu oder reduzieren bzw. schließen Sie die Position so weit, dass der realisierte Gewinn den Fehlbetrag deckt."
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "Kaufanfrage wird ausgeführt…"
 msgid "Buy GM failed"
 msgstr "GM-Kauf fehlgeschlagen"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "Die Margin dieser Position liegt unter dem für ihre Größe erforderlichen Minimum, daher wird die Abwicklung fehlschlagen. Fügen Sie Margin hinzu oder schließen Sie die Position. Beim Schließen werden die Finanzierungsgebühren automatisch abgerechnet."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "Maximaler Finanzierungsfaktor (Long)"
@@ -10404,10 +10412,6 @@ msgstr "Min. Margin: {0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "Stop-Markt"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "Einige ausgewählte Positionen haben nach ausstehenden Leih- und Finanzierungsgebühren eine negative Margin, daher wird ihre Abwicklung wahrscheinlich fehlschlagen: Positive Finanzierungsgebühren werden erst nach einer erfolgreichen Abwicklung beanspruchbar. Fügen Sie Margin hinzu oder reduzieren bzw. schließen Sie diese Positionen so weit, dass der realisierte Gewinn den Fehlbetrag deckt."
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "Abrechnung von {positionName} fehlgeschlagen: {cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4114,6 +4114,10 @@ msgstr "Min funding factor (long)"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "What makes GMX more cost-efficient than other perpetual platforms?"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "Margin is below the minimum required for the position size"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr "How much can I earn as an affiliate?"
@@ -7225,6 +7229,10 @@ msgstr "Can't withdraw collateral. Remaining collateral would be below minimum"
 msgid "Approving..."
 msgstr "Approving..."
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "Service Disruption"
@@ -7268,10 +7276,6 @@ msgstr "Receive at least {toAmountText} if executed. Price updates based on fees
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "Fulfilling buy request..."
 msgid "Buy GM failed"
 msgstr "Buy GM failed"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "Max funding factor (long)"
@@ -10404,10 +10412,6 @@ msgstr "Min margin: {0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "Stop Market"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr "Swap route unavailable for: {0}"
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "{positionName} failed to settle: {cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4114,6 +4114,10 @@ msgstr "Factor de financiación mínimo (largo)"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "¿Qué hace a GMX más eficiente en costos que otras plataformas perpetuas?"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "El margen está por debajo del mínimo requerido para el tamaño de la posición"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "No se puede retirar la garantía. La garantía restante quedaría por de
 msgid "Approving..."
 msgstr "Aprobando..."
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "Esta posición tiene un margen negativo después de las comisiones pendientes de préstamo y financiación, por lo que la compensación probablemente falle: la financiación positiva solo se vuelve reclamable tras una compensación exitosa. Añada margen, o cierre la posición lo suficiente para que el beneficio realizado cubra el déficit."
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "Interrupción del servicio"
@@ -7268,10 +7276,6 @@ msgstr "Reciba al menos {toAmountText} si se ejecuta. El precio se actualiza seg
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "Esta posición tiene un margen negativo después de las comisiones pendientes de préstamo y financiación, por lo que la compensación probablemente falle: la financiación positiva solo se vuelve reclamable tras una compensación exitosa. Añada margen, o reduzca o cierre la posición lo suficiente para que el beneficio realizado cubra el déficit."
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "Ejecutando solicitud de compra…"
 msgid "Buy GM failed"
 msgstr "La compra de GM ha fallado"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "El margen de esta posición está por debajo del mínimo requerido para su tamaño, por lo que la compensación fallará. Añada margen o cierre la posición. Al cerrarla, la financiación se compensa automáticamente."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "Factor de financiación máximo (largo)"
@@ -10404,10 +10412,6 @@ msgstr "Margen mín.: {0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "Stop Mercado"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "Algunas posiciones seleccionadas tienen un margen negativo después de las comisiones pendientes de préstamo y financiación, por lo que su compensación probablemente falle: la financiación positiva solo se vuelve reclamable tras una compensación exitosa. Añada margen, o reduzca o cierre esas posiciones lo suficiente para que el beneficio realizado cubra el déficit."
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "{positionName} no se ha podido liquidar: {cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4114,6 +4114,10 @@ msgstr "Facteur de financement minimal (long)"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "Qu'est-ce qui rend GMX plus rentable que d'autres plateformes perpétuelles ?"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "La marge est inférieure au minimum requis pour la taille de la position"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "Impossible de retirer la garantie. La garantie restante serait inférieu
 msgid "Approving..."
 msgstr "Approbation en cours…"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "Cette position a une marge négative après les frais d'emprunt et de financement en attente, le règlement risque donc d'échouer : le financement positif ne devient réclamable qu'après un règlement réussi. Ajoutez de la marge, ou fermez suffisamment la position pour que le profit réalisé couvre le déficit."
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "Interruption de service"
@@ -7268,10 +7276,6 @@ msgstr "Recevez au moins {toAmountText} en cas d'exécution. Le prix est mis à 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "Cette position a une marge négative après les frais d'emprunt et de financement en attente, le règlement risque donc d'échouer : le financement positif ne devient réclamable qu'après un règlement réussi. Ajoutez de la marge, ou réduisez ou fermez suffisamment la position pour que le profit réalisé couvre le déficit."
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "Exécution de la demande d'achat…"
 msgid "Buy GM failed"
 msgstr "Échec de l'achat de GM"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "La marge de cette position est inférieure au minimum requis pour sa taille, le règlement échouera donc. Ajoutez de la marge ou fermez la position. La fermeture règle automatiquement le financement."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "Facteur de financement maximal (long)"
@@ -10404,10 +10412,6 @@ msgstr "Marge min. : {0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "Stop Marché"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "Certaines positions sélectionnées ont une marge négative après les frais d'emprunt et de financement en attente, leur règlement risque donc d'échouer : le financement positif ne devient réclamable qu'après un règlement réussi. Ajoutez de la marge, ou réduisez ou fermez suffisamment ces positions pour que le profit réalisé couvre le déficit."
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "Le règlement de {positionName} a échoué : {cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4114,6 +4114,10 @@ msgstr "最小ファンディングファクター（ロング）"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "GMXが他のパーペチュアルプラットフォームよりコスト効率が高い理由は何ですか？"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "証拠金がポジションサイズに必要な最低額を下回っています"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "担保を出金できません。残りの担保が最低額を下回り
 msgid "Approving..."
 msgstr "承認中..."
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "このポジションは未払いの借入手数料とファンディング手数料を差し引くと証拠金がマイナスのため、決済は失敗する可能性が高いです。プラスのファンディングは決済が成功した後にのみ請求可能になります。証拠金を追加するか、実現利益が不足分を補えるようにポジションを十分にクローズしてください。"
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "サービス障害"
@@ -7268,10 +7276,6 @@ msgstr "約定時に最低{toAmountText}を受け取ります。価格は手数�
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "このポジションは未払いの借入手数料とファンディング手数料を差し引くと証拠金がマイナスのため、決済は失敗する可能性が高いです。プラスのファンディングは決済が成功した後にのみ請求可能になります。証拠金を追加するか、実現利益が不足分を補えるようにポジションを十分に縮小またはクローズしてください。"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "買いリクエストを実行中…"
 msgid "Buy GM failed"
 msgstr "GMの購入に失敗しました"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "このポジションの証拠金は、そのサイズに必要な最低額を下回っているため、決済は失敗します。証拠金を追加するか、ポジションをクローズしてください。クローズすると、ファンディングは自動的に決済されます。"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "最大ファンディングファクター（ロング）"
@@ -10404,10 +10412,6 @@ msgstr "最小証拠金：{0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "ストップマーケット"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "選択されたポジションの一部は、未払いの借入手数料とファンディング手数料を差し引くと証拠金がマイナスのため、決済は失敗する可能性が高いです。プラスのファンディングは決済が成功した後にのみ請求可能になります。証拠金を追加するか、実現利益が不足分を補えるようにそれらのポジションを十分に縮小またはクローズしてください。"
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "{positionName}の決済に失敗しました: {cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4114,6 +4114,10 @@ msgstr "최소 펀딩 계수(롱)"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "GMX가 다른 영구 플랫폼보다 비용 효율적인 이유는 무엇인가요?"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "마진이 포지션 규모에 필요한 최소 금액보다 적습니다"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "담보를 출금할 수 없습니다. 잔여 담보가 최소 기준 미
 msgid "Approving..."
 msgstr "승인 중..."
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "이 포지션은 미지급 차입 수수료와 펀딩 수수료를 차감하면 마진이 마이너스이므로 정산이 실패할 가능성이 높습니다. 플러스 펀딩은 정산이 성공한 후에만 수령할 수 있습니다. 마진을 추가하거나, 실현 이익이 부족분을 충당할 수 있도록 포지션을 충분히 종료하세요."
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "서비스 중단"
@@ -7268,10 +7276,6 @@ msgstr "체결 시 최소 {toAmountText}을(를) 수령합니다. 가격은 수�
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "이 포지션은 미지급 차입 수수료와 펀딩 수수료를 차감하면 마진이 마이너스이므로 정산이 실패할 가능성이 높습니다. 플러스 펀딩은 정산이 성공한 후에만 수령할 수 있습니다. 마진을 추가하거나, 실현 이익이 부족분을 충당할 수 있도록 포지션을 충분히 축소하거나 종료하세요."
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "매수 요청을 실행하는 중…"
 msgid "Buy GM failed"
 msgstr "GM 구매 실패"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "이 포지션의 마진이 규모에 필요한 최소 금액보다 적으므로 정산이 실패합니다. 마진을 추가하거나 포지션을 종료하세요. 종료하면 펀딩이 자동으로 정산됩니다."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "최대 펀딩 계수(롱)"
@@ -10404,10 +10412,6 @@ msgstr "최소 증거금: {0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "스탑 마켓"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "선택한 포지션 중 일부는 미지급 차입 수수료와 펀딩 수수료를 차감하면 마진이 마이너스이므로 정산이 실패할 가능성이 높습니다. 플러스 펀딩은 정산이 성공한 후에만 수령할 수 있습니다. 마진을 추가하거나, 실현 이익이 부족분을 충당할 수 있도록 해당 포지션을 충분히 축소하거나 종료하세요."
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "{positionName} 정산 실패: {cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4114,6 +4114,10 @@ msgstr ""
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr ""
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr ""
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr ""
 msgid "Approving..."
 msgstr ""
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr ""
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr ""
@@ -7267,10 +7275,6 @@ msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
-msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
 msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
@@ -9308,6 +9312,10 @@ msgstr ""
 msgid "Buy GM failed"
 msgstr ""
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr ""
@@ -10403,10 +10411,6 @@ msgstr ""
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
-msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
 msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
@@ -11972,6 +11976,10 @@ msgstr ""
 
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
+msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
 msgstr ""
 
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4114,6 +4114,10 @@ msgstr "Минимальный фактор финансирования (лон
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "Что делает GMX более экономичным, чем другие перпетуальные платформы?"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "Маржа ниже минимума, необходимого для размера позиции"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "Невозможно вывести обеспечение. Оставш
 msgid "Approving..."
 msgstr "Одобрение…"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "После вычета ожидающих комиссий за заимствование и фондирование маржа этой позиции отрицательна, поэтому расчёт, скорее всего, не удастся: положительное фондирование становится доступным для получения только после успешного расчёта. Добавьте маржу либо закройте часть позиции, чтобы реализованная прибыль покрыла недостачу."
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "Перебои в работе сервиса"
@@ -7268,10 +7276,6 @@ msgstr "Получите не менее {toAmountText} при исполнен�
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "После вычета ожидающих комиссий за заимствование и фондирование маржа этой позиции отрицательна, поэтому расчёт, скорее всего, не удастся: положительное фондирование становится доступным для получения только после успешного расчёта. Добавьте маржу либо уменьшите или закройте часть позиции, чтобы реализованная прибыль покрыла недостачу."
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "Выполнение запроса на покупку…"
 msgid "Buy GM failed"
 msgstr "Покупка GM не удалась"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "Маржа этой позиции ниже минимума, необходимого для её размера, поэтому расчёт не удастся. Добавьте маржу или закройте позицию. При закрытии фондирование рассчитывается автоматически."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "Максимальный фактор финансирования (лонг)"
@@ -10404,10 +10412,6 @@ msgstr "Мин. маржа: {0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "Стоп-рынок"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "У некоторых выбранных позиций после вычета ожидающих комиссий за заимствование и фондирование маржа отрицательна, поэтому их расчёт, скорее всего, не удастся: положительное фондирование становится доступным для получения только после успешного расчёта. Добавьте маржу либо уменьшите или закройте часть таких позиций, чтобы реализованная прибыль покрыла недостачу."
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "{positionName} — ошибка расчёта: {cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4114,6 +4114,10 @@ msgstr "最小資金因子（多頭）"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "為什麼 GMX 比其他永續合約平台更具成本效益？"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "保證金低於該倉位規模所需的最低要求"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "無法提取抵押品。剩餘抵押品將低於最低要求"
 msgid "Approving..."
 msgstr "授權中..."
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "該倉位在扣除待結借貸費用和資金費率費用後保證金為負，因此結算很可能失敗：正資金費率費用只有在結算成功後才可領取。請增加保證金，或充分平倉，使已實現利潤足以彌補缺口。"
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "服務中斷"
@@ -7268,10 +7276,6 @@ msgstr "執行後至少收到 {toAmountText}。價格根據費用和價格影響
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "該倉位在扣除待結借貸費用和資金費率費用後保證金為負，因此結算很可能失敗：正資金費率費用只有在結算成功後才可領取。請增加保證金，或充分減倉或平倉，使已實現利潤足以彌補缺口。"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "正在執行買入請求..."
 msgid "Buy GM failed"
 msgstr "購買 GM 失敗"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "該倉位的保證金低於其規模所需的最低要求，因此結算將失敗。請增加保證金或平倉。平倉時資金費率費用會自動結算。"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "最大資金因子（多頭）"
@@ -10404,10 +10412,6 @@ msgstr "最低保證金：{0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "Stop Market"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "部分所選倉位在扣除待結借貸費用和資金費率費用後保證金為負，因此其結算很可能失敗：正資金費率費用只有在結算成功後才可領取。請增加保證金，或充分減倉或平倉這些倉位，使已實現利潤足以彌補缺口。"
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "{positionName} 結算失敗：{cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4114,6 +4114,10 @@ msgstr "最小资金费率因子（多头）"
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "是什么让 GMX 比其他永续平台更具成本效益？"
 
+#: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+msgid "Margin is below the minimum required for the position size"
+msgstr "保证金低于该仓位规模所需的最低要求"
+
 #: src/components/Referrals/affiliates/faq.tsx
 msgid "How much can I earn as an affiliate?"
 msgstr ""
@@ -7225,6 +7229,10 @@ msgstr "无法提取抵押品。剩余抵押品将低于最低要求"
 msgid "Approving..."
 msgstr "授权中..."
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or close enough of the position for the realized profit to cover the shortfall."
+msgstr "该仓位在扣除待结借贷费用和资金费用后保证金为负，因此结算很可能失败：正资金费用只有在结算成功后才可领取。请增加保证金，或充分平仓，使已实现利润足以弥补缺口。"
+
 #: src/config/uiFlagEvents.tsx
 msgid "Service Disruption"
 msgstr "服务中断"
@@ -7268,10 +7276,6 @@ msgstr "执行后至少收到 {toAmountText}。价格根据费用和价格影响
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Increasing {indexTokenText} Short: +{sizeDeltaUsdText}"
 msgstr ""
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
-msgid "This position has a negative margin after pending borrow and funding fees, so settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of the position for the realized profit to cover the shortfall."
-msgstr "该仓位在扣除待结借贷费用和资金费用后保证金为负，因此结算很可能失败：正资金费用只有在结算成功后才可领取。请增加保证金，或充分减仓或平仓，使已实现利润足以弥补缺口。"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order executed"
@@ -9308,6 +9312,10 @@ msgstr "正在执行买入请求…"
 msgid "Buy GM failed"
 msgstr "买入 GM 失败"
 
+#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeRow.tsx
+msgid "This position's margin is below the minimum required for its size, so settlement will fail. Add margin, or close the position. Closing settles the funding automatically."
+msgstr "该仓位的保证金低于其规模所需的最低要求，因此结算将失败。请增加保证金或平仓。平仓时资金费用会自动结算。"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max funding factor (long)"
 msgstr "最大资金费率因子（多头）"
@@ -10404,10 +10412,6 @@ msgstr "最低保证金：{0}"
 #: src/domain/synthetics/positions/utils.ts
 msgid "Stop Market"
 msgstr "止损市价"
-
-#: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
-msgid "Some selected positions have a negative margin after pending borrow and funding fees, so their settlement is likely to fail: positive funding only becomes claimable after a successful settlement. Add margin, or reduce or close enough of those positions for the realized profit to cover the shortfall."
-msgstr "部分所选仓位在扣除待结借贷费用和资金费用后保证金为负，因此其结算很可能失败：正资金费用只有在结算成功后才可领取。请增加保证金，或充分减仓或平仓这些仓位，使已实现利润足以弥补缺口。"
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "Execution prices for increasing longs<0/>and decreasing shorts"
@@ -11973,6 +11977,10 @@ msgstr "{column}"
 #: src/components/Referrals/shared/modals/ClaimAffiliatesModal.tsx
 msgid "Swap route unavailable for: {0}"
 msgstr ""
+
+#: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
+msgid "{positionName} failed to settle: {cancellationReason}"
+msgstr "{positionName} 结算失败：{cancellationReason}"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "No trackers registered"


### PR DESCRIPTION
## Summary

Fixes [FEDEV-4266](https://linear.app/gmx-io/issue/FEDEV-4266/bug-settle-funding-fees-fails-silently-on-positions-below-min).

Settling accrued funding creates a zero-size `MarketDecrease` that withdraws 1 wei of collateral, so the position stays open and the contract re-validates it. Two independent checks cancel such an order: `willPositionCollateralBeSufficient` (collateral alone, without pnl or fees, against the size times the larger of the market's `minCollateralFactor` and the open-interest-based one → `UnableToWithdrawCollateral`) and `validatePosition` (collateral after pending fees, plus pnl and capped price impact, minus the closing fee, against the size times `minCollateralFactor` → `LiquidatablePosition("min collateral for leverage")`). The settle window offered such positions anyway, even pre-selected them, and the failure toast said only "failed to settle".

### Changes

- **`getIsPositionBelowMinCollateralForLeverage` (sdk)** mirrors both checks, including the 1 wei the settlement withdraws and the open-interest-based factor via the existing `getMinCollateralFactorForPosition`. The liquidation price-impact capping is extracted from `getLiquidationPrice`, which repeated it twice.
- **Settle window**: rows the contract would cancel are blocked the way disabled markets are — checkbox disabled, tooltip naming the way out. The FEDEV-3907 negative-margin state is blocked the same way instead of only warning (its tooltip drops "reduce or"). Pre-selection and the submitted batch go through the same gate, so a row that crosses the line while the window is open drops out of the batch instead of failing on chain.
- **Failure toast**: `OrderCancelled.reasonBytes` is stored with the order status and decoded through the shared trade-history copy: "… failed to settle: Margin is below the minimum required for the position size". That copy now separates "min collateral for leverage" from an actual liquidation state, since a position can be below the factor while far from its liquidation price.

### Testing

- Unit: settle gate spec (collateral-only check, exact 1-wei boundary, open-interest factor, pending fees, pnl, closing fee, negative margin, pre-selection), trade-history copy spec, and a spec decoding real `reasonBytes` captured from the contract. `tscheck`, eslint, prettier pass.
- Arbitrum fork (anvil, block 501618720): the gate's boundary was bisected against `SimulationRouter.simulateExecuteLatestOrder` on five planted positions (LIT long and short with USDC, LIT long with WETH collateral, ETH long with index-token collateral, ETH short). In every case the app blocks at exactly the price where the contract starts cancelling. A NATGAS position with collateral below the requirement but positive pnl is cancelled by the contract (`UnableToWithdrawCollateral`) and is now blocked; the current window version offers it and the order gets cancelled.
- Browser against the fork: blocked rows disabled with the right tooltips, healthy rows settle in one batch, pre-selection skips blocked rows; the toast round-trip verified by emitting the keeper's `OrderCancelled` with the real reason bytes.

### Notes

- Overlaps #2767 (FEDEV-4131) only in the `.po` catalogs. Both branches port `isPositionLiquidatable` separately; unifying this gate with `getResultingPositionMarginState` is a follow-up once both land.
- A settle cancelled by `UnableToWithdrawCollateral` in the submit-to-execution race shows the shared "Can't withdraw collateral…" copy; rare now that the gate covers that check.
- `closingFeeUsd` in `PositionInfo` ignores the pro discount, so the gate is marginally stricter than the contract for pro accounts — the same known gap as FEDEV-4131.

Linear: https://linear.app/gmx-io/issue/FEDEV-4266/bug-settle-funding-fees-fails-silently-on-positions-below-min
