### PR TITLE
Show one sorted row per network in the stats tooltips

### DIFF
--- a/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
@@ -6,13 +6,22 @@ import { formatAmountHuman } from "lib/numbers";
 
 import "./StatsTooltip.css";
 
+type EntryValue = bigint | number | string | undefined;
+
 type Props = {
-  entries: { [key: string]: bigint | number | string | undefined };
+  entries: { [key: string]: EntryValue };
   showDollar?: boolean;
   decimalsForConversion?: number;
   symbol?: string;
   subtotal?: ReactNode;
 };
+
+// a network row carries every version of that network, so the tooltip never splits one chain across rows
+export function sumNetworkParts(...parts: (bigint | number | undefined)[]): bigint | undefined {
+  const known = parts.filter((part): part is bigint | number => part !== undefined);
+
+  return known.length > 0 ? known.reduce<bigint>((acc, part) => acc + BigInt(part), 0n) : undefined;
+}
 
 export default function ChainsStatsTooltipRow({
   entries,
@@ -21,7 +30,14 @@ export default function ChainsStatsTooltipRow({
   symbol,
   subtotal,
 }: Props) {
-  const validEntries = Object.entries(entries).filter(([, value]) => value);
+  const validEntries = Object.entries(entries)
+    .filter(([, value]) => value)
+    .sort(([, left], [, right]) => {
+      const a = BigInt(left || 0);
+      const b = BigInt(right || 0);
+
+      return a === b ? 0 : a > b ? -1 : 1;
+    });
   const total = validEntries.reduce((acc, [, value]) => acc + (BigInt(value || 0) ?? 0n), 0n);
 
   if (validEntries.length === 0) {

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -21,7 +21,7 @@ import useWallet from "lib/wallets/useWallet";
 import { bigMath } from "sdk/utils/bigmath";
 
 import { AppCard, AppCardSection, AppCardSplit } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
+import ChainsStatsTooltipRow, { sumNetworkParts } from "components/StatsTooltip/ChainsStatsTooltipRow";
 import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
 import TooltipComponent from "components/Tooltip/Tooltip";
 
@@ -29,6 +29,19 @@ import { ACTIVE_CHAIN_IDS } from "./DashboardV2";
 import { getFormattedFeesDuration } from "./getFormattedFeesDuration";
 import { getPositionStats } from "./getPositionStats";
 import type { ChainStats } from "./useDashboardChainStatsMulticall";
+
+type NetworkRow = { label: string; value: bigint | undefined };
+
+// highest first, with a network whose value has not arrived yet kept last rather than ordered as zero
+function sortNetworkRows(rows: NetworkRow[]): NetworkRow[] {
+  return [...rows].sort((a, b) => {
+    if (a.value === undefined || b.value === undefined) {
+      return a.value === b.value ? 0 : a.value === undefined ? 1 : -1;
+    }
+
+    return a.value === b.value ? 0 : a.value > b.value ? -1 : 1;
+  });
+}
 
 export function OverviewCard({
   statsArbitrum,
@@ -250,12 +263,10 @@ export function OverviewCard({
 
   const dailyVolumeEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.dailyVolume,
-      "V2 Avalanche": v2AvalancheOverview?.dailyVolume,
-      "V2 MegaETH": v2MegaethOverview?.dailyVolume,
-      "V1 Arbitrum": v1ArbitrumDailyVolume,
-      "V1 Avalanche": v1AvalancheDailyVolume,
-      "GMTrade Solana": gmtradeDailyVolume,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.dailyVolume, v1ArbitrumDailyVolume),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.dailyVolume, v1AvalancheDailyVolume),
+      MegaETH: v2MegaethOverview?.dailyVolume,
+      Solana: gmtradeDailyVolume,
     }),
     [
       gmtradeDailyVolume,
@@ -269,12 +280,10 @@ export function OverviewCard({
 
   const openInterestEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOpenInterest,
-      "V2 Avalanche": v2AvalancheOpenInterest,
-      "V2 MegaETH": v2MegaethOpenInterest,
-      "V1 Avalanche": v1AvalancheOpenInterest,
-      "V1 Arbitrum": v1ArbitrumOpenInterest,
-      "GMTrade Solana": gmtradeOpenInterest,
+      Arbitrum: sumNetworkParts(v2ArbitrumOpenInterest, v1ArbitrumOpenInterest),
+      Avalanche: sumNetworkParts(v2AvalancheOpenInterest, v1AvalancheOpenInterest),
+      MegaETH: v2MegaethOpenInterest,
+      Solana: gmtradeOpenInterest,
     }),
     [
       v1ArbitrumOpenInterest,
@@ -288,12 +297,10 @@ export function OverviewCard({
 
   const totalLongPositionSizesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumLongPositionSizes,
-      "V2 Avalanche": v2AvalancheLongPositionSizes,
-      "V2 MegaETH": v2MegaethLongPositionSizes,
-      "V1 Arbitrum": v1ArbitrumLongPositionSizes,
-      "V1 Avalanche": v1AvalancheLongPositionSizes,
-      "GMTrade Solana": gmtradeLongPositionSizes,
+      Arbitrum: sumNetworkParts(v2ArbitrumLongPositionSizes, v1ArbitrumLongPositionSizes),
+      Avalanche: sumNetworkParts(v2AvalancheLongPositionSizes, v1AvalancheLongPositionSizes),
+      MegaETH: v2MegaethLongPositionSizes,
+      Solana: gmtradeLongPositionSizes,
     }),
     [
       v1ArbitrumLongPositionSizes,
@@ -307,12 +314,10 @@ export function OverviewCard({
 
   const totalShortPositionSizesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumShortPositionSizes,
-      "V2 Avalanche": v2AvalancheShortPositionSizes,
-      "V2 MegaETH": v2MegaethShortPositionSizes,
-      "V1 Arbitrum": v1ArbitrumShortPositionSizes,
-      "V1 Avalanche": v1AvalancheShortPositionSizes,
-      "GMTrade Solana": gmtradeShortPositionSizes,
+      Arbitrum: sumNetworkParts(v2ArbitrumShortPositionSizes, v1ArbitrumShortPositionSizes),
+      Avalanche: sumNetworkParts(v2AvalancheShortPositionSizes, v1AvalancheShortPositionSizes),
+      MegaETH: v2MegaethShortPositionSizes,
+      Solana: gmtradeShortPositionSizes,
     }),
     [
       v1ArbitrumShortPositionSizes,
@@ -326,12 +331,10 @@ export function OverviewCard({
 
   const epochFeesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumEpochFees,
-      "V2 Avalanche": v2AvalancheEpochFees,
-      "V2 MegaETH": v2MegaethEpochFees,
-      "V1 Arbitrum": v1ArbitrumEpochFees,
-      "V1 Avalanche": v1AvalancheEpochFees,
-      "GMTrade Solana": gmtradeEpochFees,
+      Arbitrum: sumNetworkParts(v2ArbitrumEpochFees, v1ArbitrumEpochFees),
+      Avalanche: sumNetworkParts(v2AvalancheEpochFees, v1AvalancheEpochFees),
+      MegaETH: v2MegaethEpochFees,
+      Solana: gmtradeEpochFees,
     }),
     [
       v1ArbitrumEpochFees,
@@ -341,6 +344,28 @@ export function OverviewCard({
       v2MegaethEpochFees,
       gmtradeEpochFees,
     ]
+  );
+
+  const tvlRows = useMemo(
+    () =>
+      sortNetworkRows([
+        { label: t`Arbitrum`, value: displayTvlArbitrum },
+        { label: t`Avalanche`, value: displayTvlAvalanche },
+        { label: "MegaETH", value: displayTvlMegaeth },
+        { label: "Solana", value: gmTvlGmtrade },
+      ]),
+    [displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade]
+  );
+
+  const gmPoolRows = useMemo(
+    () =>
+      sortNetworkRows([
+        { label: t`Arbitrum`, value: gmTvlArbitrum },
+        { label: t`Avalanche`, value: gmTvlAvalanche },
+        { label: "MegaETH", value: gmTvlMegaeth },
+        { label: "Solana", value: gmTvlGmtrade },
+      ]),
+    [gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade]
   );
 
   const [formattedDuration, setFormattedDuration] = useState(() => getFormattedFeesDuration());
@@ -428,28 +453,14 @@ export function OverviewCard({
                       <Trans>TVL includes GMX staked, GM pools, and position collateral</Trans>
                       <br />
                       <br />
-                      <StatsTooltipRow
-                        label={t`Arbitrum`}
-                        showDollar={false}
-                        value={formatAmountHuman(displayTvlArbitrum, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label={t`Avalanche`}
-                        showDollar={false}
-                        value={formatAmountHuman(displayTvlAvalanche, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label="MegaETH"
-                        showDollar={false}
-                        value={formatAmountHuman(displayTvlMegaeth, USD_DECIMALS, true, 2)}
-                      />
-                      {gmTvlGmtrade !== undefined && (
+                      {tvlRows.map(({ label, value }) => (
                         <StatsTooltipRow
-                          label="Solana (GMTrade)"
+                          key={label}
+                          label={label}
                           showDollar={false}
-                          value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
+                          value={formatAmountHuman(value, USD_DECIMALS, true, 2)}
                         />
-                      )}
+                      ))}
                       <div className="!my-8 h-1 bg-gray-800" />
                       <StatsTooltipRow
                         label={t`Total`}
@@ -475,28 +486,14 @@ export function OverviewCard({
                       <Trans>Total value of tokens in GM pools</Trans>
                       <br />
                       <br />
-                      <StatsTooltipRow
-                        label={t`Arbitrum`}
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlArbitrum, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label={t`Avalanche`}
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlAvalanche, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label="MegaETH"
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlMegaeth, USD_DECIMALS, true, 2)}
-                      />
-                      {gmTvlGmtrade !== undefined && (
+                      {gmPoolRows.map(({ label, value }) => (
                         <StatsTooltipRow
-                          label="Solana (GMTrade)"
+                          key={label}
+                          label={label}
                           showDollar={false}
-                          value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
+                          value={formatAmountHuman(value, USD_DECIMALS, true, 2)}
                         />
-                      )}
+                      ))}
                       <div className="!my-8 h-1 bg-gray-800" />
                       <StatsTooltipRow
                         label={t`Total`}

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -15,7 +15,7 @@ import { MARKETS } from "sdk/configs/markets";
 import { getTokenBySymbol } from "sdk/configs/tokens";
 
 import { AppCard, AppCardSection } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
+import ChainsStatsTooltipRow, { sumNetworkParts } from "components/StatsTooltip/ChainsStatsTooltipRow";
 import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
 import TooltipComponent from "components/Tooltip/Tooltip";
 import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
@@ -78,12 +78,10 @@ export function StatsCard() {
 
   const totalFeesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.totalFees,
-      "V2 Avalanche": v2AvalancheOverview?.totalFees,
-      "V2 MegaETH": v2MegaethOverview?.totalFees,
-      "V1 Arbitrum": v1ArbitrumTotalFees?.totalFees,
-      "V1 Avalanche": v1AvalancheTotalFees?.totalFees,
-      "GMTrade Solana": gmtradeTotalFees,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalFees, v1ArbitrumTotalFees?.totalFees),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalFees, v1AvalancheTotalFees?.totalFees),
+      MegaETH: v2MegaethOverview?.totalFees,
+      Solana: gmtradeTotalFees,
     }),
     [
       v1AvalancheTotalFees?.totalFees,
@@ -97,12 +95,10 @@ export function StatsCard() {
 
   const totalVolumeEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.totalVolume,
-      "V2 Avalanche": v2AvalancheOverview?.totalVolume,
-      "V2 MegaETH": v2MegaethOverview?.totalVolume,
-      "V1 Arbitrum": v1TotalVolume?.[ARBITRUM],
-      "V1 Avalanche": v1TotalVolume?.[AVALANCHE],
-      "GMTrade Solana": gmtradeTotalVolume,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalVolume, v1TotalVolume?.[ARBITRUM]),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalVolume, v1TotalVolume?.[AVALANCHE]),
+      MegaETH: v2MegaethOverview?.totalVolume,
+      Solana: gmtradeTotalVolume,
     }),
     [
       v1TotalVolume,
@@ -115,12 +111,10 @@ export function StatsCard() {
 
   const uniqueUsersEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.totalUsers,
-      "V2 Avalanche": v2AvalancheOverview?.totalUsers,
-      "V2 MegaETH": v2MegaethOverview?.totalUsers,
-      "V1 Arbitrum": uniqueUsers?.[ARBITRUM],
-      "V1 Avalanche": uniqueUsers?.[AVALANCHE],
-      "GMTrade Solana": gmtradeUsers,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalUsers, uniqueUsers?.[ARBITRUM]),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalUsers, uniqueUsers?.[AVALANCHE]),
+      MegaETH: v2MegaethOverview?.totalUsers,
+      Solana: gmtradeUsers,
     }),
     [
       gmtradeUsers,


### PR DESCRIPTION
FEDEV-4293

The network breakdowns split a chain across "V1 Arbitrum" and "V2 Arbitrum" rows, labelled Solana as "GMTrade Solana" or "Solana (GMTrade)", and kept object insertion order, so comparing networks meant adding rows up by eye.

- One row per network: Arbitrum, Avalanche, MegaETH, Solana. V1 and V2 are summed into their network by `sumNetworkParts` before the row is built, so contributions and totals are unchanged.
- `ChainsStatsTooltipRow` sorts rows by their unrounded value, highest first. `Array#sort` is stable, so equal values keep a fixed order.
- TVL and GM pools used their own fixed-order rows; they now go through the same sort. A network whose value has not arrived yet sorts last rather than being ordered as zero.
- Total stays below the rows, and the annualized fees and GMX buy pressure block stays a separate summary below Total.

Presentation only: no metric definition, contribution or headline total changes.

Note on missing versus zero: today `useV2Stats` reports absent market data as `0n`, so a real zero and a loading network are the same value here. That is fixed in FEDEV-4295 (#2842); this PR keeps the current filter so loading does not start rendering "$0.00".

Merge order: this PR and #2842 both touch `ChainsStatsTooltipRow`, `OverviewCard` and `StatsCard`. Merging this one first keeps the conflict to renaming the `SOLANA_ENTRY` constant there.

tsc, eslint and prettier clean. Tests: 177 files, 1683 tests.