### PR TITLE
Hotfix: hide the GMTrade TVL rows when the stats API returns nothing

### DIFF
--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -443,11 +443,13 @@ export function OverviewCard({
                         showDollar={false}
                         value={formatAmountHuman(displayTvlMegaeth, USD_DECIMALS, true, 2)}
                       />
-                      <StatsTooltipRow
-                        label="Solana (GMTrade)"
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
-                      />
+                      {gmTvlGmtrade !== undefined && (
+                        <StatsTooltipRow
+                          label="Solana (GMTrade)"
+                          showDollar={false}
+                          value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
+                        />
+                      )}
                       <div className="!my-8 h-1 bg-gray-800" />
                       <StatsTooltipRow
                         label={t`Total`}
@@ -488,11 +490,13 @@ export function OverviewCard({
                         showDollar={false}
                         value={formatAmountHuman(gmTvlMegaeth, USD_DECIMALS, true, 2)}
                       />
-                      <StatsTooltipRow
-                        label="Solana (GMTrade)"
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
-                      />
+                      {gmTvlGmtrade !== undefined && (
+                        <StatsTooltipRow
+                          label="Solana (GMTrade)"
+                          showDollar={false}
+                          value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
+                        />
+                      )}
                       <div className="!my-8 h-1 bg-gray-800" />
                       <StatsTooltipRow
                         label={t`Total`}


### PR DESCRIPTION
## Problem

`app.gmx.io/stats` currently shows `Solana (GMTrade): ...` in the TVL and GM pools tooltips.

Every other GMTrade entry added in #2835 goes through `ChainsStatsTooltipRow`, which drops entries without a value. These two are plain `StatsTooltipRow`s inside the hand-written chain list, and `formatAmountHuman(undefined, ...)` returns `"..."`, so they always render. Production has no deployment serving `/v1/stats/*` yet, `STATS_API_URLS.production` is `undefined`, and the value is therefore undefined forever.

## Fix

Render each of the two rows only when the value is known. The label stays `Solana (GMTrade)` to match its siblings in those two tooltips, which are plain chain names rather than the `V2 Arbitrum` style used elsewhere.

This is needed beyond the current rollout: the rows would print `...` again whenever the stats API is unreachable.

## Verification

Local build against the test stand, TVL tooltip in both states:

- with data: `Arbitrum $238.16m`, `Avalanche $11.45m`, `MegaETH $600.23k`, `Solana (GMTrade) $26.27m`, `Total $276.48m`
- with the stats API unreachable: `Arbitrum $238.29m`, `Avalanche $11.45m`, `MegaETH $600.25k`, `Total $250.34m`, no Solana row and no `...`

`tsc` (app and landing), eslint and prettier clean.
