### PR TITLE
Keep acceptable price impact on liquidity updates FEDEV-4287

### DIFF
--- a/src/components/PercentageInput/PercentageInput.tsx
+++ b/src/components/PercentageInput/PercentageInput.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { KeyboardEvent, ReactNode, useEffect, useMemo, useState } from "react";
 import { useLatest } from "react-use";
 
 import { BASIS_POINTS_DIVISOR } from "config/factors";
@@ -12,6 +12,8 @@ import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
 export const NUMBER_WITH_TWO_DECIMALS = /^\d+(\.\d{0,2})?$/; // 0.00 ~ 99.99
 
 export const MAX_PERCENTAGE_INPUT_VALUE = 99 * 100; // basis points
+
+export const PERCENTAGE_INPUT_STEP = 1; // basis points
 
 function getValueText(value: number) {
   return roundToTwoDecimals((value / BASIS_POINTS_DIVISOR) * 100).toString();
@@ -77,6 +79,22 @@ export default function PercentageInput({
     }
   }
 
+  function handleKeyDown(e: KeyboardEvent) {
+    const direction = e.key === "ArrowUp" ? 1 : e.key === "ArrowDown" ? -1 : 0;
+
+    if (direction === 0) {
+      return;
+    }
+
+    e.preventDefault();
+
+    const parsedValue = Math.round(Number.parseFloat(inputValue) * 100);
+    const currentValue = Number.isNaN(parsedValue) ? defaultValue : parsedValue;
+    const nextValue = Math.min(Math.max(currentValue + direction * PERCENTAGE_INPUT_STEP, 0), maxValue);
+
+    handleChange(getValueText(nextValue));
+  }
+
   const latestInputValue = useLatest(inputValue);
 
   useEffect(() => {
@@ -129,6 +147,7 @@ export default function PercentageInput({
         label={negativeSign ? "-" : undefined}
         value={inputValue}
         setValue={handleChange}
+        onKeyDown={handleKeyDown}
         placeholder={getValueText(defaultValue)}
         suggestionList={suggestions}
         suffix="%"

--- a/src/components/SuggestionInput/SuggestionInput.tsx
+++ b/src/components/SuggestionInput/SuggestionInput.tsx
@@ -55,6 +55,7 @@ export default function SuggestionInput({
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isPanelVisible, setIsPanelVisible] = useState(false);
+  const hasSuggestions = suggestionList !== undefined && suggestionList.length > 0;
 
   useEffect(() => {
     if (onPanelVisibleChange) {
@@ -91,9 +92,11 @@ export default function SuggestionInput({
       if (disabled) return;
       e.stopPropagation();
       inputRef.current?.focus();
-      setIsPanelVisible(true);
+      if (hasSuggestions) {
+        setIsPanelVisible(true);
+      }
     },
-    [disabled]
+    [disabled, hasSuggestions]
   );
 
   const handleKeyDown = useCallback(
@@ -137,7 +140,7 @@ export default function SuggestionInput({
           inputId={inputId}
           inputRef={inputRef}
           className={cx(inputClassName, "min-w-0 text-right outline-none")}
-          onFocus={() => !disabled && setIsPanelVisible(true)}
+          onFocus={() => !disabled && hasSuggestions && setIsPanelVisible(true)}
           onBlur={handleBlur}
           value={value ?? ""}
           placeholder={placeholder}
@@ -151,7 +154,7 @@ export default function SuggestionInput({
           </div>
         )}
       </div>
-      {suggestionList && isPanelVisible && (
+      {isPanelVisible && suggestionList && suggestionList.length > 0 && (
         <Portal>
           <div className="z-[1000]" ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
             <ul className="Suggestion-list">

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import {
   FloatingArrow,
   FloatingPortal,
+  OpenChangeReason,
   Placement,
   arrow,
   autoUpdate,
@@ -13,12 +14,14 @@ import {
   useFloating,
   useHover,
   useInteractions,
+  useMergeRefs,
 } from "@floating-ui/react";
 import { getOppositePlacement, getOppositeAlignmentPlacement } from "@floating-ui/utils";
 import cx from "classnames";
 import {
   ComponentPropsWithoutRef,
   ElementType,
+  FocusEvent,
   MouseEvent,
   ReactNode,
   useCallback,
@@ -119,6 +122,16 @@ export default function Tooltip<T extends ElementType>({
 }: TooltipProps<T>) {
   const [visible, setVisible] = useState(false);
   const arrowRef = useRef<SVGSVGElement>(null);
+  const referenceRef = useRef<Element | null>(null);
+
+  const handleOpenChange = useCallback((open: boolean, _event?: Event, reason?: OpenChangeReason) => {
+    if (!open && reason === "hover" && hasVisibleFocusWithin(referenceRef.current)) {
+      return;
+    }
+
+    setVisible(open);
+  }, []);
+
   const { refs, floatingStyles, context } = useFloating({
     middleware: [
       offset(10),
@@ -154,8 +167,10 @@ export default function Tooltip<T extends ElementType>({
     placement: position,
     whileElementsMounted: autoUpdate,
     open: visible,
-    onOpenChange: setVisible,
+    onOpenChange: handleOpenChange,
   });
+
+  const setReference = useMergeRefs<Element>([refs.setReference, referenceRef]);
 
   const previousDisabled = usePrevious(disabled);
 
@@ -203,16 +218,30 @@ export default function Tooltip<T extends ElementType>({
 
       // If element was blurred, allow some time so that activeElement is updated
       requestAnimationFrame(() => {
-        const activeElement = document.activeElement;
-        const focusWithin = (refs.reference.current as HTMLElement)?.contains(activeElement);
-
-        // :focus-visible check filters out handles focused by a pointer click
-        if (focusWithin && activeElement && matchesFocusVisible(activeElement)) {
+        if (hasVisibleFocusWithin(referenceRef.current)) {
           setVisible(true);
         }
       });
     },
-    [disabled, refs.reference, visible]
+    [disabled, visible]
+  );
+
+  const handleBlur = useCallback(
+    (event: FocusEvent) => {
+      const reference = referenceRef.current;
+      const nextFocused = event.relatedTarget as Node | null;
+
+      if (reference && nextFocused && reference.contains(nextFocused)) {
+        return;
+      }
+
+      if (isHovered(reference) || isHovered(refs.floating.current)) {
+        return;
+      }
+
+      setVisible(false);
+    },
+    [refs.floating]
   );
 
   const finalContent = visible ? content ?? renderContent?.() : undefined;
@@ -235,11 +264,15 @@ export default function Tooltip<T extends ElementType>({
       <Container
         {...containerProps}
         className={cx("Tooltip", className)}
-        ref={refs.setReference}
+        ref={setReference}
         {...getReferenceProps({
           onClick: (e: MouseEvent) => {
             preventClick(e);
             containerProps.onClick?.(e);
+          },
+          onBlur: (e: FocusEvent) => {
+            handleBlur(e);
+            containerProps.onBlur?.(e);
           },
         })}
       >
@@ -253,7 +286,7 @@ export default function Tooltip<T extends ElementType>({
   return (
     <span {...containerProps} className={cx("Tooltip", className)} style={style}>
       <span
-        ref={refs.setReference}
+        ref={setReference}
         className={cx("Tooltip-handle group", handleClassName)}
         style={handleStyle}
         {...getReferenceProps({
@@ -261,6 +294,7 @@ export default function Tooltip<T extends ElementType>({
             preventClick(e);
             containerProps.onClick?.(e);
           },
+          onBlur: handleBlur,
         })}
       >
         <div className={cx("flex grow items-center gap-2", contentClassName)}>
@@ -293,10 +327,25 @@ export default function Tooltip<T extends ElementType>({
   );
 }
 
+// :focus-visible filters out handles focused by a pointer click; text inputs match it either way
+function hasVisibleFocusWithin(element: Element | null): boolean {
+  const activeElement = document.activeElement;
+
+  return !!element && !!activeElement && element.contains(activeElement) && matchesFocusVisible(activeElement);
+}
+
 function matchesFocusVisible(element: Element): boolean {
   try {
     return element.matches(":focus-visible");
   } catch {
     return true;
+  }
+}
+
+function isHovered(element: Element | null): boolean {
+  try {
+    return !!element && element.matches(":hover");
+  } catch {
+    return false;
   }
 }

--- a/src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+++ b/src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
@@ -16,7 +16,7 @@ import {
   selectTradeboxExistingPositionForPreview,
   selectTradeboxSelectedTriggerAcceptablePriceImpactBps,
   selectTradeboxSetAdvancedOptions,
-  selectTradeboxSetSelectedAcceptablePriceImpactBps,
+  selectTradeboxSetUserSelectedAcceptablePriceImpactBps,
   selectTradeboxTradeFeesType,
   selectTradeboxTradeFlags,
   selectTradeboxTriggerPrice,
@@ -155,7 +155,7 @@ export function TradeBoxAdvancedGroups({
   const decreaseAmounts = useSelector(selectTradeboxDecreasePositionAmounts);
   const limitPrice = useSelector(selectTradeboxTriggerPrice);
 
-  const setSelectedTriggerAcceptablePriceImpactBps = useSelector(selectTradeboxSetSelectedAcceptablePriceImpactBps);
+  const setUserSelectedAcceptablePriceImpactBps = useSelector(selectTradeboxSetUserSelectedAcceptablePriceImpactBps);
   const selectedTriggerAcceptablePriceImpactBps = useSelector(selectTradeboxSelectedTriggerAcceptablePriceImpactBps);
   const defaultTriggerAcceptablePriceImpactBps = useSelector(selectTradeboxDefaultTriggerAcceptablePriceImpactBps);
   const isSetAcceptablePriceImpactEnabled = useSelector(selectIsSetAcceptablePriceImpactEnabled);
@@ -221,7 +221,7 @@ export function TradeBoxAdvancedGroups({
             priceImpactFeeBps={
               isTrigger ? fees?.decreasePositionPriceImpact?.bps : fees?.increasePositionPriceImpact?.bps
             }
-            setAcceptablePriceImpactBps={setSelectedTriggerAcceptablePriceImpactBps}
+            setAcceptablePriceImpactBps={setUserSelectedAcceptablePriceImpactBps}
           />
         </>
       )}

--- a/src/components/TradeBox/__tests__/useTradeboxAcceptablePriceImpactValues.spec.tsx
+++ b/src/components/TradeBox/__tests__/useTradeboxAcceptablePriceImpactValues.spec.tsx
@@ -9,17 +9,15 @@ const { selectorValues } = vi.hoisted(() => ({
 // selectors are mocked to plain keys that useSelector reads from a test-controlled map
 vi.mock("context/SyntheticsStateContext/selectors/tradeboxSelectors", () => ({
   selectTradeboxDecreasePositionAmounts: "decreaseAmounts",
-  selectTradeboxDefaultTriggerAcceptablePriceImpactBps: "defaultBps",
   selectTradeboxFromTokenAddress: "fromTokenAddress",
-  selectTradeboxFromTokenInputValue: "fromTokenInputValue",
   selectTradeboxIncreasePositionAmounts: "increaseAmounts",
+  selectTradeboxIsAcceptablePriceImpactCustomized: "isCustomized",
   selectTradeboxLeverage: "leverage",
   selectTradeboxMarketInfo: "marketInfo",
-  selectTradeboxSelectedTriggerAcceptablePriceImpactBps: "selectedBps",
   selectTradeboxSetDefaultTriggerAcceptablePriceImpactBps: "setDefaultBps",
+  selectTradeboxSetIsAcceptablePriceImpactCustomized: "setIsCustomized",
   selectTradeboxSetSelectedAcceptablePriceImpactBps: "setSelectedBps",
   selectTradeboxToTokenAddress: "toTokenAddress",
-  selectTradeboxToTokenInputValue: "toTokenInputValue",
   selectTradeboxTradeFlags: "tradeFlags",
   selectTradeboxTriggerPrice: "triggerPrice",
 }));
@@ -76,21 +74,28 @@ const limitOrderValues: TradeboxValues = {
   decreaseAmounts: undefined,
 };
 
-let latestSetSelectedBps: (value: bigint | undefined) => void;
+let latestUserSetsImpact: (value: bigint) => void;
 
 function Harness({ values }: { values: TradeboxValues }) {
   const [defaultBps, setDefaultBps] = useState<bigint>();
   const [selectedBps, setSelectedBps] = useState<bigint>();
+  const [isCustomized, setIsCustomized] = useState(false);
 
-  latestSetSelectedBps = setSelectedBps;
+  // mirrors setUserSelectedAcceptablePriceImpactBps from useTradeboxState
+  latestUserSetsImpact = (value: bigint) => {
+    setSelectedBps(value);
+    setIsCustomized(value !== defaultBps);
+  };
 
   for (const [key, value] of Object.entries(values)) {
     selectorValues.set(key, value);
   }
   selectorValues.set("defaultBps", defaultBps);
   selectorValues.set("selectedBps", selectedBps);
+  selectorValues.set("isCustomized", isCustomized);
   selectorValues.set("setDefaultBps", setDefaultBps);
   selectorValues.set("setSelectedBps", setSelectedBps);
+  selectorValues.set("setIsCustomized", setIsCustomized);
 
   useTradeboxAcceptablePriceImpactValues();
 
@@ -121,7 +126,7 @@ function renderHook(values: TradeboxValues) {
 
 function userSetsImpact(bps: bigint) {
   act(() => {
-    latestSetSelectedBps(bps);
+    latestUserSetsImpact(bps);
   });
 }
 
@@ -175,6 +180,16 @@ describe("useTradeboxAcceptablePriceImpactValues", () => {
     update({ increaseAmounts: increaseWithRecommendation(38n), fromTokenInputValue: "1000.1" });
 
     expect(read()).toEqual({ defaultBps: "38", selectedBps: "100" });
+  });
+
+  it("keeps the user's value when the recommended impact drifts onto it and past it", () => {
+    const { read, update } = renderHook(limitOrderValues);
+
+    userSetsImpact(40n);
+    update({ increaseAmounts: increaseWithRecommendation(40n) });
+    update({ increaseAmounts: increaseWithRecommendation(45n) });
+
+    expect(read()).toEqual({ defaultBps: "45", selectedBps: "40" });
   });
 
   it("re-applies the recommended impact when the user changes the limit price", () => {

--- a/src/components/TradeBox/__tests__/useTradeboxAcceptablePriceImpactValues.spec.tsx
+++ b/src/components/TradeBox/__tests__/useTradeboxAcceptablePriceImpactValues.spec.tsx
@@ -1,0 +1,212 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { selectorValues } = vi.hoisted(() => ({
+  selectorValues: new Map<string, unknown>(),
+}));
+
+// selectors are mocked to plain keys that useSelector reads from a test-controlled map
+vi.mock("context/SyntheticsStateContext/selectors/tradeboxSelectors", () => ({
+  selectTradeboxDecreasePositionAmounts: "decreaseAmounts",
+  selectTradeboxDefaultTriggerAcceptablePriceImpactBps: "defaultBps",
+  selectTradeboxFromTokenAddress: "fromTokenAddress",
+  selectTradeboxFromTokenInputValue: "fromTokenInputValue",
+  selectTradeboxIncreasePositionAmounts: "increaseAmounts",
+  selectTradeboxLeverage: "leverage",
+  selectTradeboxMarketInfo: "marketInfo",
+  selectTradeboxSelectedTriggerAcceptablePriceImpactBps: "selectedBps",
+  selectTradeboxSetDefaultTriggerAcceptablePriceImpactBps: "setDefaultBps",
+  selectTradeboxSetSelectedAcceptablePriceImpactBps: "setSelectedBps",
+  selectTradeboxToTokenAddress: "toTokenAddress",
+  selectTradeboxToTokenInputValue: "toTokenInputValue",
+  selectTradeboxTradeFlags: "tradeFlags",
+  selectTradeboxTriggerPrice: "triggerPrice",
+}));
+
+vi.mock("context/SyntheticsStateContext/utils", () => ({
+  useSelector: (key: string) => selectorValues.get(key),
+}));
+
+import { useTradeboxAcceptablePriceImpactValues } from "../hooks/useTradeboxAcceptablePriceImpactValues";
+
+type AmountsWithRecommendation = {
+  acceptablePrice: bigint;
+  acceptablePriceDeltaBps: bigint;
+  recommendedAcceptablePriceDeltaBps: bigint;
+};
+
+type TradeboxValues = {
+  tradeFlags: { isLimit: boolean; isTrigger: boolean; isLong: boolean; isSwap: boolean };
+  marketInfo: { indexTokenAddress: string } | undefined;
+  leverage: bigint | undefined;
+  fromTokenAddress: string;
+  toTokenAddress: string;
+  fromTokenInputValue: string;
+  toTokenInputValue: string;
+  triggerPrice: bigint | undefined;
+  increaseAmounts: AmountsWithRecommendation | undefined;
+  decreaseAmounts: AmountsWithRecommendation | undefined;
+};
+
+const LIMIT_FLAGS = { isLimit: true, isTrigger: false, isLong: true, isSwap: false };
+const TRIGGER_FLAGS = { isLimit: false, isTrigger: true, isLong: true, isSwap: false };
+const MARKET_FLAGS = { isLimit: false, isTrigger: false, isLong: true, isSwap: false };
+
+const ETH_MARKET = { indexTokenAddress: "0xeth" };
+
+function increaseWithRecommendation(bps: bigint): AmountsWithRecommendation {
+  return {
+    acceptablePrice: 1900n * 10n ** 30n,
+    acceptablePriceDeltaBps: -bps,
+    recommendedAcceptablePriceDeltaBps: bps,
+  };
+}
+
+const limitOrderValues: TradeboxValues = {
+  tradeFlags: LIMIT_FLAGS,
+  marketInfo: ETH_MARKET,
+  leverage: 20000n,
+  fromTokenAddress: "0xusdc",
+  toTokenAddress: "0xeth",
+  fromTokenInputValue: "1000",
+  toTokenInputValue: "1.05",
+  triggerPrice: 1900n * 10n ** 30n,
+  increaseAmounts: increaseWithRecommendation(35n),
+  decreaseAmounts: undefined,
+};
+
+let latestSetSelectedBps: (value: bigint | undefined) => void;
+
+function Harness({ values }: { values: TradeboxValues }) {
+  const [defaultBps, setDefaultBps] = useState<bigint>();
+  const [selectedBps, setSelectedBps] = useState<bigint>();
+
+  latestSetSelectedBps = setSelectedBps;
+
+  for (const [key, value] of Object.entries(values)) {
+    selectorValues.set(key, value);
+  }
+  selectorValues.set("defaultBps", defaultBps);
+  selectorValues.set("selectedBps", selectedBps);
+  selectorValues.set("setDefaultBps", setDefaultBps);
+  selectorValues.set("setSelectedBps", setSelectedBps);
+
+  useTradeboxAcceptablePriceImpactValues();
+
+  return (
+    <div>
+      <span data-testid="default">{String(defaultBps)}</span>
+      <span data-testid="selected">{String(selectedBps)}</span>
+    </div>
+  );
+}
+
+function renderHook(values: TradeboxValues) {
+  const utils = render(<Harness values={values} />);
+
+  const read = () => ({
+    defaultBps: utils.getByTestId("default").textContent,
+    selectedBps: utils.getByTestId("selected").textContent,
+  });
+
+  const update = (next: Partial<TradeboxValues>) => {
+    // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+    values = { ...values, ...next };
+    utils.rerender(<Harness values={values} />);
+  };
+
+  return { read, update };
+}
+
+function userSetsImpact(bps: bigint) {
+  act(() => {
+    latestSetSelectedBps(bps);
+  });
+}
+
+describe("useTradeboxAcceptablePriceImpactValues", () => {
+  beforeEach(() => {
+    selectorValues.clear();
+  });
+
+  afterEach(cleanup);
+
+  it("initializes both values from the recommended impact of a limit order", () => {
+    const { read } = renderHook(limitOrderValues);
+
+    expect(read()).toEqual({ defaultBps: "35", selectedBps: "35" });
+  });
+
+  it("initializes both values from the recommended impact of a trigger order", () => {
+    const { read } = renderHook({
+      ...limitOrderValues,
+      tradeFlags: TRIGGER_FLAGS,
+      increaseAmounts: undefined,
+      decreaseAmounts: {
+        acceptablePrice: 1800n * 10n ** 30n,
+        acceptablePriceDeltaBps: -42n,
+        recommendedAcceptablePriceDeltaBps: -42n,
+      },
+    });
+
+    expect(read()).toEqual({ defaultBps: "42", selectedBps: "42" });
+  });
+
+  it("leaves the values empty when there is no recommendation", () => {
+    const { read } = renderHook({ ...limitOrderValues, tradeFlags: MARKET_FLAGS });
+
+    expect(read()).toEqual({ defaultBps: "undefined", selectedBps: "undefined" });
+  });
+
+  it("follows the recommended impact on market data updates while the user has not set a value", () => {
+    const { read, update } = renderHook(limitOrderValues);
+
+    update({ increaseAmounts: increaseWithRecommendation(40n), toTokenInputValue: "1.0501" });
+
+    expect(read()).toEqual({ defaultBps: "40", selectedBps: "40" });
+  });
+
+  it("keeps the user's value and refreshes only the recommended impact on market data updates", () => {
+    const { read, update } = renderHook(limitOrderValues);
+
+    userSetsImpact(100n);
+    update({ increaseAmounts: increaseWithRecommendation(40n), toTokenInputValue: "1.0501" });
+    update({ increaseAmounts: increaseWithRecommendation(38n), fromTokenInputValue: "1000.1" });
+
+    expect(read()).toEqual({ defaultBps: "38", selectedBps: "100" });
+  });
+
+  it("re-applies the recommended impact when the user changes the limit price", () => {
+    const { read, update } = renderHook(limitOrderValues);
+
+    userSetsImpact(100n);
+    update({ triggerPrice: 1850n * 10n ** 30n, increaseAmounts: increaseWithRecommendation(40n) });
+
+    expect(read()).toEqual({ defaultBps: "40", selectedBps: "40" });
+  });
+
+  it("re-applies the recommended impact when the user changes the market", () => {
+    const { read, update } = renderHook(limitOrderValues);
+
+    userSetsImpact(100n);
+    update({
+      marketInfo: { indexTokenAddress: "0xbtc" },
+      toTokenAddress: "0xbtc",
+      increaseAmounts: increaseWithRecommendation(31n),
+    });
+
+    expect(read()).toEqual({ defaultBps: "31", selectedBps: "31" });
+  });
+
+  it("resumes following the recommended impact after the user picks it again", () => {
+    const { read, update } = renderHook(limitOrderValues);
+
+    userSetsImpact(100n);
+    update({ increaseAmounts: increaseWithRecommendation(40n) });
+    userSetsImpact(40n);
+    update({ increaseAmounts: increaseWithRecommendation(45n) });
+
+    expect(read()).toEqual({ defaultBps: "45", selectedBps: "45" });
+  });
+});

--- a/src/components/TradeBox/hooks/useTradeboxAcceptablePriceImpactValues.ts
+++ b/src/components/TradeBox/hooks/useTradeboxAcceptablePriceImpactValues.ts
@@ -33,59 +33,47 @@ export function useTradeboxAcceptablePriceImpactValues() {
 
   const isAnyValueChanged = Object.values(tradeboxChanges).some(Boolean);
 
-  /**
-   * Drop selected acceptable price impact when user changes market/pool/trade type/limit price
-   */
-  useEffect(() => {
-    if (isAnyValueChanged) {
-      setDefaultTriggerAcceptablePriceImpactBps(undefined);
-      setSelectedAcceptablePriceImpactBps(undefined);
-    }
-  }, [isAnyValueChanged, setDefaultTriggerAcceptablePriceImpactBps, setSelectedAcceptablePriceImpactBps]);
+  let recommendedAcceptablePriceImpactBps: bigint | undefined;
 
-  /**
-   * Set initial value for limit / stop market orders
-   */
-  useEffect(() => {
-    if (
-      isLimit &&
-      increaseAmounts?.acceptablePrice &&
-      defaultTriggerAcceptablePriceImpactBps === undefined &&
-      selectedTriggerAcceptablePriceImpactBps === undefined
-    ) {
-      setSelectedAcceptablePriceImpactBps(bigMath.abs(increaseAmounts.acceptablePriceDeltaBps));
-      setDefaultTriggerAcceptablePriceImpactBps(bigMath.abs(increaseAmounts.acceptablePriceDeltaBps));
-    }
-  }, [
-    defaultTriggerAcceptablePriceImpactBps,
-    increaseAmounts?.acceptablePrice,
-    increaseAmounts?.acceptablePriceDeltaBps,
-    isLimit,
-    selectedTriggerAcceptablePriceImpactBps,
-    setDefaultTriggerAcceptablePriceImpactBps,
-    setSelectedAcceptablePriceImpactBps,
-  ]);
+  if (isLimit && increaseAmounts?.acceptablePrice) {
+    recommendedAcceptablePriceImpactBps = bigMath.abs(increaseAmounts.recommendedAcceptablePriceDeltaBps);
+  } else if (isTrigger && decreaseAmounts?.acceptablePrice !== undefined) {
+    recommendedAcceptablePriceImpactBps = bigMath.abs(decreaseAmounts.recommendedAcceptablePriceDeltaBps);
+  }
 
-  /**
-   * Set initial values from TP/SL orders
-   */
-  useEffect(() => {
-    if (
-      isTrigger &&
-      decreaseAmounts?.acceptablePrice !== undefined &&
-      defaultTriggerAcceptablePriceImpactBps === undefined &&
-      selectedTriggerAcceptablePriceImpactBps === undefined
-    ) {
-      setSelectedAcceptablePriceImpactBps(bigMath.abs(decreaseAmounts.recommendedAcceptablePriceDeltaBps));
-      setDefaultTriggerAcceptablePriceImpactBps(bigMath.abs(decreaseAmounts.recommendedAcceptablePriceDeltaBps));
-    }
-  }, [
-    decreaseAmounts?.acceptablePrice,
-    decreaseAmounts?.recommendedAcceptablePriceDeltaBps,
-    defaultTriggerAcceptablePriceImpactBps,
-    isTrigger,
-    selectedTriggerAcceptablePriceImpactBps,
-    setDefaultTriggerAcceptablePriceImpactBps,
-    setSelectedAcceptablePriceImpactBps,
-  ]);
+  useEffect(
+    function resetAcceptablePriceImpactOnTradeboxChanges() {
+      if (isAnyValueChanged) {
+        setDefaultTriggerAcceptablePriceImpactBps(undefined);
+        setSelectedAcceptablePriceImpactBps(undefined);
+      }
+    },
+    [isAnyValueChanged, setDefaultTriggerAcceptablePriceImpactBps, setSelectedAcceptablePriceImpactBps]
+  );
+
+  useEffect(
+    function followRecommendedAcceptablePriceImpact() {
+      if (recommendedAcceptablePriceImpactBps === undefined) {
+        return;
+      }
+
+      const isCustomized =
+        selectedTriggerAcceptablePriceImpactBps !== undefined &&
+        defaultTriggerAcceptablePriceImpactBps !== undefined &&
+        selectedTriggerAcceptablePriceImpactBps !== defaultTriggerAcceptablePriceImpactBps;
+
+      if (!isCustomized) {
+        setSelectedAcceptablePriceImpactBps(recommendedAcceptablePriceImpactBps);
+      }
+
+      setDefaultTriggerAcceptablePriceImpactBps(recommendedAcceptablePriceImpactBps);
+    },
+    [
+      defaultTriggerAcceptablePriceImpactBps,
+      recommendedAcceptablePriceImpactBps,
+      selectedTriggerAcceptablePriceImpactBps,
+      setDefaultTriggerAcceptablePriceImpactBps,
+      setSelectedAcceptablePriceImpactBps,
+    ]
+  );
 }

--- a/src/components/TradeBox/hooks/useTradeboxAcceptablePriceImpactValues.ts
+++ b/src/components/TradeBox/hooks/useTradeboxAcceptablePriceImpactValues.ts
@@ -2,10 +2,10 @@ import { useEffect } from "react";
 
 import {
   selectTradeboxDecreasePositionAmounts,
-  selectTradeboxDefaultTriggerAcceptablePriceImpactBps,
   selectTradeboxIncreasePositionAmounts,
-  selectTradeboxSelectedTriggerAcceptablePriceImpactBps,
+  selectTradeboxIsAcceptablePriceImpactCustomized,
   selectTradeboxSetDefaultTriggerAcceptablePriceImpactBps,
+  selectTradeboxSetIsAcceptablePriceImpactCustomized,
   selectTradeboxSetSelectedAcceptablePriceImpactBps,
   selectTradeboxTradeFlags,
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
@@ -17,8 +17,7 @@ import { useTradeboxChanges } from "./useTradeboxChanges";
 export function useTradeboxAcceptablePriceImpactValues() {
   const increaseAmounts = useSelector(selectTradeboxIncreasePositionAmounts);
   const decreaseAmounts = useSelector(selectTradeboxDecreasePositionAmounts);
-  const defaultTriggerAcceptablePriceImpactBps = useSelector(selectTradeboxDefaultTriggerAcceptablePriceImpactBps);
-  const selectedTriggerAcceptablePriceImpactBps = useSelector(selectTradeboxSelectedTriggerAcceptablePriceImpactBps);
+  const isAcceptablePriceImpactCustomized = useSelector(selectTradeboxIsAcceptablePriceImpactCustomized);
 
   const tradeFlags = useSelector(selectTradeboxTradeFlags);
 
@@ -28,6 +27,7 @@ export function useTradeboxAcceptablePriceImpactValues() {
     selectTradeboxSetDefaultTriggerAcceptablePriceImpactBps
   );
   const setSelectedAcceptablePriceImpactBps = useSelector(selectTradeboxSetSelectedAcceptablePriceImpactBps);
+  const setIsAcceptablePriceImpactCustomized = useSelector(selectTradeboxSetIsAcceptablePriceImpactCustomized);
 
   const tradeboxChanges = useTradeboxChanges();
 
@@ -46,9 +46,15 @@ export function useTradeboxAcceptablePriceImpactValues() {
       if (isAnyValueChanged) {
         setDefaultTriggerAcceptablePriceImpactBps(undefined);
         setSelectedAcceptablePriceImpactBps(undefined);
+        setIsAcceptablePriceImpactCustomized(false);
       }
     },
-    [isAnyValueChanged, setDefaultTriggerAcceptablePriceImpactBps, setSelectedAcceptablePriceImpactBps]
+    [
+      isAnyValueChanged,
+      setDefaultTriggerAcceptablePriceImpactBps,
+      setIsAcceptablePriceImpactCustomized,
+      setSelectedAcceptablePriceImpactBps,
+    ]
   );
 
   useEffect(
@@ -57,21 +63,15 @@ export function useTradeboxAcceptablePriceImpactValues() {
         return;
       }
 
-      const isCustomized =
-        selectedTriggerAcceptablePriceImpactBps !== undefined &&
-        defaultTriggerAcceptablePriceImpactBps !== undefined &&
-        selectedTriggerAcceptablePriceImpactBps !== defaultTriggerAcceptablePriceImpactBps;
-
-      if (!isCustomized) {
+      if (!isAcceptablePriceImpactCustomized) {
         setSelectedAcceptablePriceImpactBps(recommendedAcceptablePriceImpactBps);
       }
 
       setDefaultTriggerAcceptablePriceImpactBps(recommendedAcceptablePriceImpactBps);
     },
     [
-      defaultTriggerAcceptablePriceImpactBps,
+      isAcceptablePriceImpactCustomized,
       recommendedAcceptablePriceImpactBps,
-      selectedTriggerAcceptablePriceImpactBps,
       setDefaultTriggerAcceptablePriceImpactBps,
       setSelectedAcceptablePriceImpactBps,
     ]

--- a/src/components/TradeBox/hooks/useTradeboxChanges.ts
+++ b/src/components/TradeBox/hooks/useTradeboxChanges.ts
@@ -7,8 +7,6 @@ import {
   selectTradeboxToTokenAddress,
   selectTradeboxTradeFlags,
   selectTradeboxTriggerPrice,
-  selectTradeboxFromTokenInputValue,
-  selectTradeboxToTokenInputValue,
 } from "context/SyntheticsStateContext/selectors/tradeboxSelectors";
 import { useSelector } from "context/SyntheticsStateContext/utils";
 
@@ -17,8 +15,6 @@ export function useTradeboxChanges() {
   const leverage = useSelector(selectTradeboxLeverage);
   const fromTokenAddress = useSelector(selectTradeboxFromTokenAddress);
   const toTokenAddress = useSelector(selectTradeboxToTokenAddress);
-  const fromTokenInputValue = useSelector(selectTradeboxFromTokenInputValue);
-  const toTokenInputValue = useSelector(selectTradeboxToTokenInputValue);
 
   const previousMarketIndexTokenAddress = usePrevious(marketInfo?.indexTokenAddress);
   const tradeFlags = useSelector(selectTradeboxTradeFlags);
@@ -33,8 +29,6 @@ export function useTradeboxChanges() {
   const previousIsSwap = usePrevious(tradeFlags.isSwap);
 
   const previousLimitPrice = usePrevious(triggerPrice);
-  const previousFromTokenInputValue = usePrevious(fromTokenInputValue);
-  const previousToTokenInputValue = usePrevious(toTokenInputValue);
 
   const isMarketChanged = previousMarketIndexTokenAddress !== marketInfo?.indexTokenAddress;
   const isLimitChanged = previousIsLimit !== tradeFlags.isLimit;
@@ -44,8 +38,6 @@ export function useTradeboxChanges() {
   const isFromTokenAddressChanged = previousFromTokenAddress !== fromTokenAddress;
   const isToTokenAddressChanged = previousToTokenAddress !== toTokenAddress;
   const isDirectionChanged = previousIsSwap !== tradeFlags.isSwap || previousTradeIsLong !== tradeFlags.isLong;
-  const isFromTokenInputValueChanged = previousFromTokenInputValue !== fromTokenInputValue;
-  const isToTokenInputValueChanged = previousToTokenInputValue !== toTokenInputValue;
 
   return {
     market: isMarketChanged,
@@ -56,7 +48,5 @@ export function useTradeboxChanges() {
     leverage: isLeverageChanged,
     fromTokenAddress: isFromTokenAddressChanged,
     toTokenAddress: isToTokenAddressChanged,
-    fromTokenInputValue: isFromTokenInputValueChanged,
-    toTokenInputValue: isToTokenInputValueChanged,
   };
 }

--- a/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
+++ b/src/context/SyntheticsStateContext/selectors/tradeboxSelectors/index.ts
@@ -523,6 +523,12 @@ export const selectTradeboxSelectedTriggerAcceptablePriceImpactBps = (s: Synthet
   s.tradebox.selectedTriggerAcceptablePriceImpactBps;
 export const selectTradeboxSetSelectedAcceptablePriceImpactBps = (s: SyntheticsState) =>
   s.tradebox.setSelectedAcceptablePriceImpactBps;
+export const selectTradeboxSetUserSelectedAcceptablePriceImpactBps = (s: SyntheticsState) =>
+  s.tradebox.setUserSelectedAcceptablePriceImpactBps;
+export const selectTradeboxIsAcceptablePriceImpactCustomized = (s: SyntheticsState) =>
+  s.tradebox.isAcceptablePriceImpactCustomized;
+export const selectTradeboxSetIsAcceptablePriceImpactCustomized = (s: SyntheticsState) =>
+  s.tradebox.setIsAcceptablePriceImpactCustomized;
 export const selectTradeboxDefaultAllowedSwapSlippageBps = (s: SyntheticsState) =>
   s.tradebox.defaultAllowedSwapSlippageBps;
 export const selectTradeboxSetDefaultAllowedSwapSlippageBps = (s: SyntheticsState) =>

--- a/src/domain/synthetics/trade/useTradeboxState.ts
+++ b/src/domain/synthetics/trade/useTradeboxState.ts
@@ -292,6 +292,7 @@ export function useTradeboxState(
   const [focusedInput, setFocusedInput] = useState<"from" | "to">();
   const [defaultTriggerAcceptablePriceImpactBps, setDefaultTriggerAcceptablePriceImpactBps] = useState<bigint>();
   const [selectedTriggerAcceptablePriceImpactBps, setSelectedTriggerAcceptablePriceImpactBps] = useState<bigint>();
+  const [isAcceptablePriceImpactCustomized, setIsAcceptablePriceImpactCustomized] = useState(false);
   const [defaultAllowedSwapSlippageBps, setDefaultAllowedSwapSlippageBps] = useState<bigint>();
   const [selectedAllowedSwapSlippageBps, setSelectedAllowedSwapSlippageBps] = useState<bigint>();
   const [closeSizeInputValue, setCloseSizeInputValue] = useState("");
@@ -302,6 +303,16 @@ export function useTradeboxState(
 
   const [advancedOptions, setAdvancedOptions] = useSafeState<TradeboxAdvancedOptions>(
     storedOptions.advanced ?? INITIAL_SYNTHETICS_TRADE_OPTIONS_STATE.advanced
+  );
+
+  const latestDefaultTriggerAcceptablePriceImpactBps = useLatest(defaultTriggerAcceptablePriceImpactBps);
+
+  const setUserSelectedAcceptablePriceImpactBps = useCallback(
+    (value: bigint) => {
+      setSelectedTriggerAcceptablePriceImpactBps(value);
+      setIsAcceptablePriceImpactCustomized(value !== latestDefaultTriggerAcceptablePriceImpactBps.current);
+    },
+    [latestDefaultTriggerAcceptablePriceImpactBps]
   );
 
   const { swapTokens } = availableTokensOptions;
@@ -779,6 +790,9 @@ export function useTradeboxState(
     setDefaultTriggerAcceptablePriceImpactBps,
     selectedTriggerAcceptablePriceImpactBps,
     setSelectedAcceptablePriceImpactBps: setSelectedTriggerAcceptablePriceImpactBps,
+    setUserSelectedAcceptablePriceImpactBps,
+    isAcceptablePriceImpactCustomized,
+    setIsAcceptablePriceImpactCustomized,
     defaultAllowedSwapSlippageBps,
     setDefaultAllowedSwapSlippageBps,
     selectedAllowedSwapSlippageBps,


### PR DESCRIPTION
## Summary

- **Fix (the ticket):** the "Acceptable price impact" field flashed `N/A` and dropped the user's value on every market-data refresh. `useTradeboxChanges` treated the auto-backfilled Margin/Size input strings as user changes (keys added in a026c3720 for the since-removed pool auto-selection), and `useTradeboxAcceptablePriceImpactValues` reset both values to `undefined` on any change. Those keys are removed; the hook now resets only on user actions (market, direction, order type, limit price, leverage, tokens), keeps the recommended value live from `recommendedAcceptablePriceDeltaBps`, and lets the selected value follow it only while the user hasn't customized it (`selected === default`, the same convention `PercentageInput` uses for "cleared"). Vitest on the hook; two of its cases fail on the old code.
  - Behavior change: editing size/margin (including the size slider) no longer resets a customized acceptable price impact; the recommended value and the low/high warnings stay live.
- **`PercentageInput`:** ↑/↓ arrow keys step the value by 0.01% (1 bps), clamped to `[0, max]`; from an empty field the step starts at the placeholder. Applies to every `PercentageInput` (allowed slippage, network fee buffer). Done via `onKeyDown` rather than `type="number"` to keep the shared text `NumberInput` sanitizer and avoid spinner/locale/wheel side effects.
- **`SuggestionInput`:** an empty suggestion list no longer opens the (empty) panel, so `PercentageInput` no longer disables its warning tooltip while the field is focused. The high/low acceptable price impact warning with "Set recommended impact" now shows while typing.
- **`Tooltip`:** a tooltip opened by focus flickered whenever the pointer left the handle (floating-ui hover close followed by the focus-within reopen). Hover-initiated closes are now ignored while the handle has visible focus, and the tooltip closes on blur unless the handle or the popup is hovered (so a link inside the popup stays clickable). Side effect for every tooltip with focusable content: after tabbing away the popup now closes instead of staying open until an outside click.

Verified on a live Arbitrum stand (Long → Limit, 1000 USDC, limit price 2400, "Set acceptable price impact" enabled) with a MutationObserver on the form: before — 22 `N/A` flashes and 22 input remounts in 40 s, a typed 1% wiped within 0.4 s; after — 38 liquidity updates in 70 s with 0 flashes and the typed value intact; the focused warning tooltip survives repeated pointer sweeps with zero DOM changes.

Linear: https://linear.app/gmx-io/issue/FEDEV-4287/bug-acceptable-price-impact-field-flickers-when-available-liquidity
