### PR TITLE
Let only the active form switch the express gas payment token FEDEV-4220

### DIFF
--- a/src/components/ActiveFormScope/ActiveFormScope.tsx
+++ b/src/components/ActiveFormScope/ActiveFormScope.tsx
@@ -1,0 +1,41 @@
+import { PropsWithChildren, useCallback, useEffect, useId, useSyncExternalStore } from "react";
+
+import { activateForm, deactivateForm, getActiveFormId, subscribeToActiveForm } from "./activeFormStore";
+
+export function useIsActiveForm(formId: string) {
+  return useSyncExternalStore(subscribeToActiveForm, () => getActiveFormId() === formId);
+}
+
+export function useActiveForm() {
+  const formId = useId();
+  const isActiveForm = useIsActiveForm(formId);
+
+  return { formId, isActiveForm };
+}
+
+export function ActiveFormScope({ formId, children }: PropsWithChildren<{ formId: string }>) {
+  useEffect(() => {
+    activateForm(formId);
+
+    return () => {
+      deactivateForm(formId);
+    };
+  }, [formId]);
+
+  const handleInteraction = useCallback(() => {
+    activateForm(formId);
+  }, [formId]);
+
+  return (
+    <div
+      className="contents"
+      onPointerDownCapture={handleInteraction}
+      onClickCapture={handleInteraction}
+      onFocusCapture={handleInteraction}
+      onKeyDownCapture={handleInteraction}
+      onInputCapture={handleInteraction}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ActiveFormScope/__tests__/ActiveFormScope.spec.tsx
+++ b/src/components/ActiveFormScope/__tests__/ActiveFormScope.spec.tsx
@@ -1,0 +1,141 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ActiveFormScope, useActiveForm } from "../ActiveFormScope";
+
+type Activity = Map<string, boolean>;
+
+// Mirrors the real forms: the hook lives in the form component, while the scope is rendered only
+// while the form's content is on screen (Modal renders its children only when it is visible).
+function Form({ name, isOpen = true, activity }: { name: string; isOpen?: boolean; activity: Activity }) {
+  const { formId, isActiveForm } = useActiveForm();
+
+  activity.set(name, isActiveForm);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <ActiveFormScope formId={formId}>
+      <input aria-label={name} />
+      <button type="button" aria-label={`${name} max`} />
+    </ActiveFormScope>
+  );
+}
+
+function renderForms(forms: { name: string; isOpen?: boolean }[]) {
+  const activity: Activity = new Map();
+
+  const ui = (nextForms: { name: string; isOpen?: boolean }[]) => (
+    <>
+      {nextForms.map((form) => (
+        <Form key={form.name} name={form.name} isOpen={form.isOpen} activity={activity} />
+      ))}
+    </>
+  );
+
+  const { rerender } = render(ui(forms));
+
+  return { activity, rerender: (nextForms: { name: string; isOpen?: boolean }[]) => rerender(ui(nextForms)) };
+}
+
+describe("ActiveFormScope", () => {
+  afterEach(cleanup);
+
+  it("makes the only mounted form active", () => {
+    const { activity } = renderForms([{ name: "page" }]);
+
+    expect(activity.get("page")).toBe(true);
+  });
+
+  it("hands activity to a form that appears later, e.g. a modal opened over the page", () => {
+    const { activity, rerender } = renderForms([{ name: "page" }, { name: "modal", isOpen: false }]);
+
+    rerender([{ name: "page" }, { name: "modal", isOpen: true }]);
+
+    expect(activity.get("modal")).toBe(true);
+    expect(activity.get("page")).toBe(false);
+  });
+
+  it("returns activity to the previously active form when the active one closes", () => {
+    const { activity, rerender } = renderForms([{ name: "page" }, { name: "modal", isOpen: true }]);
+
+    rerender([{ name: "page" }, { name: "modal", isOpen: false }]);
+
+    expect(activity.get("page")).toBe(true);
+    expect(activity.get("modal")).toBe(false);
+  });
+
+  it("returns activity to the previously active form when the active one unmounts", () => {
+    const { activity, rerender } = renderForms([{ name: "page" }, { name: "modal" }]);
+
+    rerender([{ name: "page" }]);
+
+    expect(activity.get("page")).toBe(true);
+  });
+
+  it("never activates a form whose content is not on screen", () => {
+    const { activity } = renderForms([{ name: "hidden", isOpen: false }, { name: "page" }]);
+
+    expect(activity.get("hidden")).toBe(false);
+    expect(activity.get("page")).toBe(true);
+  });
+
+  it("activates the form the user points at", () => {
+    const { activity } = renderForms([{ name: "first" }, { name: "second" }]);
+
+    expect(activity.get("second")).toBe(true);
+
+    fireEvent.pointerDown(screen.getByLabelText("first"));
+
+    expect(activity.get("first")).toBe(true);
+    expect(activity.get("second")).toBe(false);
+  });
+
+  it("activates the form that receives focus", () => {
+    const { activity } = renderForms([{ name: "first" }, { name: "second" }]);
+
+    fireEvent.focusIn(screen.getByLabelText("first"));
+
+    expect(activity.get("first")).toBe(true);
+    expect(activity.get("second")).toBe(false);
+  });
+
+  it("activates the form the user types into", () => {
+    const { activity } = renderForms([{ name: "first" }, { name: "second" }]);
+
+    fireEvent.keyDown(screen.getByLabelText("first"), { key: "1" });
+
+    expect(activity.get("first")).toBe(true);
+    expect(activity.get("second")).toBe(false);
+  });
+
+  it("activates the form whose field is filled programmatically, without focus or pointer events", () => {
+    const { activity } = renderForms([{ name: "first" }, { name: "second" }]);
+
+    fireEvent.input(screen.getByLabelText("first"), { target: { value: "10" } });
+
+    expect(activity.get("first")).toBe(true);
+    expect(activity.get("second")).toBe(false);
+  });
+
+  it("activates the form whose control is clicked without a preceding pointer event", () => {
+    const { activity } = renderForms([{ name: "first" }, { name: "second" }]);
+
+    fireEvent.click(screen.getByLabelText("first max"));
+
+    expect(activity.get("first")).toBe(true);
+    expect(activity.get("second")).toBe(false);
+  });
+
+  it("keeps the touched form active after other forms close", () => {
+    const { activity, rerender } = renderForms([{ name: "first" }, { name: "second" }, { name: "third" }]);
+
+    fireEvent.pointerDown(screen.getByLabelText("second"));
+    rerender([{ name: "first" }, { name: "second" }, { name: "third", isOpen: false }]);
+
+    expect(activity.get("second")).toBe(true);
+    expect(activity.get("first")).toBe(false);
+  });
+});

