### PR TITLE
Send an unconditional Environment property to Intercom FEDEV-4289

### DIFF
--- a/src/domain/supportChat/useSupportChat.ts
+++ b/src/domain/supportChat/useSupportChat.ts
@@ -115,6 +115,7 @@ export function useSupportChat() {
       hide_default_launcher: true,
       hide_notifications: false,
       user_id: supportChatUserId,
+      Environment: "EVM",
       // theme goes into the boot settings: update({ theme_mode }) during the boot window
       // suppresses the initial unread count delivery in the Intercom widget
       theme_mode: themeToIntercomTheme(themeModeRef.current),


### PR DESCRIPTION
## Summary

- Support conversations from the GMX app and from GM Trade land in the same Intercom inbox with nothing to tell them apart; GM Trade sends `Environment: SOLANA` on their side.
- Add `Environment: "EVM"` to the Intercom boot settings in `useSupportChat` (the object passed to `Intercom()` on first init and to `boot()` after `shutdown()`). It goes out in the very first `ping` for every user who has the messenger at all: wallet connected or not (`?openChat=1` / "opened without wallet" flag), before volumes, portfolio and wallet type have loaded.
- The wallet-dependent attributes (Tier, volumes, Active Network, Wallet Type, Trading Mode) keep going through the existing `update()` call, which is untouched; `update()` merges attributes on the user, so `Environment` is not cleared.
- Deliberately not sent as a separate `update({ Environment })` after boot: an `update()` inside the boot window suppresses the initial unread-count delivery (documented in the same hook).

Verified with headed Chromium on a fresh profile without a wallet: the outgoing `POST /messenger/web/ping` carries `user_data={"user_id":"…","Environment":"EVM"}`, `source=apiBoot`.

## CI note

The red jobs are not caused by this PR: they fail inside the SDK test suite on `sdk/src/configs/__tests__/markets.spec.ts:61` (`AssertionError: expected undefined to be defined`), the keeper consistency check hitting markets the oracle keeper has delisted (TON, MELANIA, MKR, PI, KTA). The same failure is red on sibling PRs against the current `release` (e.g. #2833) and is fixed by #2831 (skip for the delisted markets). This PR changes only `src/domain/supportChat/useSupportChat.ts`.

Linear: https://linear.app/gmx-io/issue/FEDEV-4289/send-an-unconditional-environment-property-to-intercom
