### PR TITLE
Tell partial and stale stats apart from complete totals

### DIFF
--- a/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
@@ -12,6 +12,7 @@ type Props = {
   decimalsForConversion?: number;
   symbol?: string;
   subtotal?: ReactNode;
+  staleTitles?: string[];
 };
 
 export default function ChainsStatsTooltipRow({
@@ -20,17 +21,22 @@ export default function ChainsStatsTooltipRow({
   decimalsForConversion = USD_DECIMALS,
   symbol,
   subtotal,
+  staleTitles,
 }: Props) {
-  const validEntries = Object.entries(entries).filter(([, value]) => value);
-  const total = validEntries.reduce((acc, [, value]) => acc + (BigInt(value || 0) ?? 0n), 0n);
+  // an entry that has not answered yet is named instead of being summed as zero, so the total stays honest
+  const knownEntries = Object.entries(entries).filter(([, value]) => value !== undefined && value !== null);
+  const missingTitles = Object.entries(entries)
+    .filter(([, value]) => value === undefined || value === null)
+    .map(([title]) => title);
+  const total = knownEntries.reduce((acc, [, value]) => acc + BigInt(value || 0), 0n);
 
-  if (validEntries.length === 0) {
+  if (knownEntries.length === 0) {
     return null;
   }
 
   return (
     <>
-      {validEntries.map(([title, value]) => {
+      {knownEntries.map(([title, value]) => {
         return (
           <p key={title} className="Tooltip-row">
             <span className="label">
@@ -53,6 +59,16 @@ export default function ChainsStatsTooltipRow({
           {!showDollar && symbol && " " + symbol}
         </span>
       </p>
+      {missingTitles.length > 0 && (
+        <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">
+          <Trans>Partial total: no data yet from {missingTitles.join(", ")}.</Trans>
+        </p>
+      )}
+      {staleTitles !== undefined && staleTitles.length > 0 && (
+        <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">
+          <Trans>Included but not up to date: {staleTitles.join(", ")}.</Trans>
+        </p>
+      )}
       {subtotal}
     </>
   );

--- a/src/domain/protocolStats/useProtocolStatsSummary.ts
+++ b/src/domain/protocolStats/useProtocolStatsSummary.ts
@@ -4,7 +4,11 @@ import { getUiStatsApiUrl } from "config/api";
 import { CONFIG_UPDATE_INTERVAL } from "lib/timeConstants";
 import { HttpClient } from "sdk/utils/http/http";
 import { fetchApiProtocolStatsSummary } from "sdk/utils/stats/api";
-import type { ProtocolStatsFilterParams, ProtocolStatsSummaryResponse } from "sdk/utils/stats/types";
+import type {
+  ProtocolStatsFilterParams,
+  ProtocolStatsNetwork,
+  ProtocolStatsSummaryResponse,
+} from "sdk/utils/stats/types";
 
 export function useProtocolStatsSummary(params?: ProtocolStatsFilterParams) {
   const apiUrl = getUiStatsApiUrl();
@@ -18,4 +22,14 @@ export function useProtocolStatsSummary(params?: ProtocolStatsFilterParams) {
   );
 
   return { data, error, isLoading };
+}
+
+// the api keeps summing a lagging source and only flags it, so the interface has to read the flag to show it
+export function isProtocolStatsNetworkStale(
+  data: ProtocolStatsSummaryResponse | undefined,
+  network: ProtocolStatsNetwork
+) {
+  const source = data?.meta.sources.find((item) => item.network === network);
+
+  return source !== undefined && source.health !== "fresh";
 }

--- a/src/domain/synthetics/stats/useV2Stats.ts
+++ b/src/domain/synthetics/stats/useV2Stats.ts
@@ -10,18 +10,23 @@ import useUsers from "../stats/useUsers";
 import useVolumeInfo from "../stats/useVolumeInfo";
 import { useTokensDataRequest } from "../tokens";
 
+// undefined means the source has not answered yet, which a dashboard total must not read as zero
 type DashboardOverview = {
-  totalGMLiquidity: bigint;
-  totalLongPositionSizes: bigint;
-  totalShortPositionSizes: bigint;
-  openInterest: bigint;
-  dailyVolume: bigint;
-  totalVolume: bigint;
-  weeklyFees: bigint;
-  epochFees: bigint;
-  totalFees: bigint;
-  totalUsers: bigint;
+  totalGMLiquidity: bigint | undefined;
+  totalLongPositionSizes: bigint | undefined;
+  totalShortPositionSizes: bigint | undefined;
+  openInterest: bigint | undefined;
+  dailyVolume: bigint | undefined;
+  totalVolume: bigint | undefined;
+  weeklyFees: bigint | undefined;
+  epochFees: bigint | undefined;
+  totalFees: bigint | undefined;
+  totalUsers: bigint | undefined;
 };
+
+function toBigInt(value: string | number | bigint | undefined | null): bigint | undefined {
+  return value === undefined || value === null ? undefined : BigInt(value);
+}
 
 export default function useV2Stats(chainId: ContractsChainId): DashboardOverview {
   const volumeInfo = useVolumeInfo(chainId);
@@ -31,33 +36,35 @@ export default function useV2Stats(chainId: ContractsChainId): DashboardOverview
   const usersInfo = useUsers(chainId);
 
   const stats = useMemo(() => {
-    const allMarkets = Object.values(marketsInfoData || {}).filter((market) => !market.isDisabled);
-    const totalLiquidity = allMarkets.reduce((acc, market) => {
+    const allMarkets = marketsInfoData
+      ? Object.values(marketsInfoData).filter((market) => !market.isDisabled)
+      : undefined;
+    const totalLiquidity = allMarkets?.reduce((acc, market) => {
       return acc + BigInt(market.poolValueMax ?? 0);
     }, 0n);
 
-    const totalLongInterestUsd = allMarkets.reduce((acc, market) => {
+    const totalLongInterestUsd = allMarkets?.reduce((acc, market) => {
       return acc + getOpenInterestForBalance(market, true);
     }, 0n);
 
-    const totalShortInterestUsd = allMarkets.reduce((acc, market) => {
+    const totalShortInterestUsd = allMarkets?.reduce((acc, market) => {
       return acc + getOpenInterestForBalance(market, false);
     }, 0n);
 
     return {
-      totalGMLiquidity: totalLiquidity ?? 0n,
-      totalLongPositionSizes: totalLongInterestUsd ?? 0n,
-      totalShortPositionSizes: totalShortInterestUsd ?? 0n,
+      totalGMLiquidity: totalLiquidity,
+      totalLongPositionSizes: totalLongInterestUsd,
+      totalShortPositionSizes: totalShortInterestUsd,
       openInterest:
         totalLongInterestUsd !== undefined && totalShortInterestUsd !== undefined
           ? totalLongInterestUsd + totalShortInterestUsd
-          : 0n,
-      dailyVolume: BigInt(volumeInfo?.dailyVolume ?? 0) || 0n,
-      totalVolume: BigInt(volumeInfo?.totalVolume ?? 0) || 0n,
-      weeklyFees: BigInt(feesInfo?.weeklyFees ?? 0) || 0n,
-      epochFees: BigInt(feesInfo?.epochFees ?? 0) || 0n,
-      totalFees: BigInt(feesInfo?.totalFees ?? 0) || 0n,
-      totalUsers: BigInt(usersInfo?.totalUsers ?? 0) || 0n,
+          : undefined,
+      dailyVolume: toBigInt(volumeInfo?.dailyVolume),
+      totalVolume: toBigInt(volumeInfo?.totalVolume),
+      weeklyFees: toBigInt(feesInfo?.weeklyFees),
+      epochFees: toBigInt(feesInfo?.epochFees),
+      totalFees: toBigInt(feesInfo?.totalFees),
+      totalUsers: toBigInt(usersInfo?.totalUsers),
     };
   }, [marketsInfoData, volumeInfo, feesInfo, usersInfo]);
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -5064,6 +5064,10 @@ msgstr "GMX-Genehmigung ausstehend..."
 msgid "AMOUNT"
 msgstr "BETRAG"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 24h Volumen: $1,01 Milliarden.</0><1>Vielen Dank an die Hundertt
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Einzahlungsbetrag eingeben"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Pending GMX approval..."
 msgid "AMOUNT"
 msgstr "AMOUNT"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr "Partial total: no data yet from {0}."
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 24h Volume: $1.01 Billion.</0><1>Thank you to the hundreds of th
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Enter deposit amount"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr "Included but not up to date: {0}."
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Aprobación de GMX pendiente..."
 msgid "AMOUNT"
 msgstr "CANTIDAD"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 Volumen 24h: $1.01 Mil Millones.</0><1>Gracias a los cientos de 
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Ingresa cantidad de depósito"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Approbation GMX en attente..."
 msgid "AMOUNT"
 msgstr "MONTANT"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 Volume 24h : 1,01 milliard $.</0><1>Merci aux centaines de milli
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Entrez le montant de dépôt"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -5064,6 +5064,10 @@ msgstr "GMX の承認待ち..."
 msgid "AMOUNT"
 msgstr "金額"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 24時間ボリューム: 10.1億ドル。</0><1>パーミッシ�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "入金額を入力"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -5064,6 +5064,10 @@ msgstr "GMX 승인 대기 중..."
 msgid "AMOUNT"
 msgstr "금액"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 24시간 거래량: $1.01 Billion.</0><1>퍼미션리스 온체�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "입금 금액 입력"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -5064,6 +5064,10 @@ msgstr ""
 msgid "AMOUNT"
 msgstr ""
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8732,6 +8736,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
+msgstr ""
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
 msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Ожидание одобрения GMX..."
 msgid "AMOUNT"
 msgstr "СУММА"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 Объем за 24ч: $1.01 млрд.</0><1>Спасибо со�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Введите сумму внесения"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -5064,6 +5064,10 @@ msgstr "等待 GMX 授權中..."
 msgid "AMOUNT"
 msgstr "金額"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 24小時交易量：$10.1 億。</0><1>感謝數十萬 GMX 用�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "請輸入存入金額"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -5064,6 +5064,10 @@ msgstr "等待 GMX 授权中..."
 msgid "AMOUNT"
 msgstr "AMOUNT"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8733,6 +8737,10 @@ msgstr "<0>🔷 24 小时交易量：10.1 亿美元。</0><1>感谢数十万 GMX
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "输入存入金额"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -7,7 +7,7 @@ import { ARBITRUM, AVALANCHE, MEGAETH } from "config/chains";
 import { USD_DECIMALS } from "config/factors";
 import { useGmxPrice, useTotalGmxStaked } from "domain/legacy";
 import { useProtocolStatsFeesInfo } from "domain/protocolStats/useProtocolStatsFeesInfo";
-import { useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
+import { isProtocolStatsNetworkStale, useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
 import { parseProtocolStatsUsd } from "domain/protocolStats/utils";
 import { useV1FeesInfo, useVolumeInfo } from "domain/stats";
 import { usePositionsTotalMargin } from "domain/synthetics/positions/usePositionsTotalMargin";
@@ -30,6 +30,13 @@ import { getFormattedFeesDuration } from "./getFormattedFeesDuration";
 import { getPositionStats } from "./getPositionStats";
 import type { ChainStats } from "./useDashboardChainStatsMulticall";
 
+// a headline total stays unknown until every contribution is known, so a missing network never reads as zero
+function sumKnown(...parts: (bigint | undefined)[]): bigint | undefined {
+  return parts.some((part) => part === undefined) ? undefined : parts.reduce<bigint>((acc, part) => acc + part!, 0n);
+}
+
+const SOLANA_ENTRY = "GMTrade Solana";
+
 export function OverviewCard({
   statsArbitrum,
   statsAvalanche,
@@ -43,7 +50,12 @@ export function OverviewCard({
   const v2ArbitrumOverview = useV2Stats(ARBITRUM);
   const v2AvalancheOverview = useV2Stats(AVALANCHE);
   const v2MegaethOverview = useV2Stats(MEGAETH);
-  const gmtradeOverview = useProtocolStatsSummary({ networks: ["solana"] }).data?.byNetwork.solana;
+  const gmtradeSummary = useProtocolStatsSummary({ networks: ["solana"] });
+  const gmtradeOverview = gmtradeSummary.data?.byNetwork.solana;
+  const staleTitles = useMemo(
+    () => (isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : []),
+    [gmtradeSummary.data]
+  );
   const gmtradeFees = useProtocolStatsFeesInfo({ networks: ["solana"] });
 
   const { data: positionStats } = useSWR<
@@ -107,7 +119,7 @@ export function OverviewCard({
   const gmTvlMegaeth = v2MegaethOverview.totalGMLiquidity;
   const gmTvlGmtrade = parseProtocolStatsUsd(gmtradeOverview?.tvl?.pools);
 
-  const totalGmTvl = gmTvlArbitrum + gmTvlAvalanche + gmTvlMegaeth + (gmTvlGmtrade ?? 0n);
+  const totalGmTvl = sumKnown(gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade);
 
   let displayTvlArbitrum: bigint | undefined = undefined;
   let displayTvlAvalanche: bigint | undefined = undefined;
@@ -121,7 +133,10 @@ export function OverviewCard({
     glpMarketCapAvalanche !== undefined &&
     arbitrumPositionsMarginUsd !== undefined &&
     avalanchePositionsMarginUsd !== undefined &&
-    megaethPositionsMarginUsd !== undefined
+    megaethPositionsMarginUsd !== undefined &&
+    gmTvlArbitrum !== undefined &&
+    gmTvlAvalanche !== undefined &&
+    gmTvlMegaeth !== undefined
   ) {
     const stakedGmxUsdArbitrum = bigMath.mulDiv(gmxPrice, stakedGmxArbitrum, expandDecimals(1, GMX_DECIMALS));
     const stakedGmxUsdAvalanche = bigMath.mulDiv(gmxPrice, stakedGmxAvalanche, expandDecimals(1, GMX_DECIMALS));
@@ -130,7 +145,7 @@ export function OverviewCard({
     displayTvlArbitrum = stakedGmxUsdArbitrum + glpMarketCapArbitrum + gmTvlArbitrum + arbitrumPositionsMarginUsd;
     displayTvlAvalanche = stakedGmxUsdAvalanche + glpMarketCapAvalanche + gmTvlAvalanche + avalanchePositionsMarginUsd;
     displayTvlMegaeth = gmTvlMegaeth + megaethPositionsMarginUsd;
-    displayTvl = displayTvlArbitrum + displayTvlAvalanche + displayTvlMegaeth + (gmTvlGmtrade ?? 0n);
+    displayTvl = sumKnown(displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade);
   }
 
   // #endregion TVL and GLP Pool
@@ -255,7 +270,7 @@ export function OverviewCard({
       "V2 MegaETH": v2MegaethOverview?.dailyVolume,
       "V1 Arbitrum": v1ArbitrumDailyVolume,
       "V1 Avalanche": v1AvalancheDailyVolume,
-      "GMTrade Solana": gmtradeDailyVolume,
+      [SOLANA_ENTRY]: gmtradeDailyVolume,
     }),
     [
       gmtradeDailyVolume,
@@ -274,7 +289,7 @@ export function OverviewCard({
       "V2 MegaETH": v2MegaethOpenInterest,
       "V1 Avalanche": v1AvalancheOpenInterest,
       "V1 Arbitrum": v1ArbitrumOpenInterest,
-      "GMTrade Solana": gmtradeOpenInterest,
+      [SOLANA_ENTRY]: gmtradeOpenInterest,
     }),
     [
       v1ArbitrumOpenInterest,
@@ -293,7 +308,7 @@ export function OverviewCard({
       "V2 MegaETH": v2MegaethLongPositionSizes,
       "V1 Arbitrum": v1ArbitrumLongPositionSizes,
       "V1 Avalanche": v1AvalancheLongPositionSizes,
-      "GMTrade Solana": gmtradeLongPositionSizes,
+      [SOLANA_ENTRY]: gmtradeLongPositionSizes,
     }),
     [
       v1ArbitrumLongPositionSizes,
@@ -312,7 +327,7 @@ export function OverviewCard({
       "V2 MegaETH": v2MegaethShortPositionSizes,
       "V1 Arbitrum": v1ArbitrumShortPositionSizes,
       "V1 Avalanche": v1AvalancheShortPositionSizes,
-      "GMTrade Solana": gmtradeShortPositionSizes,
+      [SOLANA_ENTRY]: gmtradeShortPositionSizes,
     }),
     [
       v1ArbitrumShortPositionSizes,
@@ -331,7 +346,7 @@ export function OverviewCard({
       "V2 MegaETH": v2MegaethEpochFees,
       "V1 Arbitrum": v1ArbitrumEpochFees,
       "V1 Avalanche": v1AvalancheEpochFees,
-      "GMTrade Solana": gmtradeEpochFees,
+      [SOLANA_ENTRY]: gmtradeEpochFees,
     }),
     [
       v1ArbitrumEpochFees,
@@ -410,7 +425,13 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalEpochFeesUsd, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={epochFeesEntries} subtotal={feesSubtotal} />}
+                  content={
+                    <ChainsStatsTooltipRow
+                      entries={epochFeesEntries}
+                      subtotal={feesSubtotal}
+                      staleTitles={staleTitles}
+                    />
+                  }
                 />
               </div>
             </div>
@@ -522,7 +543,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalDailyVolume, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={dailyVolumeEntries} />}
+                  content={<ChainsStatsTooltipRow entries={dailyVolumeEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>
@@ -536,7 +557,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalOpenInterest, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={openInterestEntries} />}
+                  content={<ChainsStatsTooltipRow entries={openInterestEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>
@@ -550,7 +571,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalLongPositionSizes, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={totalLongPositionSizesEntries} />}
+                  content={<ChainsStatsTooltipRow entries={totalLongPositionSizesEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>
@@ -564,7 +585,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalShortPositionSizes, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={totalShortPositionSizesEntries} />}
+                  content={<ChainsStatsTooltipRow entries={totalShortPositionSizesEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 
 import { ARBITRUM, AVALANCHE, MEGAETH, ContractsChainIdProduction } from "config/chains";
 import { USD_DECIMALS } from "config/factors";
-import { useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
+import { isProtocolStatsNetworkStale, useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
 import { parseProtocolStatsUsd } from "domain/protocolStats/utils";
 import { useTotalVolume, useV1FeesInfo } from "domain/stats";
 import { useTreasuryAllChains } from "domain/stats/treasury/useTreasuryAllChains";
@@ -32,13 +32,20 @@ const gmGmxTokenAddresses = chains.map((chain) =>
 );
 const gmxGmAndTokensAddresses = [...gmxTokenAddresses, ...gmGmxTokenAddresses];
 
+const SOLANA_ENTRY = "GMTrade Solana";
+
 export function StatsCard() {
   const v1TotalVolume = useTotalVolume();
 
   const v2ArbitrumOverview = useV2Stats(ARBITRUM);
   const v2AvalancheOverview = useV2Stats(AVALANCHE);
   const v2MegaethOverview = useV2Stats(MEGAETH);
-  const gmtradeStats = useProtocolStatsSummary({ networks: ["solana"] }).data?.byNetwork.solana;
+  const gmtradeSummary = useProtocolStatsSummary({ networks: ["solana"] });
+  const gmtradeStats = gmtradeSummary.data?.byNetwork.solana;
+  const staleTitles = useMemo(
+    () => (isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : []),
+    [gmtradeSummary.data]
+  );
   const gmtradeTotalFees = parseProtocolStatsUsd(gmtradeStats?.fees.total);
   const gmtradeTotalVolume = parseProtocolStatsUsd(gmtradeStats?.volume.total);
   // users.all counts a wallet on its first action of any kind, the same basis as the V2 totalUsers entries
@@ -83,7 +90,7 @@ export function StatsCard() {
       "V2 MegaETH": v2MegaethOverview?.totalFees,
       "V1 Arbitrum": v1ArbitrumTotalFees?.totalFees,
       "V1 Avalanche": v1AvalancheTotalFees?.totalFees,
-      "GMTrade Solana": gmtradeTotalFees,
+      [SOLANA_ENTRY]: gmtradeTotalFees,
     }),
     [
       v1AvalancheTotalFees?.totalFees,
@@ -102,7 +109,7 @@ export function StatsCard() {
       "V2 MegaETH": v2MegaethOverview?.totalVolume,
       "V1 Arbitrum": v1TotalVolume?.[ARBITRUM],
       "V1 Avalanche": v1TotalVolume?.[AVALANCHE],
-      "GMTrade Solana": gmtradeTotalVolume,
+      [SOLANA_ENTRY]: gmtradeTotalVolume,
     }),
     [
       v1TotalVolume,
@@ -120,7 +127,7 @@ export function StatsCard() {
       "V2 MegaETH": v2MegaethOverview?.totalUsers,
       "V1 Arbitrum": uniqueUsers?.[ARBITRUM],
       "V1 Avalanche": uniqueUsers?.[AVALANCHE],
-      "GMTrade Solana": gmtradeUsers,
+      [SOLANA_ENTRY]: gmtradeUsers,
     }),
     [
       gmtradeUsers,
@@ -147,7 +154,7 @@ export function StatsCard() {
               className="whitespace-nowrap"
               handle={formatAmountHuman(totalFeesUsd, USD_DECIMALS, true, 2)}
               handleClassName="numbers"
-              content={<ChainsStatsTooltipRow entries={totalFeesEntries} />}
+              content={<ChainsStatsTooltipRow entries={totalFeesEntries} staleTitles={staleTitles} />}
             />
           </div>
         </div>
@@ -174,7 +181,7 @@ export function StatsCard() {
                 2
               )}
               handleClassName="numbers"
-              content={<ChainsStatsTooltipRow entries={totalVolumeEntries} />}
+              content={<ChainsStatsTooltipRow entries={totalVolumeEntries} staleTitles={staleTitles} />}
             />
           </div>
         </div>
@@ -202,7 +209,12 @@ export function StatsCard() {
               )}
               handleClassName="numbers"
               content={
-                <ChainsStatsTooltipRow showDollar={false} entries={uniqueUsersEntries} decimalsForConversion={0} />
+                <ChainsStatsTooltipRow
+                  showDollar={false}
+                  entries={uniqueUsersEntries}
+                  decimalsForConversion={0}
+                  staleTitles={staleTitles}
+                />
               }
             />
           </div>


### PR DESCRIPTION
FEDEV-4295

`useV2Stats` reported every missing EVM value as `0n`, and Solana values that were unavailable were added as zero or dropped. A loading or failing source therefore looked like a confirmed zero inside a total presented as complete, which is how Arbitrum GM pools could read $0.00 next to a $34.54m total.

- `useV2Stats` returns `undefined` for market, volume, fee and user data that has not arrived. A zero now means zero.
- `totalGmTvl` and `displayTvl` stay `undefined` until every contribution is known, including Solana, which was previously folded in as `?? 0n`.
- `ChainsStatsTooltipRow` distinguishes three states: a known value, including a real zero, which used to be filtered out as falsy; an unavailable value; and a value the API flagged as behind. The total is the sum of what is known, and under it the tooltip names the sources that have not answered ("Partial total: no data yet from ...") and the ones included but lagging ("Included but not up to date: ...").
- `isProtocolStatsNetworkStale` reads `meta.sources[].health` from the stats API, which keeps summing a lagging source and only flags it, so the interface has to read the flag to show it.

Recovery is automatic: once the sources answer, the notes disappear and the totals and breakdowns come back.

Not in this PR: the headline number itself carries no marker, the state is communicated in its tooltip. Putting an indicator on the figure needs a design call.

Merge order: #2841 touches the same three files. Merging it first leaves only the `SOLANA_ENTRY` constant to reconcile here.

tsc, eslint and prettier clean. Tests: 177 files, 1683 tests.