--- a/src/components/ActiveFormScope/activeFormStore.ts
+++ b/src/components/ActiveFormScope/activeFormStore.ts
@@ -1,0 +1,49 @@
+const activatedFormIds: string[] = [];
+const listeners = new Set<() => void>();
+
+let activeFormId: string | undefined;
+
+function removeFormId(formId: string) {
+  const index = activatedFormIds.indexOf(formId);
+
+  if (index !== -1) {
+    activatedFormIds.splice(index, 1);
+  }
+}
+
+function updateActiveFormId() {
+  const nextActiveFormId = activatedFormIds[activatedFormIds.length - 1];
+
+  if (nextActiveFormId === activeFormId) {
+    return;
+  }
+
+  activeFormId = nextActiveFormId;
+
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function activateForm(formId: string) {
+  removeFormId(formId);
+  activatedFormIds.push(formId);
+  updateActiveFormId();
+}
+
+export function deactivateForm(formId: string) {
+  removeFormId(formId);
+  updateActiveFormId();
+}
+
+export function getActiveFormId() {
+  return activeFormId;
+}
+
+export function subscribeToActiveForm(listener: () => void) {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,6 +5,7 @@ import { RemoveScroll } from "react-remove-scroll";
 
 import { PRIVY_DIALOG_SCROLL_SHARDS } from "lib/wallets/privyUiCompat";
 
+import { ActiveFormScope } from "components/ActiveFormScope/ActiveFormScope";
 import Button from "components/Button/Button";
 import ErrorBoundary from "components/Errors/ErrorBoundary";
 
@@ -52,6 +53,7 @@ export type ModalProps = PropsWithChildren<{
   withMobileBottomPosition?: boolean;
   takeFullHeight?: boolean;
   hideHeaderBorder?: boolean;
+  activeFormId?: string;
 }>;
 
 export default function Modal({
@@ -72,6 +74,7 @@ export default function Modal({
   withMobileBottomPosition = false,
   takeFullHeight = false,
   hideHeaderBorder = false,
+  activeFormId,
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement | null>(null);
 
@@ -111,6 +114,27 @@ export default function Modal({
   const stopPropagation = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
   }, []);
+
+  const body = (
+    <ErrorBoundary id="Modal" variant="block" wrapperClassName="rounded-t-8">
+      {disableOverflowHandling ? (
+        children
+      ) : (
+        <div className={cx("overflow-auto", { "flex grow flex-col": takeFullHeight })}>
+          <div
+            className={cx("Modal-body", {
+              "px-adaptive": contentPadding,
+              "pb-adaptive": contentPadding && !footerContent,
+              "flex grow flex-col": takeFullHeight,
+            })}
+          >
+            {children}
+          </div>
+        </div>
+      )}
+      {footerContent && <div className="border-t-1/2 border-slate-600 px-adaptive py-16">{footerContent}</div>}
+    </ErrorBoundary>
+  );
 
   return (
     <AnimatePresence>
@@ -165,26 +189,7 @@ export default function Modal({
                 </div>
                 {headerContent}
               </div>
-              <ErrorBoundary id="Modal" variant="block" wrapperClassName="rounded-t-8">
-                {disableOverflowHandling ? (
-                  children
-                ) : (
-                  <div className={cx("overflow-auto", { "flex grow flex-col": takeFullHeight })}>
-                    <div
-                      className={cx("Modal-body", {
-                        "px-adaptive": contentPadding,
-                        "pb-adaptive": contentPadding && !footerContent,
-                        "flex grow flex-col": takeFullHeight,
-                      })}
-                    >
-                      {children}
-                    </div>
-                  </div>
-                )}
-                {footerContent && (
-                  <div className="border-t-1/2 border-slate-600 px-adaptive py-16">{footerContent}</div>
-                )}
-              </ErrorBoundary>
+              {activeFormId ? <ActiveFormScope formId={activeFormId}>{body}</ActiveFormScope> : body}
             </div>
           </motion.div>
         </RemoveScroll>

--- a/src/components/OrderEditor/OrderEditor.tsx
+++ b/src/components/OrderEditor/OrderEditor.tsx
@@ -127,6 +127,7 @@ import { bigMath } from "sdk/utils/bigmath";
 import { BatchOrderTxnParams, buildUpdateOrderPayload } from "sdk/utils/orderTransactions";
 
 import { AcceptablePriceImpactInputRow } from "components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow";
+import { useActiveForm } from "components/ActiveFormScope/ActiveFormScope";
 import { AlertInfoCard } from "components/AlertInfo/AlertInfoCard";
 import Button from "components/Button/Button";
 import { EmbeddedActionButton } from "components/Button/EmbeddedActionButton";
@@ -524,10 +525,13 @@ export function OrderEditor(p: Props) {
     additionalExecutionFee?.feeTokenAmount,
   ]);
 
+  const { formId, isActiveForm } = useActiveForm();
+
   const { expressParams, expressParamsPromise, isMultichainSubmitDisabled } = useExpressOrdersParams({
     orderParams: batchParams,
     label: "Order Editor",
     isGmxAccount: srcChainId !== undefined,
+    canSwitchGasPaymentToken: isActiveForm,
   });
 
   const networkFee = useMemo(() => {
@@ -952,6 +956,7 @@ export function OrderEditor(p: Props) {
   return (
     <div className="PositionEditor">
       <Modal
+        activeFormId={formId}
         className="PositionSeller-modal"
         isVisible={true}
         setIsVisible={p.onClose}

--- a/src/components/OrdersModal/AddTPSLModal.tsx
+++ b/src/components/OrdersModal/AddTPSLModal.tsx
@@ -91,6 +91,7 @@ import { getExecutionFee } from "sdk/utils/fees/executionFee";
 import { getBatchTotalExecutionFee } from "sdk/utils/orderTransactions";
 import { getIsEquivalentTokens } from "sdk/utils/tokens";
 
+import { useActiveForm } from "components/ActiveFormScope/ActiveFormScope";
 import { AlertInfoCard } from "components/AlertInfo/AlertInfoCard";
 import Button from "components/Button/Button";
 import {
@@ -768,10 +769,13 @@ export function AddTPSLModal({
     return getBatchTotalExecutionFee({ batchParams, chainId, tokensData });
   }, [batchParams, chainId, tokensData]);
 
+  const { formId, isActiveForm } = useActiveForm();
+
   const { expressParamsPromise, isMultichainSubmitDisabled } = useExpressOrdersParams({
     orderParams: batchParams,
     label: "Add TP/SL",
     isGmxAccount: srcChainId !== undefined,
+    canSwitchGasPaymentToken: isActiveForm,
   });
 
   const submitError = useMemo(() => {
@@ -1004,6 +1008,7 @@ export function AddTPSLModal({
 
   return (
     <Modal
+      activeFormId={formId}
       isVisible={isVisible}
       setIsVisible={setIsVisible}
       label={`${modePrefix}: ${actionLabel} ${marketPairLabel} ${directionLabel}`}

--- a/src/components/PositionEditor/PositionEditor.tsx
+++ b/src/components/PositionEditor/PositionEditor.tsx
@@ -58,6 +58,7 @@ import {
 } from "sdk/configs/tokens";
 import { getMaxNegativeImpactBps } from "sdk/utils/fees/priceImpact";
 
+import { useActiveForm } from "components/ActiveFormScope/ActiveFormScope";
 import { AlertInfoCard } from "components/AlertInfo/AlertInfoCard";
 import Button from "components/Button/Button";
 import { ValidationBannerErrorContent } from "components/Errors/gasErrors";
@@ -243,7 +244,8 @@ export function PositionEditor() {
     operation,
   });
 
-  const submitButtonState = usePositionEditorButtonState(operation);
+  const { formId, isActiveForm } = useActiveForm();
+  const submitButtonState = usePositionEditorButtonState(operation, isActiveForm);
   const gasPaymentToken = submitButtonState.expressParams?.gasPaymentParams.gasPaymentToken;
 
   // express params cannot resolve without the trigger price, so fall back to the native-token estimate
@@ -445,6 +447,7 @@ export function PositionEditor() {
   return (
     <div className="PositionEditor">
       <Modal
+        activeFormId={formId}
         className="PositionEditor-modal"
         isVisible={!!position}
         setIsVisible={onClose}

--- a/src/components/PositionEditor/usePositionEditorButtonState.tsx
+++ b/src/components/PositionEditor/usePositionEditorButtonState.tsx
@@ -112,7 +112,10 @@ type PositionEditorButtonState = {
   bannerErrorName: ValidationBannerErrorName | undefined;
 };
 
-export function usePositionEditorButtonState(operation: Operation): PositionEditorButtonState {
+export function usePositionEditorButtonState(
+  operation: Operation,
+  canSwitchGasPaymentToken: boolean
+): PositionEditorButtonState {
   const [editingPositionKey, setEditingPositionKey] = usePositionEditorPositionState();
   const allowedSlippage = useSavedAllowedSlippage();
   const { chainId, srcChainId } = useChainId();
@@ -300,6 +303,7 @@ export function usePositionEditorButtonState(operation: Operation): PositionEdit
     label: "Position Editor",
     orderParams: batchParams,
     isGmxAccount: isCollateralTokenFromGmxAccount,
+    canSwitchGasPaymentToken,
   });
 
   const approvalTokens = useMemo(() => {

--- a/src/components/PositionSeller/PositionSeller.tsx
+++ b/src/components/PositionSeller/PositionSeller.tsx
@@ -110,6 +110,7 @@ import {
 import { TradeMode } from "sdk/utils/trade";
 import { getIsValidTwapParams } from "sdk/utils/twap";
 
+import { useActiveForm } from "components/ActiveFormScope/ActiveFormScope";
 import { AlertInfoCard } from "components/AlertInfo/AlertInfoCard";
 import { AmountWithUsdBalance } from "components/AmountWithUsd/AmountWithUsd";
 import Button from "components/Button/Button";
@@ -465,6 +466,8 @@ export function PositionSeller() {
     userReferralInfo?.referralCodeForTxn,
   ]);
 
+  const { formId, isActiveForm } = useActiveForm();
+
   const {
     expressParams,
     isLoading: isExpressLoading,
@@ -476,6 +479,7 @@ export function PositionSeller() {
     label: "Position Seller",
     orderParams: batchParams,
     isGmxAccount: srcChainId !== undefined || effectiveIsReceiveToGmxAccount,
+    canSwitchGasPaymentToken: isActiveForm,
   });
 
   const approvalTokens = useMemo(() => {
@@ -1060,6 +1064,7 @@ export function PositionSeller() {
   return (
     <div className="text-body-medium">
       <Modal
+        activeFormId={formId}
         isVisible={isVisible}
         setIsVisible={onClose}
         label={(() => {

--- a/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
+++ b/src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -35,6 +35,7 @@ import { getToken } from "sdk/configs/tokens";
 import { getExecutionFee } from "sdk/utils/fees/executionFee";
 import { buildDecreaseOrderPayload } from "sdk/utils/orderTransactions";
 
+import { useActiveForm } from "components/ActiveFormScope/ActiveFormScope";
 import { AlertInfo } from "components/AlertInfo/AlertInfo";
 import Button from "components/Button/Button";
 import Modal from "components/Modal/Modal";
@@ -155,10 +156,13 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
     allowedSlippage,
   ]);
 
+  const { formId, isActiveForm } = useActiveForm();
+
   const { expressParams, expressParamsPromise, isMultichainSubmitDisabled } = useExpressOrdersParams({
     orderParams: batchParams,
     label: "Settle Funding Fee",
     isGmxAccount: srcChainId !== undefined,
+    canSwitchGasPaymentToken: isActiveForm,
   });
 
   const approvalTokens = useMemo(() => {
@@ -323,6 +327,7 @@ export function SettleAccruedFundingFeeModal({ allowedSlippage, isVisible, onClo
 
   return (
     <Modal
+      activeFormId={formId}
       className="Confirmation-box ClaimableModal"
       isVisible={isVisible}
       setIsVisible={handleOnClose}

--- a/src/components/TradeBox/TradeBox.tsx
+++ b/src/components/TradeBox/TradeBox.tsx
@@ -103,6 +103,7 @@ import { estimateExecuteSwapOrderGasLimit, getExecutionFee } from "sdk/utils/fee
 import { getMaxNegativeImpactBps } from "sdk/utils/fees/priceImpact";
 import { TradeMode } from "sdk/utils/trade/types";
 
+import { useIsActiveForm } from "components/ActiveFormScope/ActiveFormScope";
 import { AlertInfoCard } from "components/AlertInfo/AlertInfoCard";
 import Button from "components/Button/Button";
 import BuyInputSection from "components/BuyInputSection/BuyInputSection";
@@ -148,7 +149,7 @@ import "./TradeBox.scss";
 
 const TRADEBOX_INPUT_PLACEHOLDER = "0.00";
 
-export function TradeBox({ isMobile }: { isMobile: boolean }) {
+export function TradeBox({ isMobile, activeFormId }: { isMobile: boolean; activeFormId: string }) {
   const localizedTradeModeLabels = useLocalizedMap(tradeModeLabels);
   const localizedTradeTypeLabels = useLocalizedMap(tradeTypeLabels);
 
@@ -350,9 +351,12 @@ export function TradeBox({ isMobile }: { isMobile: boolean }) {
     isCreatingNewAutoCancel: isTrigger,
   });
 
+  const isActiveForm = useIsActiveForm(activeFormId);
+
   const submitButtonState = useTradeboxButtonState({
     account,
     setToTokenInputValue,
+    canSwitchGasPaymentToken: isActiveForm,
   });
 
   const wrappedOnSubmit = useCallback(async () => {

--- a/src/components/TradeBox/TradeBoxResponsiveContainer.tsx
+++ b/src/components/TradeBox/TradeBoxResponsiveContainer.tsx
@@ -1,5 +1,8 @@
+import { useId } from "react";
+
 import { useBreakpoints } from "lib/useBreakpoints";
 
+import { ActiveFormScope } from "components/ActiveFormScope/ActiveFormScope";
 import ErrorBoundary from "components/Errors/ErrorBoundary";
 
 import { Curtain } from "./Curtain";
@@ -8,23 +11,28 @@ import { TradeBoxHeaderTabs } from "./TradeBoxHeaderTabs";
 
 export function TradeBoxResponsiveContainer() {
   const { isTablet } = useBreakpoints();
+  const formId = useId();
 
   if (!isTablet) {
     return (
       <div className="text-body-medium flex flex-col rounded-8" data-qa="tradebox">
         <TradeBoxHeaderTabs />
-        <ErrorBoundary id="TradeBox" variant="block">
-          <TradeBox isMobile={isTablet} />
-        </ErrorBoundary>
+        <ActiveFormScope formId={formId}>
+          <ErrorBoundary id="TradeBox" variant="block">
+            <TradeBox isMobile={isTablet} activeFormId={formId} />
+          </ErrorBoundary>
+        </ActiveFormScope>
       </div>
     );
   }
 
   return (
     <Curtain header={<TradeBoxHeaderTabs isInCurtain />} dataQa="tradebox" hideChevron headerHeight={48}>
-      <ErrorBoundary id="TradeBox" variant="block">
-        <TradeBox isMobile={isTablet} />
-      </ErrorBoundary>
+      <ActiveFormScope formId={formId}>
+        <ErrorBoundary id="TradeBox" variant="block">
+          <TradeBox isMobile={isTablet} activeFormId={formId} />
+        </ErrorBoundary>
+      </ActiveFormScope>
     </Curtain>
   );
 }

--- a/src/components/TradeBox/__tests__/OneClickNetworkSwitch.ct.stories.tsx
+++ b/src/components/TradeBox/__tests__/OneClickNetworkSwitch.ct.stories.tsx
@@ -19,6 +19,7 @@ import { getContract } from "sdk/configs/contracts";
 import { SUBACCOUNT_ORDER_ACTION } from "sdk/configs/dataStore";
 import type { SignedSubaccountApproval } from "sdk/utils/subaccount";
 
+import { ActiveFormScope } from "components/ActiveFormScope/ActiveFormScope";
 import { TradeBox } from "components/TradeBox/TradeBox";
 
 const EXPRESS_AVAILABLE_FEATURES = { relayRouterEnabled: true, subaccountRelayRouterEnabled: true };
@@ -102,7 +103,9 @@ export function OneClickNetworkSwitchStory({
       <SyntheticsStateWithAppChainContext>
         <NetworkSwitchControl />
         <div className="text-body-medium flex flex-col rounded-8">
-          <TradeBox isMobile={false} />
+          <ActiveFormScope formId="tradebox">
+            <TradeBox isMobile={false} activeFormId="tradebox" />
+          </ActiveFormScope>
         </div>
       </SyntheticsStateWithAppChainContext>
     </CtAppProviders>

--- a/src/components/TradeBox/__tests__/TradeBox.ct.stories.tsx
+++ b/src/components/TradeBox/__tests__/TradeBox.ct.stories.tsx
@@ -20,6 +20,8 @@ import { ETH_ADDRESS, ETH_TOKEN, NATIVE_ETH_ADDRESS, USDC_ADDRESS } from "domain
 import { expandDecimals } from "lib/numbers";
 import { TradeMode, TradeType } from "sdk/utils/trade/types";
 
+import { ActiveFormScope } from "components/ActiveFormScope/ActiveFormScope";
+
 import { TradeBox } from "../TradeBox";
 import { TradeBoxHeaderTabs } from "../TradeBoxHeaderTabs";
 
@@ -440,7 +442,9 @@ export function TradeBoxStory({
       {withGasTokenControl && <SetConflictingGasTokenControl />}
       <div className="text-body-medium flex flex-col rounded-8">
         <TradeBoxHeaderTabs />
-        <TradeBox isMobile={false} />
+        <ActiveFormScope formId="tradebox">
+          <TradeBox isMobile={false} activeFormId="tradebox" />
+        </ActiveFormScope>
       </div>
     </MockSyntheticsStateProvider>
   );

--- a/src/components/TradeBox/hooks/useTradeButtonState.tsx
+++ b/src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -109,6 +109,7 @@ import { useTradeboxTransactions } from "./useTradeboxTransactions";
 interface TradeboxButtonStateOptions {
   account?: string;
   setToTokenInputValue: (value: string, shouldResetPriceImpactWarning: boolean) => void;
+  canSwitchGasPaymentToken: boolean;
 }
 
 type TradeboxButtonState = {
@@ -128,6 +129,7 @@ type TradeboxButtonState = {
 export function useTradeboxButtonState({
   account,
   setToTokenInputValue,
+  canSwitchGasPaymentToken,
 }: TradeboxButtonStateOptions): TradeboxButtonState {
   const chainId = useSelector(selectChainId);
   const srcChainId = useSelector(selectSrcChainId);
@@ -181,6 +183,7 @@ export function useTradeboxButtonState({
     primaryExecutionFee,
   } = useTradeboxTransactions({
     setPendingTxns,
+    canSwitchGasPaymentToken,
   });
 
   const approvalTokens = useMemo(() => {

--- a/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
+++ b/src/components/TradeBox/hooks/useTradeboxTransactions.tsx
@@ -73,9 +73,10 @@ import { useSidecarOrderPayloads } from "./useSidecarOrderPayloads";
 
 interface TradeboxTransactionsProps {
   setPendingTxns: (txns: any) => void;
+  canSwitchGasPaymentToken: boolean;
 }
 
-export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactionsProps) {
+export function useTradeboxTransactions({ setPendingTxns, canSwitchGasPaymentToken }: TradeboxTransactionsProps) {
   const { chainId, srcChainId } = useChainId();
   const { signer, account } = useWallet();
   const { provider } = useJsonRpcProvider(chainId);
@@ -178,6 +179,7 @@ export function useTradeboxTransactions({ setPendingTxns }: TradeboxTransactions
     orderParams: batchParams,
     label: "TradeBox",
     isGmxAccount: isFromTokenGmxAccount,
+    canSwitchGasPaymentToken,
   });
 
   const initOrderMetricData = useCallback(() => {

--- a/src/domain/synthetics/express/useRelayerFeeHandler.ts
+++ b/src/domain/synthetics/express/useRelayerFeeHandler.ts
@@ -47,11 +47,13 @@ export function useExpressOrdersParams({
   orderParams,
   label,
   isGmxAccount,
+  canSwitchGasPaymentToken,
 }: {
   orderParams: BatchOrderTxnParams | undefined;
   totalExecutionFee?: bigint;
   label?: string;
   isGmxAccount: boolean;
+  canSwitchGasPaymentToken: boolean;
 }): ExpressOrdersParamsResult {
   const { chainId } = useChainId();
 
@@ -225,6 +227,7 @@ export function useExpressOrdersParams({
     expressParams: result.expressParams,
     orderParams,
     isGmxAccount,
+    canSwitchGasPaymentToken,
   });
 
   if (showDebugValues && label && result.expressParams) {

--- a/src/domain/synthetics/express/useSwitchGasPaymentTokenIfRequired.ts
+++ b/src/domain/synthetics/express/useSwitchGasPaymentTokenIfRequired.ts
@@ -94,10 +94,12 @@ export function useSwitchGasPaymentTokenIfRequiredFromExpressParams({
   expressParams,
   orderParams,
   isGmxAccount,
+  canSwitchGasPaymentToken,
 }: {
   expressParams: Pick<ExpressTxnParams, "gasPaymentValidations" | "gasPaymentParams"> | undefined;
   orderParams: BatchOrderTxnParams | undefined;
   isGmxAccount: boolean;
+  canSwitchGasPaymentToken: boolean;
 }) {
   const payAmounts = useMemo(() => (orderParams ? getBatchTotalPayCollateralAmount(orderParams) : {}), [orderParams]);
 
@@ -107,6 +109,7 @@ export function useSwitchGasPaymentTokenIfRequiredFromExpressParams({
     gasPaymentTokenAmount: expressParams?.gasPaymentParams.gasPaymentTokenAmount,
     payAmounts,
     isGmxAccount,
+    canSwitchGasPaymentToken,
   });
 }
 
@@ -116,12 +119,14 @@ function useSwitchGasPaymentTokenIfRequired({
   gasPaymentTokenAmount,
   payAmounts,
   isGmxAccount,
+  canSwitchGasPaymentToken,
 }: {
   gasPaymentValidations: GasPaymentValidations | undefined;
   gasPaymentToken: TokenData | undefined;
   gasPaymentTokenAmount: bigint | undefined;
   payAmounts: Record<string, bigint>;
   isGmxAccount: boolean;
+  canSwitchGasPaymentToken: boolean;
 }) {
   const { chainId } = useChainId();
   const setGasPaymentTokenAddress = useSelector(selectSetGasPaymentTokenAddress);
@@ -131,6 +136,7 @@ function useSwitchGasPaymentTokenIfRequired({
   useEffect(
     function switchGasPaymentToken() {
       if (
+        !canSwitchGasPaymentToken ||
         !getIsConfirmedOutOfGasPaymentTokenBalance(gasPaymentValidations) ||
         !gasPaymentToken ||
         gasPaymentTokenAmount === undefined
@@ -159,6 +165,7 @@ function useSwitchGasPaymentTokenIfRequired({
       }
     },
     [
+      canSwitchGasPaymentToken,
       chainId,
       gasPaymentToken,
       gasPaymentTokenAmount,


### PR DESCRIPTION
## Summary

- Root cause: the gas payment token is a single global setting, but `useSwitchGasPaymentTokenIfRequired` runs inside every live express estimator at once. With the ticket's balances the filled tradebox pushes the setting to WETH while the open Edit-margin modal pushes it back to USDC, so the express banner and the "Gas token switched" toast keep flipping.
- Fix: only the form the user is interacting with may switch the token. `ActiveFormScope` (`components/ActiveFormScope`) derives the active form from plain facts — mount/unmount of the form's content and capture-phase `pointerdown`/`click`/`focus`/`keydown`/`input` inside it; the most recently activated mounted form wins. The domain hook only receives a boolean `canSwitchGasPaymentToken` and knows nothing about the UI.
- Wiring: `Modal` gets an optional `activeFormId` and wraps its content in the scope (modal content mounts only while open, so opening a modal counts as interacting with it); the tradebox is wrapped in `TradeBoxResponsiveContainer`. Each of the six express forms passes `canSwitchGasPaymentToken: isActiveForm`.
- Behaviour for a single form is unchanged: the auto-switch and the toast still happen, just from one form at a time. While a modal is open the tradebox behind it stays silent; when the modal closes the tradebox switches back once.
- Spec: `ActiveFormScope.spec.tsx` — mount/unmount handoff, pointer/focus/keyboard, programmatic `input` without focus, synthesized `click` without a pointer, hidden content never becomes active.

Linear: https://linear.app/gmx-io/issue/FEDEV-4220/bug-express-gas-token-auto-switch-regression-when-editing-margin
