### PR TITLE
ecosystem: add Hypertradeworx to integrations

### DIFF
--- a/src/pages/Ecosystem/ecosystemConstants.tsx
+++ b/src/pages/Ecosystem/ecosystemConstants.tsx
@@ -464,6 +464,14 @@ export const integrations: EcosystemGmxPage[] = [
     about: msg`AI trading assistant`,
     chainIds: [ARBITRUM],
   },
+  {
+    title: msg`Hypertradeworx`,
+    link: "https://www.hypertradeworx.com",
+    linkLabel: "hypertradeworx.com",
+    about: msg`Multi-venue perps terminal routing orders to GMX`,
+
+    chainIds: [ARBITRUM],
+  },
 ];
 
 type EcosystemTelegramGroup = {


### PR DESCRIPTION
Adds Hypertradeworx to the `integrations` list on the Ecosystem page.

Hypertradeworx is a self-custodial trading terminal (web at https://app.hypertradeworx.xyz and an Android app on Google Play) that routes perpetual futures orders to GMX on Arbitrum alongside Hyperliquid, Lighter, AsterDex and Ostium from a single order ticket and one embedded wallet. The venue is an explicit field on every order, orders are signed on the user's device, and positions from every venue show in one portfolio while margin stays on GMX for GMX positions.

Site: https://www.hypertradeworx.com
Docs on venue routing: https://www.hypertradeworx.com/en/docs/venues

Entry follows the existing `EcosystemGmxPage` shape; `chainIds` is `[ARBITRUM]` because that is the only chain we route GMX orders on today.