### PR TITLE
Hotfix: read the stats from the arbitrum production API

### DIFF
--- a/sdk/src/configs/api.ts
+++ b/sdk/src/configs/api.ts
@@ -48,10 +48,9 @@ export function isApiSupported(chainId: number, environment: ApiEnvironment = "p
   return getApiUrl(chainId, environment) !== undefined;
 }
 
-// Stats are chain-agnostic and served by the Arbitrum test stand; production has no deployment with the
-// stats flag yet, and calling it there would only fill its error log with 503s.
+// Stats are chain-agnostic, so one deployment per environment serves them for every network
 const STATS_API_URLS: Record<ApiEnvironment, string | undefined> = {
-  production: undefined,
+  production: API_URLS.production[ARBITRUM],
   test: API_URLS.test[ARBITRUM],
 };
 

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -44,8 +44,5 @@ export function getUiStatsApiUrl() {
     }
   }
 
-  const url = getStatsApiUrl(getUiApiEnvironment());
-
-  // the test stand is the only deployment serving stats, so previews and local builds fall back to it
-  return url ?? (isDevelopment() ? getStatsApiUrl("test") : undefined);
+  return getStatsApiUrl(getUiApiEnvironment());
 }


### PR DESCRIPTION
## Why

The unified stats are live in production: gmx-api #183 enabled the flag on the arbitrum deployment, and `https://arbitrum.gmxapi.io/v1/stats/*` has been answering 200 since 20:03 UTC with all four sources fresh and `completeness: complete`. The interface still resolves `undefined` for the production environment, so it never issues the request and app.gmx.io shows no GMTrade numbers, while the branch preview does through the development fallback.

## What

- `STATS_API_URLS.production` points at the arbitrum production API, the deployment that serves the chain-agnostic stats.
- The development fallback in `getUiStatsApiUrl` goes with it: both environments resolve a URL now, so the branch was dead. The `stats-api-url` localStorage override is unchanged and still points a local build at a local API.

## Verification

- Production API: `200` on `/v1/stats/summary` and `/v1/stats/sources`, four sources `fresh`, `completeness: complete`.
- CORS from the app origin: `access-control-allow-origin: *` on the GET and a `204` preflight for `Origin: https://app.gmx.io`.
- Local build on this branch, with no localStorage override and the fallback removed, so the only URL it can resolve is the production one: the stats page renders 24h volume $1.03b against $67m without GMTrade, users 777.96k, fees $488.32m, epoch fees $1.08m.
- `tsc` (app, landing, sdk), eslint, prettier clean; the stats unit tests pass (4 + 7).

If the API is unavailable the cards simply drop the GMTrade entries, and since #2836 the TVL and GM pools rows no longer print `...` in that case.
