### PR TITLE
Unified stats: GMX-only buy pressure, one sorted row per network, partial and stale data

### DIFF
--- a/sdk/src/utils/__tests__/positions.spec.ts
+++ b/sdk/src/utils/__tests__/positions.spec.ts
@@ -23,15 +23,15 @@ import {
 import { convertToUsd, getIsEquivalentTokens } from "utils/tokens";
 import { Token } from "utils/tokens/types";
 
-vi.mock("../markets", () => ({
-  ...vi.importActual("../markets"),
+vi.mock("../markets", async () => ({
+  ...(await vi.importActual("../markets")),
   getPositiveMarketPnl: vi.fn(),
   getPoolUsdWithoutPnl: vi.fn(),
   getCappedPoolPnl: vi.fn(),
 }));
 
-vi.mock("../tokens", () => ({
-  ...vi.importActual("../tokens"),
+vi.mock("../tokens", async () => ({
+  ...(await vi.importActual("../tokens")),
   convertToUsd: vi.fn(),
   getIsEquivalentTokens: vi.fn(),
 }));

--- a/sdk/src/utils/stats/types.ts
+++ b/sdk/src/utils/stats/types.ts
@@ -35,6 +35,7 @@ export type ProtocolStatsRevenue = {
 export type ProtocolStatsTvl = {
   pools: ProtocolStatsUsd;
   glv: ProtocolStatsUsd;
+  store: ProtocolStatsUsd | null;
   total: ProtocolStatsUsd;
 };
 

--- a/src/components/NetworkDropdown/SolanaNetworkItem.tsx
+++ b/src/components/NetworkDropdown/SolanaNetworkItem.tsx
@@ -36,19 +36,16 @@ const SolanaNetworkItem = forwardRef<HTMLDivElement>(function SolanaNetworkItem(
       <ModalWithPortal
         isVisible={isModalOpen}
         setIsVisible={setIsModalOpen}
-        label={t`GMTrade`}
+        label={t`GMX on Solana`}
         contentClassName="!max-w-[420px]"
       >
         <div className="flex flex-col gap-16">
-          <p className="text-15 text-typography-secondary">
-            <Trans>GMX on Solana (GMTrade) is currently served from a separate domain</Trans>
-          </p>
           <p className="mb-8 text-15 text-typography-secondary">
-            <Trans>Opens GMTrade in a new tab</Trans>
+            <Trans>GMX on Solana (known as GMTrade) is currently served from a separate domain.</Trans>
           </p>
 
           <Button variant="primary-action" className="w-full" to="https://gmtrade.xyz" newTab>
-            <Trans>Open GMTrade</Trans>
+            <Trans>Open GMTrade in a new tab</Trans>
           </Button>
         </div>
       </ModalWithPortal>

--- a/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
@@ -6,13 +6,22 @@ import { formatAmountHuman } from "lib/numbers";
 
 import "./StatsTooltip.css";
 
+type EntryValue = bigint | number | string | undefined;
+
 type Props = {
-  entries: { [key: string]: bigint | number | string | undefined };
+  entries: { [key: string]: EntryValue };
   showDollar?: boolean;
   decimalsForConversion?: number;
   symbol?: string;
   subtotal?: ReactNode;
 };
+
+// a network row carries every version of that network, so the tooltip never splits one chain across rows
+export function sumNetworkParts(...parts: (bigint | number | undefined)[]): bigint | undefined {
+  const known = parts.filter((part): part is bigint | number => part !== undefined);
+
+  return known.length > 0 ? known.reduce<bigint>((acc, part) => acc + BigInt(part), 0n) : undefined;
+}
 
 export default function ChainsStatsTooltipRow({
   entries,
@@ -21,7 +30,14 @@ export default function ChainsStatsTooltipRow({
   symbol,
   subtotal,
 }: Props) {
-  const validEntries = Object.entries(entries).filter(([, value]) => value);
+  const validEntries = Object.entries(entries)
+    .filter(([, value]) => value)
+    .sort(([, left], [, right]) => {
+      const a = BigInt(left || 0);
+      const b = BigInt(right || 0);
+
+      return a === b ? 0 : a > b ? -1 : 1;
+    });
   const total = validEntries.reduce((acc, [, value]) => acc + (BigInt(value || 0) ?? 0n), 0n);
 
   if (validEntries.length === 0) {

--- a/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
@@ -17,13 +17,6 @@ type Props = {
   staleTitles?: string[];
 };
 
-// a network row carries every version of that network, so the tooltip never splits one chain across rows
-export function sumNetworkParts(...parts: (bigint | number | undefined)[]): bigint | undefined {
-  const known = parts.filter((part): part is bigint | number => part !== undefined);
-
-  return known.length > 0 ? known.reduce<bigint>((acc, part) => acc + BigInt(part), 0n) : undefined;
-}
-
 export default function ChainsStatsTooltipRow({
   entries,
   showDollar = true,

--- a/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
@@ -14,6 +14,7 @@ type Props = {
   decimalsForConversion?: number;
   symbol?: string;
   subtotal?: ReactNode;
+  staleTitles?: string[];
 };
 
 // a network row carries every version of that network, so the tooltip never splits one chain across rows
@@ -29,24 +30,29 @@ export default function ChainsStatsTooltipRow({
   decimalsForConversion = USD_DECIMALS,
   symbol,
   subtotal,
+  staleTitles,
 }: Props) {
-  const validEntries = Object.entries(entries)
-    .filter(([, value]) => value)
+  // an entry that has not answered yet is named instead of being summed as zero, so the total stays honest
+  const knownEntries = Object.entries(entries)
+    .filter(([, value]) => value !== undefined && value !== null)
     .sort(([, left], [, right]) => {
       const a = BigInt(left || 0);
       const b = BigInt(right || 0);
 
       return a === b ? 0 : a > b ? -1 : 1;
     });
-  const total = validEntries.reduce((acc, [, value]) => acc + (BigInt(value || 0) ?? 0n), 0n);
+  const missingTitles = Object.entries(entries)
+    .filter(([, value]) => value === undefined || value === null)
+    .map(([title]) => title);
+  const total = knownEntries.reduce((acc, [, value]) => acc + BigInt(value || 0), 0n);
 
-  if (validEntries.length === 0) {
+  if (knownEntries.length === 0) {
     return null;
   }
 
   return (
     <>
-      {validEntries.map(([title, value]) => {
+      {knownEntries.map(([title, value]) => {
         return (
           <p key={title} className="Tooltip-row">
             <span className="label">
@@ -69,6 +75,16 @@ export default function ChainsStatsTooltipRow({
           {!showDollar && symbol && " " + symbol}
         </span>
       </p>
+      {missingTitles.length > 0 && (
+        <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">
+          <Trans>Partial total: no data yet from {missingTitles.join(", ")}.</Trans>
+        </p>
+      )}
+      {staleTitles !== undefined && staleTitles.length > 0 && (
+        <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">
+          <Trans>Included but not up to date: {staleTitles.join(", ")}.</Trans>
+        </p>
+      )}
       {subtotal}
     </>
   );

--- a/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
@@ -8,6 +8,18 @@ import "./StatsTooltip.css";
 
 type EntryValue = bigint | number | string | undefined;
 
+function isKnown(value: EntryValue) {
+  return value !== undefined && value !== null;
+}
+
+function amountOf(value: EntryValue): bigint {
+  return BigInt(value || 0);
+}
+
+function Notice({ children }: { children: ReactNode }) {
+  return <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">{children}</p>;
+}
+
 type Props = {
   entries: { [key: string]: EntryValue };
   showDollar?: boolean;
@@ -23,21 +35,21 @@ export default function ChainsStatsTooltipRow({
   decimalsForConversion = USD_DECIMALS,
   symbol,
   subtotal,
-  staleTitles,
+  staleTitles = [],
 }: Props) {
-  // an entry that has not answered yet is named instead of being summed as zero, so the total stays honest
-  const knownEntries = Object.entries(entries)
-    .filter(([, value]) => value !== undefined && value !== null)
+  const allEntries = Object.entries(entries);
+
+  // an entry that has not answered yet is named below the total rather than summed as zero
+  const knownEntries = allEntries
+    .filter(([, value]) => isKnown(value))
     .sort(([, left], [, right]) => {
-      const a = BigInt(left || 0);
-      const b = BigInt(right || 0);
+      const a = amountOf(left);
+      const b = amountOf(right);
 
       return a === b ? 0 : a > b ? -1 : 1;
     });
-  const missingTitles = Object.entries(entries)
-    .filter(([, value]) => value === undefined || value === null)
-    .map(([title]) => title);
-  const total = knownEntries.reduce((acc, [, value]) => acc + BigInt(value || 0), 0n);
+  const missingTitles = allEntries.filter(([, value]) => !isKnown(value)).map(([title]) => title);
+  const total = knownEntries.reduce((acc, [, value]) => acc + amountOf(value), 0n);
 
   if (knownEntries.length === 0) {
     return null;
@@ -69,14 +81,14 @@ export default function ChainsStatsTooltipRow({
         </span>
       </p>
       {missingTitles.length > 0 && (
-        <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">
+        <Notice>
           <Trans>Partial total: no data yet from {missingTitles.join(", ")}.</Trans>
-        </p>
+        </Notice>
       )}
-      {staleTitles !== undefined && staleTitles.length > 0 && (
-        <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">
+      {staleTitles.length > 0 && (
+        <Notice>
           <Trans>Included but not up to date: {staleTitles.join(", ")}.</Trans>
-        </p>
+        </Notice>
       )}
       {subtotal}
     </>

--- a/src/config/backend.ts
+++ b/src/config/backend.ts
@@ -1,7 +1,5 @@
 import { ARBITRUM, AVALANCHE } from "./chains";
 
-export const GMX_STATS_API_URL = "https://stats.gmx.io/api";
-
 const BACKEND_URLS: { default: string } & Partial<Record<number, string>> = {
   default: "https://gmx-server-mainnet.uw.r.appspot.com",
 

--- a/src/domain/protocolStats/useProtocolStatsSummary.ts
+++ b/src/domain/protocolStats/useProtocolStatsSummary.ts
@@ -4,7 +4,11 @@ import { getUiStatsApiUrl } from "config/api";
 import { CONFIG_UPDATE_INTERVAL } from "lib/timeConstants";
 import { HttpClient } from "sdk/utils/http/http";
 import { fetchApiProtocolStatsSummary } from "sdk/utils/stats/api";
-import type { ProtocolStatsFilterParams, ProtocolStatsSummaryResponse } from "sdk/utils/stats/types";
+import type {
+  ProtocolStatsFilterParams,
+  ProtocolStatsNetwork,
+  ProtocolStatsSummaryResponse,
+} from "sdk/utils/stats/types";
 
 export function useProtocolStatsSummary(params?: ProtocolStatsFilterParams) {
   const apiUrl = getUiStatsApiUrl();
@@ -18,4 +22,14 @@ export function useProtocolStatsSummary(params?: ProtocolStatsFilterParams) {
   );
 
   return { data, error, isLoading };
+}
+
+// the api keeps summing a lagging source and only flags it, so the interface has to read the flag to show it
+export function isProtocolStatsNetworkStale(
+  data: ProtocolStatsSummaryResponse | undefined,
+  network: ProtocolStatsNetwork
+) {
+  const source = data?.meta.sources.find((item) => item.network === network);
+
+  return source !== undefined && source.health !== "fresh";
 }

--- a/src/domain/stats/useV1FeesInfo.ts
+++ b/src/domain/stats/useV1FeesInfo.ts
@@ -81,11 +81,8 @@ export function useV1FeesInfo(chainId: number) {
       // eslint-disable-next-line no-console
       console.error(`Error fetching feesInfo data for chain ${chainId}:`, error);
 
-      return {
-        weeklyFees: 0n,
-        epochFees: 0n,
-        totalFees: 0n,
-      };
+      // a failed source stays unknown: a zero here would settle the network total as complete
+      return undefined;
     }
   }
 

--- a/src/domain/stats/useVolumeInfo.ts
+++ b/src/domain/stats/useVolumeInfo.ts
@@ -1,22 +1,70 @@
+import { gql } from "@apollo/client";
 import useSWR from "swr";
 
-import { GMX_STATS_API_URL } from "config/backend";
 import { ARBITRUM, AVALANCHE } from "config/chains";
-import { toBigInt } from "lib/numbers";
+import { getGmxGraphClient } from "lib/indexers/clients";
+import { sumBigInts } from "lib/sumBigInts";
 import { CONFIG_UPDATE_INTERVAL } from "lib/timeConstants";
 
-const URL = `${GMX_STATS_API_URL}/volume/24h`;
+const volumeStatsQuery = gql`
+  query volumeInfo($lastTimestamp: Int!) {
+    volumeStats(where: { period: hourly, id_gte: $lastTimestamp }, orderBy: id, orderDirection: desc, first: 25) {
+      margin
+      swap
+      liquidation
+      mint
+      burn
+    }
+  }
+`;
+
+type VolumeStatsItem = {
+  margin: string;
+  swap: string;
+  liquidation: string;
+  mint: string;
+  burn: string;
+};
+
+type VolumeStatsData = {
+  volumeStats: VolumeStatsItem[];
+};
+
+async function fetchDailyVolume(chainId: number) {
+  try {
+    const client = getGmxGraphClient(chainId);
+    const lastTimestamp = Math.floor(Date.now() / 1000 / 3600) * 3600 - 60 * 60 * 24;
+
+    const { data } = await client!.query<VolumeStatsData>({
+      query: volumeStatsQuery,
+      variables: {
+        lastTimestamp,
+      },
+      fetchPolicy: "no-cache",
+    });
+
+    return data.volumeStats.reduce(
+      (acc, stat) => acc + sumBigInts(...[stat.margin, stat.swap, stat.liquidation, stat.mint, stat.burn].map(BigInt)),
+      0n
+    );
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error fetching V1 volume data for chain ${chainId}:`, error);
+
+    // a chain that failed stays unknown: a zero here would settle its network total as complete
+    return undefined;
+  }
+}
 
 export function useVolumeInfo() {
   const { data } = useSWR(
-    URL,
-    async (url) => {
-      const res = await fetch(url);
-      const json = await res.json();
+    "v1VolumeInfo",
+    async () => {
+      const [arbitrum, avalanche] = await Promise.all([fetchDailyVolume(ARBITRUM), fetchDailyVolume(AVALANCHE)]);
+
       return {
-        [ARBITRUM]: toBigInt(json[ARBITRUM]),
-        [AVALANCHE]: toBigInt(json[AVALANCHE]),
-        total: toBigInt(json.total),
+        [ARBITRUM]: arbitrum,
+        [AVALANCHE]: avalanche,
       };
     },
     {

--- a/src/domain/synthetics/stats/useUsers.ts
+++ b/src/domain/synthetics/stats/useUsers.ts
@@ -27,25 +27,13 @@ export default function useUsers(chainId: number) {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(`Error fetching usersInfo data for chain ${chainId}:`, error);
-      return {
-        totalUsers: 0n,
-      };
+      // a failed source stays unknown: a zero here would settle the network total as complete
+      return undefined;
     }
   }
 
   async function fetcher([, chainId]: [string, number]) {
-    try {
-      const { totalUsers } = await fetchUsersInfo(chainId);
-      return {
-        totalUsers,
-      };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error("Error fetching usersInfo data:", error);
-      return {
-        totalUsers: 0n,
-      };
-    }
+    return fetchUsersInfo(chainId);
   }
 
   const { data: feesInfo } = useSWR(["v2UsersInfo", chainId], fetcher, {

--- a/src/domain/synthetics/stats/useV2FeesInfo.ts
+++ b/src/domain/synthetics/stats/useV2FeesInfo.ts
@@ -161,11 +161,8 @@ export default function useV2FeesInfo(chainId: number) {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(`Error fetching feesInfo data for chain ${chainId}:`, error);
-      return {
-        epochFees: 0n,
-        weeklyFees: 0n,
-        totalFees: 0n,
-      };
+      // a failed source stays unknown: a zero here would settle the network total as complete
+      return undefined;
     }
   }
 

--- a/src/domain/synthetics/stats/useV2Stats.ts
+++ b/src/domain/synthetics/stats/useV2Stats.ts
@@ -10,18 +10,23 @@ import useUsers from "../stats/useUsers";
 import useVolumeInfo from "../stats/useVolumeInfo";
 import { useTokensDataRequest } from "../tokens";
 
+// undefined means the source has not answered yet, which a dashboard total must not read as zero
 type DashboardOverview = {
-  totalGMLiquidity: bigint;
-  totalLongPositionSizes: bigint;
-  totalShortPositionSizes: bigint;
-  openInterest: bigint;
-  dailyVolume: bigint;
-  totalVolume: bigint;
-  weeklyFees: bigint;
-  epochFees: bigint;
-  totalFees: bigint;
-  totalUsers: bigint;
+  totalGMLiquidity: bigint | undefined;
+  totalLongPositionSizes: bigint | undefined;
+  totalShortPositionSizes: bigint | undefined;
+  openInterest: bigint | undefined;
+  dailyVolume: bigint | undefined;
+  totalVolume: bigint | undefined;
+  weeklyFees: bigint | undefined;
+  epochFees: bigint | undefined;
+  totalFees: bigint | undefined;
+  totalUsers: bigint | undefined;
 };
+
+function toBigInt(value: string | number | bigint | undefined | null): bigint | undefined {
+  return value === undefined || value === null ? undefined : BigInt(value);
+}
 
 export default function useV2Stats(chainId: ContractsChainId): DashboardOverview {
   const volumeInfo = useVolumeInfo(chainId);
@@ -31,33 +36,35 @@ export default function useV2Stats(chainId: ContractsChainId): DashboardOverview
   const usersInfo = useUsers(chainId);
 
   const stats = useMemo(() => {
-    const allMarkets = Object.values(marketsInfoData || {}).filter((market) => !market.isDisabled);
-    const totalLiquidity = allMarkets.reduce((acc, market) => {
+    const allMarkets = marketsInfoData
+      ? Object.values(marketsInfoData).filter((market) => !market.isDisabled)
+      : undefined;
+    const totalLiquidity = allMarkets?.reduce((acc, market) => {
       return acc + BigInt(market.poolValueMax ?? 0);
     }, 0n);
 
-    const totalLongInterestUsd = allMarkets.reduce((acc, market) => {
+    const totalLongInterestUsd = allMarkets?.reduce((acc, market) => {
       return acc + getOpenInterestForBalance(market, true);
     }, 0n);
 
-    const totalShortInterestUsd = allMarkets.reduce((acc, market) => {
+    const totalShortInterestUsd = allMarkets?.reduce((acc, market) => {
       return acc + getOpenInterestForBalance(market, false);
     }, 0n);
 
     return {
-      totalGMLiquidity: totalLiquidity ?? 0n,
-      totalLongPositionSizes: totalLongInterestUsd ?? 0n,
-      totalShortPositionSizes: totalShortInterestUsd ?? 0n,
+      totalGMLiquidity: totalLiquidity,
+      totalLongPositionSizes: totalLongInterestUsd,
+      totalShortPositionSizes: totalShortInterestUsd,
       openInterest:
         totalLongInterestUsd !== undefined && totalShortInterestUsd !== undefined
           ? totalLongInterestUsd + totalShortInterestUsd
-          : 0n,
-      dailyVolume: BigInt(volumeInfo?.dailyVolume ?? 0) || 0n,
-      totalVolume: BigInt(volumeInfo?.totalVolume ?? 0) || 0n,
-      weeklyFees: BigInt(feesInfo?.weeklyFees ?? 0) || 0n,
-      epochFees: BigInt(feesInfo?.epochFees ?? 0) || 0n,
-      totalFees: BigInt(feesInfo?.totalFees ?? 0) || 0n,
-      totalUsers: BigInt(usersInfo?.totalUsers ?? 0) || 0n,
+          : undefined,
+      dailyVolume: toBigInt(volumeInfo?.dailyVolume),
+      totalVolume: toBigInt(volumeInfo?.totalVolume),
+      weeklyFees: toBigInt(feesInfo?.weeklyFees),
+      epochFees: toBigInt(feesInfo?.epochFees),
+      totalFees: toBigInt(feesInfo?.totalFees),
+      totalUsers: toBigInt(usersInfo?.totalUsers),
     };
   }, [marketsInfoData, volumeInfo, feesInfo, usersInfo]);
 

--- a/src/domain/synthetics/stats/useVolumeInfo.ts
+++ b/src/domain/synthetics/stats/useVolumeInfo.ts
@@ -42,26 +42,15 @@ export default function useVolumeInfo(chainId: number) {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(`Error fetching volume data for chain ${chain}:`, error);
-      return {
-        dailyVolume: 0n,
-        totalVolume: 0n,
-      };
+      // a failed source stays unknown: a zero here would settle the network total as complete
+      return undefined;
     }
   }
 
   async function fetcher([, chainId]: [string, number]) {
     const lastPeriodFor24Hours = Math.floor(Date.now() / 1000 / 3600) * 3600 - 60 * 60 * 24;
-    try {
-      const { dailyVolume, totalVolume } = await fetchVolumeData(chainId, lastPeriodFor24Hours);
-      return {
-        dailyVolume,
-        totalVolume,
-      };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error("Error fetching volume data:", error);
-      return {};
-    }
+
+    return fetchVolumeData(chainId, lastPeriodFor24Hours);
   }
 
   const { data: volumes } = useSWR(["v2VolumeInfos", chainId], fetcher, {

--- a/src/lib/sumBigInts.spec.ts
+++ b/src/lib/sumBigInts.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { sumBigInts, sumKnownBigInts } from "./sumBigInts";
+
+describe("sumBigInts", () => {
+  it("counts a missing part as zero", () => {
+    expect(sumBigInts(2n, undefined, 3n)).toBe(5n);
+  });
+});
+
+describe("sumKnownBigInts", () => {
+  it("sums the parts when every one is known", () => {
+    expect(sumKnownBigInts(2n, 3, 4n)).toBe(9n);
+  });
+
+  it("keeps a real zero", () => {
+    expect(sumKnownBigInts(0n, 0n)).toBe(0n);
+  });
+
+  it("returns undefined when one part is missing", () => {
+    expect(sumKnownBigInts(2n, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when every part is missing", () => {
+    expect(sumKnownBigInts(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/src/lib/sumBigInts.tsx
+++ b/src/lib/sumBigInts.tsx
@@ -8,9 +8,12 @@ export function sumBigInts(...args: (bigint | number | undefined)[]) {
 
 // unknown if any part is unknown: a network whose half has not loaded must not settle as a number
 export function sumKnownBigInts(...args: (bigint | number | undefined)[]): bigint | undefined {
-  if (args.some((arg) => arg === undefined)) {
-    return undefined;
+  let sum = 0n;
+  for (const arg of args) {
+    if (arg === undefined) {
+      return undefined;
+    }
+    sum += BigInt(arg);
   }
-
-  return args.reduce<bigint>((sum, arg) => sum + BigInt(arg!), 0n);
+  return sum;
 }

--- a/src/lib/sumBigInts.tsx
+++ b/src/lib/sumBigInts.tsx
@@ -5,3 +5,12 @@ export function sumBigInts(...args: (bigint | number | undefined)[]) {
   }
   return sum;
 }
+
+// unknown if any part is unknown: a network whose half has not loaded must not settle as a number
+export function sumKnownBigInts(...args: (bigint | number | undefined)[]): bigint | undefined {
+  if (args.some((arg) => arg === undefined)) {
+    return undefined;
+  }
+
+  return args.reduce<bigint>((sum, arg) => sum + BigInt(arg!), 0n);
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4633,10 +4633,6 @@ msgstr "Wallet exportieren"
 msgid "20s"
 msgstr "20s"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "Virtuelle Markt-ID"
@@ -10652,6 +10648,10 @@ msgstr "Pool"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATIONSPREIS"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "Externer Swap vorübergehend deaktiviert. Versuchen Sie es erneut"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL in Vaults und Pools"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "Sonstige realisierte Gebühren"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "Erstellen Sie tBTC mit BTC über <0>Threshold</0>"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "Fehlgeschlagener TWAP-Teil"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "TWAP erstellen"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Slippage ist die Differenz zwischen deinem erwarteten und tatsächlichen Ausführungspreis aufgrund von Preisvolatilität. Orders werden nicht ausgeführt, wenn die Slippage dein erlaubtes Maximum überschreitet. Der Standardwert kann in den Einstellungen angepasst werden.<0/><1/>Ein niedriger Wert (z. B. weniger als -{0}) kann bei Volatilität zu fehlgeschlagenen Orders führen.<2/><3/>Hinweis: Slippage unterscheidet sich vom Preis-Impact, der auf Open-Interest-Ungleichgewichten basiert. <4>Mehr erfahren</4>."
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "In anderen Token"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "Einzeln"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "Investieren mit Kontrolle über Risiko und Rendite"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "Der Empfänger hat zuvor noch keine GLP-Token gestaked"
 msgid "Already live"
 msgstr "Bereits live"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "Gesamter realisierter und unrealisierter PnL einschließlich Gebühren u
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "In GMX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "Preiseinfluss beim Schließen"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "Öffnet GMTrade in einem neuen Tab"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "Updates"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "GMTrade öffnen"
 
@@ -11306,6 +11310,10 @@ msgstr "Geschätzte jährliche Rückkaufrate. Beim jüngsten Durchschnittstempo 
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "Der Export konnte nicht abgeschlossen werden. Es wurde keine Datei heruntergeladen."
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -4633,6 +4633,10 @@ msgstr "Wallet exportieren"
 msgid "20s"
 msgstr "20s"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "Virtuelle Markt-ID"
@@ -10648,10 +10652,6 @@ msgstr "Pool"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATIONSPREIS"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3999,6 +3999,10 @@ msgstr "Dieser Auslösepreis liegt jenseits des aktuellen Liquidationspreises. D
 msgid "Creating..."
 msgstr "Wird erstellt…"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "Einreichen..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "Poolstatistiken"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "Renditeoptimierte Tresore, die Liquidität über mehrere GMX Märkte bereitstellen"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "Analytics"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "wstETH APR"
@@ -9343,10 +9339,6 @@ msgstr "Eingesetztes Kapital = max(Summe der Sicherheiten offener Positionen - r
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "Annualisiert:"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "Liquidität verwalten"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL Long"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "Für detaillierte Statistiken"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -311,10 +311,6 @@ msgstr "Limit fehlgeschlagen"
 msgid "Performance"
 msgstr "Leistung"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Eröffnungsgebühren"
@@ -5535,6 +5531,10 @@ msgstr "Positiver Einflussfaktor"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "Alle Trades"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -311,6 +311,10 @@ msgstr "Limit fehlgeschlagen"
 msgid "Performance"
 msgstr "Leistung"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Eröffnungsgebühren"
@@ -4165,10 +4169,6 @@ msgstr "Fehlgeschlagener TWAP-Tauschteil"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "Annualisierte Daten basierend auf den letzten 7 Tagen"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "Worker-Thread"
@@ -5127,10 +5127,6 @@ msgstr "Das externe Routing ist nach einem fehlgeschlagenen Versuch vorübergehe
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Kaufe</0> {wrappedNativeTokenSymbol}."
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "Annualisierter Kaufdruck:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "Der Ausführungspreis kann aufgrund von Gebühren und Preiseinfluss vom 
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "Privat"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -5064,6 +5064,10 @@ msgstr "GMX-Genehmigung ausstehend..."
 msgid "AMOUNT"
 msgstr "BETRAG"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 24h Volumen: $1,01 Milliarden.</0><1>Vielen Dank an die Hundertt
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Einzahlungsbetrag eingeben"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4633,6 +4633,10 @@ msgstr "Export wallet"
 msgid "20s"
 msgstr "20s"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "Virtual market ID"
@@ -10648,10 +10652,6 @@ msgstr "Pool"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATION PRICE"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr "TVL includes GMX staked, GM pools, and position collateral"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3999,6 +3999,10 @@ msgstr "This trigger price is beyond the current liquidation price. Your positio
 msgid "Creating..."
 msgstr "Creating..."
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr "Annualized fees:"
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "Submitting..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr "Estimated time: ~5 min"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "Pools stats"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr "Create your referral code and earn rebates from your referrals"
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "Analytics"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "wstETH APR"
@@ -9343,10 +9339,6 @@ msgstr "Capital used = max(sum of collateral of open positions - realized PnL + 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "Annualized:"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "Manage liquidity"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL long"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "For detailed stats"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4633,10 +4633,6 @@ msgstr "Export wallet"
 msgid "20s"
 msgstr "20s"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "Virtual market ID"
@@ -10652,6 +10648,10 @@ msgstr "Pool"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATION PRICE"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr "TVL includes GMX staked, GM pools, and position collateral"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -311,10 +311,6 @@ msgstr "Failed Limit"
 msgid "Performance"
 msgstr "Performance"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Open fees"
@@ -5535,6 +5531,10 @@ msgstr "Positive impact factor"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "All trades"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "External swap temporarily disabled. Try again"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr "Enter the referral code and save up to 10% on fees"
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL in vaults and pools"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr "GMX on Solana"
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "Other realized fees"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "Mint tBTC using BTC with <0>Threshold</0>"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr "In other tokens:"
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "Failed TWAP part"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr "GMX on Solana (GMTrade) is currently served from a separate domain"
 
@@ -5644,10 +5650,6 @@ msgstr "Create TWAP"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "In other tokens"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "Single"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "Invest with control over risk and reward"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr "GMX on Solana (known as GMTrade) is currently served from a separate domain."
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "Receiver has not staked GLP tokens before"
 msgid "Already live"
 msgstr "Already live"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr "In GMX:"
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr "Claim rebates"
@@ -8652,10 +8662,6 @@ msgstr "Total realized and unrealized PnL including fees and price impact"
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "In GMX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "Close price impact"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "Opens GMTrade in a new tab"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "Updates"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "Open GMTrade"
 
@@ -11306,6 +11310,10 @@ msgstr "Estimated yearly buyback rate. At the recent average pace, GMX buybacks 
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "The export could not be completed. No file was downloaded."
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr "Open GMTrade in a new tab"
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Pending GMX approval..."
 msgid "AMOUNT"
 msgstr "AMOUNT"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr "Partial total: no data yet from {0}."
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 24h Volume: $1.01 Billion.</0><1>Thank you to the hundreds of th
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Enter deposit amount"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr "Included but not up to date: {0}."
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -311,6 +311,10 @@ msgstr "Failed Limit"
 msgid "Performance"
 msgstr "Performance"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Open fees"
@@ -4165,10 +4169,6 @@ msgstr "Failed TWAP Swap part"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr "No events in the past {DAYS_BACK} days"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "Annualized data based on the past 7 days"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "Worker thread"
@@ -5127,10 +5127,6 @@ msgstr "External routing is temporarily paused after a failed attempt.<0/><1/><2
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Buy</0> {wrappedNativeTokenSymbol}."
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "Annualized buy pressure:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "Execution price may differ from limit price due to fees and price impact
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "Private"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr "Annualized GMX buy pressure:"
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3999,6 +3999,10 @@ msgstr "Este precio de activación supera el precio de liquidación actual. Tu p
 msgid "Creating..."
 msgstr "Creando…"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "Enviando..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "Estadísticas de pools"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "Bóvedas optimizadas para rendimiento que suministran liquidez en múltiples mercados de GMX"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "Analíticas"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "APR de wstETH"
@@ -9343,10 +9339,6 @@ msgstr "Capital usado = max(suma de colateral de posiciones abiertas - PnL reali
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "Anualizado:"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "Gestionar liquidez"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL largo"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "Para estadísticas detalladas"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4633,6 +4633,10 @@ msgstr "Exportar monedero"
 msgid "20s"
 msgstr "20s"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "ID de mercado virtual"
@@ -10648,10 +10652,6 @@ msgstr "Reserva"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATION PRICE"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Aprobación de GMX pendiente..."
 msgid "AMOUNT"
 msgstr "CANTIDAD"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 Volumen 24h: $1.01 Mil Millones.</0><1>Gracias a los cientos de 
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Ingresa cantidad de depósito"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4633,10 +4633,6 @@ msgstr "Exportar monedero"
 msgid "20s"
 msgstr "20s"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "ID de mercado virtual"
@@ -10652,6 +10648,10 @@ msgstr "Reserva"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATION PRICE"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -311,10 +311,6 @@ msgstr "Límite Fallido"
 msgid "Performance"
 msgstr "Rendimiento"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Comisiones de apertura"
@@ -5535,6 +5531,10 @@ msgstr "Factor de impacto positivo"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "Todas las operaciones"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "Intercambio externo desactivado temporalmente. Inténtelo de nuevo"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL en bóvedas y pools"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "Otras comisiones realizadas"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "Acuñar tBTC utilizando BTC con <0>Threshold</0>"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "Parte de TWAP fallida"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "Crear TWAP"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "El deslizamiento es la diferencia entre el precio de ejecución esperado y el real debido a la volatilidad del precio. Las órdenes no se ejecutarán si el deslizamiento supera tu máximo permitido. El valor predeterminado puede ajustarse en la configuración.<0/><1/>Un valor bajo (por ejemplo, menos de -{0}) puede causar órdenes fallidas durante la volatilidad.<2/><3/>Nota: el deslizamiento es diferente del impacto en el precio, que se basa en desequilibrios del interés abierto. <4>Más información</4>."
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "En otros tokens"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "Simple"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "Invierte con control sobre riesgo y recompensa"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "El destinatario nunca ha hecho staking de tokens GLP"
 msgid "Already live"
 msgstr "Ya en producción"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "PnL total realizado y no realizado, incluyendo comisiones e impacto en e
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "En GMX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "Impacto en el precio de cierre"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "Abre GMTrade en una nueva pestaña"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "Actualizaciones"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "Abrir GMTrade"
 
@@ -11306,6 +11310,10 @@ msgstr "Tasa anual estimada de recompra. Al ritmo promedio reciente, las recompr
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "No se pudo completar la exportación. No se descargó ningún archivo."
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -311,6 +311,10 @@ msgstr "Límite Fallido"
 msgid "Performance"
 msgstr "Rendimiento"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Comisiones de apertura"
@@ -4165,10 +4169,6 @@ msgstr "Parte de TWAP Swap fallida"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "Datos anualizados basados en los últimos 7 días"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "Hilo de trabajo"
@@ -5127,10 +5127,6 @@ msgstr "El enrutamiento externo está pausado temporalmente tras un intento fall
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Comprar</0> {wrappedNativeTokenSymbol}."
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "Presión de compra anualizada:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "El precio de ejecución puede diferir del precio límite debido a las co
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "Privado"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4633,6 +4633,10 @@ msgstr "Exporter le portefeuille"
 msgid "20s"
 msgstr "20s"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "ID de marché virtuel"
@@ -10648,10 +10652,6 @@ msgstr "Pool"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATION PRICE"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "Swap externe temporairement désactivé. Veuillez réessayer"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL dans les coffres et les pools"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "Autres frais réalisés"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "Frappe de tBTC en utilisant BTC avec <0>Threshold</0>"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "Partie TWAP échouée"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "Créer TWAP"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Le slippage est la différence entre le prix d'exécution attendu et réel due à la volatilité des prix. Les ordres ne s'exécuteront pas si le slippage dépasse votre maximum autorisé. La valeur par défaut peut être ajustée dans les paramètres.<0/><1/>Une valeur faible (par ex. moins de -{0}) peut entraîner des ordres échoués pendant la volatilité.<2/><3/>Note : le slippage est différent de l'impact sur le prix, qui est basé sur les déséquilibres de l'intérêt ouvert. <4>En savoir plus</4>."
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "En autres tokens"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "Unique"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "Investir avec contrôle sur le risque et la récompense"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "Le destinataire n’a jamais staké de tokens GLP auparavant"
 msgid "Already live"
 msgstr "Déjà en ligne"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "PnL total réalisé et non réalisé, frais et impact sur le prix inclus
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "En GMX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "Impact sur le prix de clôture"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "Ouvre GMTrade dans un nouvel onglet"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "Mises à jour"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "Ouvrir GMTrade"
 
@@ -11306,6 +11310,10 @@ msgstr "Taux de rachat annuel estimé. Au rythme moyen récent, les rachats de G
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "L’exportation n’a pas pu être terminée. Aucun fichier n’a été téléchargé."
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -311,10 +311,6 @@ msgstr "Limite échouée"
 msgid "Performance"
 msgstr "Performance"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Frais d'ouverture"
@@ -5535,6 +5531,10 @@ msgstr "Facteur d'impact positif"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "Toutes les transactions"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -311,6 +311,10 @@ msgstr "Limite échouée"
 msgid "Performance"
 msgstr "Performance"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Frais d'ouverture"
@@ -4165,10 +4169,6 @@ msgstr "Partie TWAP Swap échouée"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "Données annualisées basées sur les 7 derniers jours"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "Thread Worker"
@@ -5127,10 +5127,6 @@ msgstr "Le routage externe est temporairement suspendu après une tentative éch
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Acheter</0> {wrappedNativeTokenSymbol}."
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "Pression d'achat annualisée :"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "Le prix d'exécution peut différer du prix limite en raison des frais e
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "Privé"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3999,6 +3999,10 @@ msgstr "Ce prix de déclenchement dépasse le prix de liquidation actuel. Votre 
 msgid "Creating..."
 msgstr "Création en cours…"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "Soumission..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "Statistiques des pools"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "Coffres optimisés pour le rendement fournissant de la liquidité sur plusieurs marchés GMX"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "Analytics"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "APR wstETH"
@@ -9343,10 +9339,6 @@ msgstr "Capital utilisé = max(somme du collatéral des positions ouvertes - PnL
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "Annualisé :"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "Gérer la liquidité"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL long"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "Pour des stats détaillées"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4633,10 +4633,6 @@ msgstr "Exporter le portefeuille"
 msgid "20s"
 msgstr "20s"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "ID de marché virtuel"
@@ -10652,6 +10648,10 @@ msgstr "Pool"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "LIQUIDATION PRICE"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Approbation GMX en attente..."
 msgid "AMOUNT"
 msgstr "MONTANT"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 Volume 24h : 1,01 milliard $.</0><1>Merci aux centaines de milli
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Entrez le montant de dépôt"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -311,10 +311,6 @@ msgstr "指値失敗"
 msgid "Performance"
 msgstr "パフォーマンス"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "オープン手数料"
@@ -5535,6 +5531,10 @@ msgstr "正の影響係数"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "すべての取引"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3999,6 +3999,10 @@ msgstr "このトリガー価格は現在の清算価格を超えています。
 msgid "Creating..."
 msgstr "作成中…"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "送信中..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "プール統計"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "複数のGMXマーケットに流動性を提供する利回り最適化ボールト"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "アナリティクス"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "wstETH APR"
@@ -9343,10 +9339,6 @@ msgstr "使用資本 = max(オープンポジションの担保合計 - 実現Pn
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "年率化:"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "流動性を管理"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL ロング"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "詳細統計のために"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "外部スワップが一時的に無効になっています。再度お試しください"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "ボールトおよびプール内のTVL"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "その他の実現手数料"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "<0>Threshold</0> を使用して BTC で tBTC をミントできます"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "TWAP パート失敗"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "TWAPを作成"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "スリッページとは、価格変動により予想約定価格と実際の約定価格の差です。スリッページが許容最大値を超えると注文は約定されません。デフォルト値は設定で調整できます。<0/><1/>低い値（例：-{0}未満）は、ボラティリティ時に注文失敗の原因となる場合があります。<2/><3/>注：スリッページは、オープンインタレストの不均衡に基づく価格影響とは異なります。<4>詳細はこちら</4>。"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "その他のトークン"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "シングル"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "リスクと報酬をコントロールして投資"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "受信者はこれまでGLPトークンをステークしていません
 msgid "Already live"
 msgstr "すでに稼働中"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "手数料と価格への影響を含む、実現損益および含み損
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "GMX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "決済時の価格への影響"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "GMTradeを新しいタブで開きます"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "アップデート"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "GMTradeを開く"
 
@@ -11306,6 +11310,10 @@ msgstr "推定年間バイバック率。直近の平均ペースでは、GMXの
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "エクスポートを完了できませんでした。ファイルはダウンロードされていません。"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -311,6 +311,10 @@ msgstr "指値失敗"
 msgid "Performance"
 msgstr "パフォーマンス"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "オープン手数料"
@@ -4165,10 +4169,6 @@ msgstr "TWAP スワップパート失敗"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "過去7日間に基づく年率換算データ"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "ワーカースレッド"
@@ -5127,10 +5127,6 @@ msgstr "外部ルーティングは失敗した試行の後、一時的に停止
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol}を購入</0>。"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "年間購入圧力："
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "手数料や価格への影響により、約定価格が指値と異な
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "プライベート"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4633,6 +4633,10 @@ msgstr "ウォレットをエクスポート"
 msgid "20s"
 msgstr "20秒"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "仮想マーケットID"
@@ -10648,10 +10652,6 @@ msgstr "プール"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "清算価格"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -5064,6 +5064,10 @@ msgstr "GMX の承認待ち..."
 msgid "AMOUNT"
 msgstr "金額"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 24時間ボリューム: 10.1億ドル。</0><1>パーミッシ�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "入金額を入力"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -4633,10 +4633,6 @@ msgstr "ウォレットをエクスポート"
 msgid "20s"
 msgstr "20秒"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "仮想マーケットID"
@@ -10652,6 +10648,10 @@ msgstr "プール"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "清算価格"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4633,10 +4633,6 @@ msgstr "지갑 내보내기"
 msgid "20s"
 msgstr "20초"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "가상 마켓 ID"
@@ -10652,6 +10648,10 @@ msgstr "풀"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "청산가"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -4633,6 +4633,10 @@ msgstr "지갑 내보내기"
 msgid "20s"
 msgstr "20초"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "가상 마켓 ID"
@@ -10648,10 +10652,6 @@ msgstr "풀"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "청산가"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -311,6 +311,10 @@ msgstr "지정가 실패"
 msgid "Performance"
 msgstr "성과"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "개시 수수료"
@@ -4165,10 +4169,6 @@ msgstr "TWAP 스왑 부분 실패"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "최근 7일 데이터 기반 연환산"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "워커 스레드"
@@ -5127,10 +5127,6 @@ msgstr "실패한 시도 이후 외부 라우팅이 일시적으로 중지되었
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol} 구매</0>."
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "연간 매수 압력:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "수수료 및 가격 영향으로 인해 체결가가 지정가와 다�
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "비공개"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "외부 스왑이 일시적으로 비활성화되었습니다. 다시 시도하십시오"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "금고 및 풀의 TVL"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "기타 실현 수수료"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "<0>Threshold</0>를 통해 BTC로 tBTC를 발행하십시오"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "TWAP 부분 실패"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "TWAP 생성"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "슬리피지는 가격 변동성으로 인해 예상 체결 가격과 실제 체결 가격의 차이입니다. 슬리피지가 허용 최대값을 초과하면 주문이 체결되지 않습니다. 기본값은 설정에서 조정할 수 있습니다.<0/><1/>낮은 값(예: -{0} 미만)은 변동성이 높을 때 주문 실패를 유발할 수 있습니다.<2/><3/>참고: 슬리피지는 미결제약정 불균형에 기반한 가격 영향과 다릅니다. <4>자세히 보기</4>."
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "기타 토큰"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "단일"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "위험과 보상을 제어하며 투자"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "수신자가 이전에 GLP 토큰을 스테이킹한 적이 없습니다
 msgid "Already live"
 msgstr "이미 운영 중"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "수수료 및 가격 영향을 포함한 총 실현 및 미실현 PnL"
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "GMX 보유분"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "청산 가격 영향"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "새 탭에서 GMTrade를 엽니다"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "업데이트"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "GMTrade 열기"
 
@@ -11306,6 +11310,10 @@ msgstr "추정 연간 바이백 비율. 최근 평균 속도라면 GMX 바이백
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "내보내기를 완료할 수 없습니다. 다운로드된 파일이 없습니다."
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3999,6 +3999,10 @@ msgstr "이 조건가는 현재 청산가를 초과합니다. 이 TP/SL 주문�
 msgid "Creating..."
 msgstr "생성 중…"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "제출 중..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "풀 통계"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "여러 GMX 마켓에 유동성을 공급하는 수익률 최적화 볼트"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "Analytics"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "wstETH APR"
@@ -9343,10 +9339,6 @@ msgstr "사용 자본 = max(열린 포지션 담보 합계 - 실현 PnL + 시작
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "연간화:"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "유동성 관리"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL 롱"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "상세 통계"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -5064,6 +5064,10 @@ msgstr "GMX 승인 대기 중..."
 msgid "AMOUNT"
 msgstr "금액"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 24시간 거래량: $1.01 Billion.</0><1>퍼미션리스 온체�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "입금 금액 입력"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -311,10 +311,6 @@ msgstr "지정가 실패"
 msgid "Performance"
 msgstr "성과"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "개시 수수료"
@@ -5535,6 +5531,10 @@ msgstr "긍정적 영향 계수"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "모든 거래"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -311,10 +311,6 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "[!! Open fees !!]"
@@ -5534,6 +5530,10 @@ msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
+msgstr ""
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4633,10 +4633,6 @@ msgstr ""
 msgid "20s"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr ""
@@ -10651,6 +10647,10 @@ msgstr ""
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
+msgstr ""
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr ""
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr ""
 
@@ -1116,6 +1115,10 @@ msgstr ""
 
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
+msgstr ""
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
 msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
@@ -4153,6 +4156,10 @@ msgstr "[!! Other realized fees !!]"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr ""
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr ""
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr ""
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5643,10 +5649,6 @@ msgstr ""
 
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
-msgstr ""
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
 msgstr ""
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
@@ -6134,6 +6136,10 @@ msgstr ""
 
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
+msgstr ""
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
 msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
@@ -8394,6 +8400,10 @@ msgstr ""
 msgid "Already live"
 msgstr ""
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8651,10 +8661,6 @@ msgstr ""
 
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
-msgstr ""
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr ""
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr ""
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr ""
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr ""
 
@@ -11305,6 +11309,10 @@ msgstr ""
 
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
+msgstr ""
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
 msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -5064,6 +5064,10 @@ msgstr ""
 msgid "AMOUNT"
 msgstr ""
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8728,6 +8732,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
+msgstr ""
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
 msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -3999,6 +3999,10 @@ msgstr ""
 msgid "Creating..."
 msgstr ""
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4829,10 +4833,6 @@ msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
-msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
 msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr ""
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr ""
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr ""
@@ -9342,10 +9338,6 @@ msgstr "[!! Capital used = max(sum of collateral of open positions - realized Pn
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
-msgstr ""
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
 msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
@@ -11898,10 +11890,6 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
-msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
 msgstr ""
 
 #: src/components/TenderlySettings/TenderlySettings.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -4633,6 +4633,10 @@ msgstr ""
 msgid "20s"
 msgstr ""
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr ""
@@ -10647,10 +10651,6 @@ msgstr ""
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
-msgstr ""
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -311,6 +311,10 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "[!! Open fees !!]"
@@ -4165,10 +4169,6 @@ msgstr ""
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr ""
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr ""
@@ -5126,10 +5126,6 @@ msgstr ""
 
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
-msgstr ""
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
 msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12807,6 +12803,10 @@ msgstr ""
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
+msgstr ""
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
 msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4633,6 +4633,10 @@ msgstr "Экспортировать кошелёк"
 msgid "20s"
 msgstr "20с"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "Виртуальный ID рынка"
@@ -10648,10 +10652,6 @@ msgstr "Пул"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "ЦЕНА ЛИКВИДАЦИИ"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -5064,6 +5064,10 @@ msgstr "Ожидание одобрения GMX..."
 msgid "AMOUNT"
 msgstr "СУММА"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 Объем за 24ч: $1.01 млрд.</0><1>Спасибо со�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "Введите сумму внесения"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -3999,6 +3999,10 @@ msgstr "Эта цена активации находится за предел�
 msgid "Creating..."
 msgstr "Создание…"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "Отправка..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "Статистика пулов"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "Оптимизированные по доходности хранилища, обеспечивающие ликвидность на нескольких рынках GMX"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "Аналитика"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "APR wstETH"
@@ -9343,10 +9339,6 @@ msgstr "Использованный капитал = max(сумма залог�
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "Годовое:"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "Управление ликвидностью"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL лонг"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "Для детальной статистики"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "Внешний своп временно отключён. Попробуйте снова"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL в хранилищах и пулах"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "Прочие реализованные комиссии"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "Выпуск tBTC с использованием BTC через <0>Threshold</0>"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "Ошибка части TWAP"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "Создать TWAP"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Проскальзывание — это разница между ожидаемой и фактической ценой исполнения из-за волатильности. Ордера не будут исполнены, если проскальзывание превысит максимально допустимое значение. Значение по умолчанию можно изменить в настройках.<0/><1/>Низкое значение (например, менее -{0}) может привести к неисполненным ордерам при волатильности.<2/><3/>Примечание: проскальзывание отличается от влияния на цену, которое основано на дисбалансе открытого интереса. <4>Подробнее</4>."
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "В других токенах"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "Одиночный"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "Инвестируйте с контролем над риском и вознаграждением"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "Получатель ранее не стейкал токены GLP"
 msgid "Already live"
 msgstr "Уже работают"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "Общий реализованный и нереализованный 
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "В GMX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "Влияние на цену при закрытии"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "Открывает GMTrade в новой вкладке"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "Обновления"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "Открыть GMTrade"
 
@@ -11306,6 +11310,10 @@ msgstr "Расчётная годовая ставка выкупа. При не
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "Не удалось завершить экспорт. Файл не был загружен."
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4633,10 +4633,6 @@ msgstr "Экспортировать кошелёк"
 msgid "20s"
 msgstr "20с"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "Виртуальный ID рынка"
@@ -10652,6 +10648,10 @@ msgstr "Пул"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "ЦЕНА ЛИКВИДАЦИИ"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -311,6 +311,10 @@ msgstr "Лимит не удался"
 msgid "Performance"
 msgstr "Производительность"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Комиссии за открытие"
@@ -4165,10 +4169,6 @@ msgstr "Ошибка части TWAP Swap"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "Годовые данные на основе последних 7 дней"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "Рабочий поток"
@@ -5127,10 +5127,6 @@ msgstr "Внешняя маршрутизация временно приост�
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Купить</0> {wrappedNativeTokenSymbol}."
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "Годовое давление на покупку:"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "Цена исполнения может отличаться от ли�
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "Приватный"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -311,10 +311,6 @@ msgstr "Лимит не удался"
 msgid "Performance"
 msgstr "Производительность"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "Комиссии за открытие"
@@ -5535,6 +5531,10 @@ msgstr "Фактор положительного влияния"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "Все сделки"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -5064,6 +5064,10 @@ msgstr "等待 GMX 授權中..."
 msgid "AMOUNT"
 msgstr "金額"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 24小時交易量：$10.1 億。</0><1>感謝數十萬 GMX 用�
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "請輸入存入金額"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -311,10 +311,6 @@ msgstr "限價單失敗"
 msgid "Performance"
 msgstr "績效"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "開倉費用"
@@ -5535,6 +5531,10 @@ msgstr "正向影響因子"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "所有交易"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4633,10 +4633,6 @@ msgstr "匯出錢包"
 msgid "20s"
 msgstr "20 秒"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "虛擬市場 ID"
@@ -10652,6 +10648,10 @@ msgstr "池"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "清算價格"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "外部兌換暫時停用。請重試"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "金庫與池中的 TVL"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "其他已實現費用"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "使用 BTC 透過 <0>Threshold</0> 鑄造 tBTC"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "TWAP 部分失敗"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "建立 TWAP"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "滑點是由於價格波動導致您的預期成交價格與實際成交價格之間的差異。若滑點超過您設定的最大容許值，訂單將不會執行。預設值可在設定中調整。<0/><1/>過低的值（例如低於 -{0}）可能導致在波動期間訂單失敗。<2/><3/>注意：滑點不同於價格影響，後者是基於未平倉量的不平衡。<4>閱讀更多</4>。"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "其他代幣"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "單一"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "掌控風險與收益的投資方式"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "接收者先前未曾質押 GLP 代幣"
 msgid "Already live"
 msgstr "已上線"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "包含費用和價格影響的已實現與未實現 PnL 總和"
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "GMX 中"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "平倉價格影響"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "在新分頁中開啟 GMTrade"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "更新"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "開啟 GMTrade"
 
@@ -11306,6 +11310,10 @@ msgstr "預計年度回購率。按近期平均速度，GMX 回購在一年內�
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "無法完成匯出。未下載任何檔案。"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -3999,6 +3999,10 @@ msgstr "此觸發價格超過目前清算價格。在此 TP/SL 訂單執行之�
 msgid "Creating..."
 msgstr "建立中..."
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "提交中..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "池統計"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "跨多個 GMX 市場提供流動性的收益優化金庫"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "分析"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "wstETH APR"
@@ -9343,10 +9339,6 @@ msgstr "已用資本 = max(未平倉倉位抵押品總和 - 已實現 PnL + 初�
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "年化："
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "管理流動性"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "做多 PnL"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "查看詳細統計"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -4633,6 +4633,10 @@ msgstr "匯出錢包"
 msgid "20s"
 msgstr "20 秒"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "虛擬市場 ID"
@@ -10648,10 +10652,6 @@ msgstr "池"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "清算價格"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -311,6 +311,10 @@ msgstr "限價單失敗"
 msgid "Performance"
 msgstr "績效"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "開倉費用"
@@ -4165,10 +4169,6 @@ msgstr "TWAP 兌換部分失敗"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "年化數據基於過去 7 天"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "工作執行緒"
@@ -5127,10 +5127,6 @@ msgstr "外部路由在一次失敗的嘗試後暫時暫停。<0/><1/><2>重試�
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>買入</0> {wrappedNativeTokenSymbol}。"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "年化買入壓力："
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "由於費用和價格影響，成交價格可能與限價不同。您將
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "私有"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -250,7 +250,6 @@ msgid "External swap temporarily disabled. Try again"
 msgstr "外部兑换暂时禁用。请重试"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMTrade"
 msgstr "GMTrade"
 
@@ -1117,6 +1116,10 @@ msgstr ""
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "金库和池中的 TVL"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana"
+msgstr ""
 
 #: src/components/Referrals/affiliates/dashboard/AffiliatesOverviewChartCards.tsx
 msgid "Volume traded by your referred traders"
@@ -4153,6 +4156,10 @@ msgstr "其他已实现费用"
 msgid "Mint tBTC using BTC with <0>Threshold</0>"
 msgstr "通过 <0>Threshold</0> 使用 BTC 铸造 tBTC"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In other tokens:"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed TWAP part"
 msgstr "TWAP 子单失败"
@@ -5325,7 +5332,6 @@ msgid "{secondLabel}"
 msgstr "{secondLabel}"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "GMX on Solana (GMTrade) is currently served from a separate domain"
 msgstr ""
 
@@ -5644,10 +5650,6 @@ msgstr "创建 TWAP"
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "滑点是由于价格波动导致的预期执行价格与实际执行价格之间的差异。如果滑点超过您允许的最大值，订单将不会执行。默认值可以在设置中调整。<0/><1/>低值（例如小于 -{0}）可能会在波动期间导致订单失败。<2/><3/>注意：滑点与基于未平仓合约不平衡的价格影响不同。<4>了解更多</4>。"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In other tokens"
-msgstr "其他代币部分"
 
 #: src/components/OrdersModal/AddTPSLModal.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -6135,6 +6137,10 @@ msgstr "单一"
 #: landing/src/pages/Home/LiqiuditySection/PoolCards.tsx
 msgid "Invest with control over risk and reward"
 msgstr "投资控制风险和回报"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "GMX on Solana (known as GMTrade) is currently served from a separate domain."
+msgstr ""
 
 #: landing/src/pages/Home/SponsorsSection/SponsorsSection.tsx
 msgid "Over 100 protocols"
@@ -8394,6 +8400,10 @@ msgstr "接收方此前未质押过 GLP 代币"
 msgid "Already live"
 msgstr "已上线"
 
+#: src/pages/Dashboard/StatsCard.tsx
+msgid "In GMX:"
+msgstr ""
+
 #: src/components/Referrals/shared/cards/ClaimableRebatesCard.tsx
 msgid "Claim rebates"
 msgstr ""
@@ -8652,10 +8662,6 @@ msgstr "已实现和未实现盈亏总计，包含费用和价格影响"
 #: landing/src/pages/Builders/ApiSurfacesSection/ApiSurfacesSection.tsx
 msgid "Squid GraphQL"
 msgstr "Squid GraphQL"
-
-#: src/pages/Dashboard/StatsCard.tsx
-msgid "In GMX"
-msgstr "GMX 中"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Dolomite"
@@ -9382,7 +9388,6 @@ msgid "Close price impact"
 msgstr "平仓价格影响"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Opens GMTrade in a new tab"
 msgstr "将在新标签页中打开 GMTrade"
 
@@ -10983,7 +10988,6 @@ msgid "Updates"
 msgstr "更新"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
-#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Open GMTrade"
 msgstr "打开 GMTrade"
 
@@ -11306,6 +11310,10 @@ msgstr "预计年度回购率。按近期平均速度，GMX 回购在一年内�
 #: src/components/HistoryExport/useHistoryExport.ts
 msgid "The export could not be completed. No file was downloaded."
 msgstr "无法完成导出。未下载任何文件。"
+
+#: src/components/NetworkDropdown/SolanaNetworkItem.tsx
+msgid "Open GMTrade in a new tab"
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy {nativeTokenSymbol} directly on <0>{chainName}</0>"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -311,10 +311,6 @@ msgstr "限价失败"
 msgid "Performance"
 msgstr "表现"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
-msgstr ""
-
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "开仓费用"
@@ -5535,6 +5531,10 @@ msgstr "正向影响因子"
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "All trades"
 msgstr "所有交易"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking more than 20% of your max historical staked GMX or esGMX will reset your accrued rewards."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3999,6 +3999,10 @@ msgstr "此触发价格超过当前清算价格。在此 TP/SL 订单执行之�
 msgid "Creating..."
 msgstr "正在创建…"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized fees:"
+msgstr ""
+
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 #: src/components/DelistingExitAnnouncements/delistingExitAnnouncementsLogic.ts
 msgid "{0, plural, one {is} other {are}}"
@@ -4830,10 +4834,6 @@ msgstr "提交中..."
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Estimated time: ~5 min"
 msgstr ""
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Pools stats"
-msgstr "池统计数据"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
@@ -7504,10 +7504,6 @@ msgstr ""
 msgid "Yield-optimized vaults supplying liquidity across multiple GMX markets"
 msgstr "收益优化金库，跨多个 GMX 市场提供流动性"
 
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "Analytics"
-msgstr "数据分析"
-
 #: src/components/AprInfo/AprInfo.tsx
 msgid "wstETH APR"
 msgstr "wstETH APR"
@@ -9343,10 +9339,6 @@ msgstr "已用资本 = max(未平仓仓位抵押品总和 - 已实现盈亏 + �
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "D2.Finance"
 msgstr "D2.Finance"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized:"
-msgstr "年化："
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 msgid "Trigger tickers failure"
@@ -11899,10 +11891,6 @@ msgstr "管理流动性"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "PnL long"
 msgstr "PnL 做多"
-
-#: src/pages/Dashboard/DashboardV2.tsx
-msgid "For detailed stats"
-msgstr "详细统计"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "Simulate transactions"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -311,6 +311,10 @@ msgstr "限价失败"
 msgid "Performance"
 msgstr "表现"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks."
+msgstr ""
+
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "Open fees"
 msgstr "开仓费用"
@@ -4165,10 +4169,6 @@ msgstr "TWAP 兑换子单失败"
 msgid "No events in the past {DAYS_BACK} days"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized data based on the past 7 days"
-msgstr "基于过去 7 天数据的年化计算"
-
 #: src/pages/RpcDebug/parts.tsx
 msgid "Worker thread"
 msgstr "Worker 线程"
@@ -5127,10 +5127,6 @@ msgstr "外部路由在一次失败的尝试后暂时暂停。<0/><1/><2>重试�
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>购买</0> {wrappedNativeTokenSymbol}。"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Annualized buy pressure:"
-msgstr "年化买入压力："
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -12808,6 +12804,10 @@ msgstr "由于费用和价格影响，成交价格可能与限价不同。您将
 #: src/pages/RpcDebug/parts.tsx
 msgid "Private"
 msgstr "私有"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "Annualized GMX buy pressure:"
+msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -5064,6 +5064,10 @@ msgstr "等待 GMX 授权中..."
 msgid "AMOUNT"
 msgstr "AMOUNT"
 
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Partial total: no data yet from {0}."
+msgstr ""
+
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
 msgid "Current margin excludes pending borrow and funding fees. Post-close margin reflects realized PnL and settled fees."
 msgstr ""
@@ -8729,6 +8733,10 @@ msgstr "<0>🔷 24 小时交易量：10.1 亿美元。</0><1>感谢数十万 GMX
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Enter deposit amount"
 msgstr "输入存入金额"
+
+#: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+msgid "Included but not up to date: {0}."
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4633,6 +4633,10 @@ msgstr "导出钱包"
 msgid "20s"
 msgstr "20 秒"
 
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "虚拟市场 ID"
@@ -10648,10 +10652,6 @@ msgstr "池子"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "清算价格"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral"
-msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4633,10 +4633,6 @@ msgstr "导出钱包"
 msgid "20s"
 msgstr "20 秒"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only."
-msgstr ""
-
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual market ID"
 msgstr "虚拟市场 ID"
@@ -10652,6 +10648,10 @@ msgstr "池子"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LIQUIDATION PRICE"
 msgstr "清算价格"
+
+#: src/pages/Dashboard/OverviewCard.tsx
+msgid "TVL includes GMX staked, GM pools, and position collateral"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Venus"

--- a/src/pages/Dashboard/DashboardV2.tsx
+++ b/src/pages/Dashboard/DashboardV2.tsx
@@ -1,5 +1,4 @@
-import { Trans, t } from "@lingui/macro";
-import { Link } from "react-router-dom";
+import { t } from "@lingui/macro";
 
 import { ARBITRUM, AVALANCHE } from "config/chains";
 import { SyntheticsStateContextProvider } from "context/SyntheticsStateContext/SyntheticsStateContextProvider";
@@ -13,11 +12,8 @@ import { bigMath } from "sdk/utils/bigmath";
 import AppPageLayout from "components/AppPageLayout/AppPageLayout";
 import { ChainContentHeader } from "components/ChainContentHeader/ChainContentHeader";
 import { BuybackDashboard } from "components/Earn/BuybackTracker/BuybackDashboard";
-import ExternalLink from "components/ExternalLink/ExternalLink";
 import { MarketsList } from "components/MarketsList/MarketsList";
 import PageTitle from "components/PageTitle/PageTitle";
-
-import V2Icon from "img/ic_v2.svg?react";
 
 import { GmCard } from "./GmCard";
 import { GmxCard } from "./GmxCard";
@@ -54,27 +50,7 @@ export default function DashboardV2() {
   return (
     <AppPageLayout title={t`Stats`} header={<ChainContentHeader />}>
       <div className="default-container DashboardV2 page-layout flex flex-col gap-20">
-        <PageTitle
-          title={t`Total stats`}
-          qa="dashboard-page"
-          subtitle={
-            <div className="flex items-center gap-6 font-medium text-typography-secondary">
-              <Trans>For detailed stats</Trans>{" "}
-              <ExternalLink
-                className="flex items-center gap-4 !no-underline hover:text-typography-primary"
-                href="https://dune.com/gmx-io/gmx-analytics"
-              >
-                <V2Icon className="size-15" /> <Trans>Analytics</Trans>
-              </ExternalLink>
-              <Link
-                className="flex items-center gap-4 text-typography-secondary !no-underline hover:text-typography-primary"
-                to="/monitor"
-              >
-                <V2Icon className="size-15" /> <Trans>Pools stats</Trans>
-              </Link>
-            </div>
-          }
-        />
+        <PageTitle title={t`Total stats`} qa="dashboard-page" />
         <div className="flex flex-col gap-20">
           <div className="DashboardV2-cards">
             <OverviewCard statsArbitrum={statsArbitrum} statsAvalanche={statsAvalanche} />

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -464,9 +464,7 @@ export function OverviewCard({
                   position="bottom-end"
                   content={
                     <>
-                      <Trans>
-                        TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only.
-                      </Trans>
+                      <Trans>TVL includes GMX staked, GM pools, and position collateral</Trans>
                       <br />
                       <br />
                       {tvlRows.map(({ label, value }) => (

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -126,6 +126,8 @@ export function OverviewCard({
   const gmTvlAvalanche = v2AvalancheOverview.totalGMLiquidity;
   const gmTvlMegaeth = v2MegaethOverview.totalGMLiquidity;
   const gmTvlGmtrade = parseProtocolStatsUsd(gmtradeOverview?.tvl?.pools);
+  // the store carries position collateral the way the EVM figures do, which the pool value on its own leaves out
+  const displayTvlGmtrade = parseProtocolStatsUsd(gmtradeOverview?.tvl?.store) ?? gmTvlGmtrade;
 
   const totalGmTvl = sumKnownBigInts(gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade);
 
@@ -153,7 +155,7 @@ export function OverviewCard({
     displayTvlArbitrum = stakedGmxUsdArbitrum + glpMarketCapArbitrum + gmTvlArbitrum + arbitrumPositionsMarginUsd;
     displayTvlAvalanche = stakedGmxUsdAvalanche + glpMarketCapAvalanche + gmTvlAvalanche + avalanchePositionsMarginUsd;
     displayTvlMegaeth = gmTvlMegaeth + megaethPositionsMarginUsd;
-    displayTvl = sumKnownBigInts(displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade);
+    displayTvl = sumKnownBigInts(displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, displayTvlGmtrade);
   }
 
   // #endregion TVL and GLP Pool
@@ -362,9 +364,9 @@ export function OverviewCard({
         { label: t`Arbitrum`, value: displayTvlArbitrum },
         { label: t`Avalanche`, value: displayTvlAvalanche },
         { label: "MegaETH", value: displayTvlMegaeth },
-        { label: "Solana", value: gmTvlGmtrade },
+        { label: "Solana", value: displayTvlGmtrade },
       ]),
-    [displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade]
+    [displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, displayTvlGmtrade]
   );
 
   const gmPoolRows = useMemo(

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -353,13 +353,12 @@ export function OverviewCard({
   }, []);
 
   const feesSubtotal = useMemo(() => {
-    // GMTrade allocates nothing to buybacks since 2026-01-16, so it only joins the annualized fees
-    const v1BuyingPressure = (((v1ArbitrumWeeklyFees ?? 0n) + (v1AvalancheWeeklyFees ?? 0n)) * 30n) / 100n;
-    const v2BuyingPressure =
+    // only GMX-buyback fee allocations feed this: GMTrade fees buy GT historically and nothing since 2026-01-16
+    const v1GmxBuyPressure = (((v1ArbitrumWeeklyFees ?? 0n) + (v1AvalancheWeeklyFees ?? 0n)) * 30n) / 100n;
+    const v2GmxBuyPressure =
       (((v2ArbitrumWeeklyFees ?? 0n) + (v2AvalancheWeeklyFees ?? 0n) + (v2MegaethWeeklyFees ?? 0n)) * 27n) / 100n;
     const annualizedTotal = (totalWeeklyFeesUsd * 365n) / 7n;
-    const totalBuyingPressure = v1BuyingPressure + v2BuyingPressure;
-    const annualizedTotalBuyingPressure = (totalBuyingPressure * 365n) / 7n;
+    const annualizedGmxBuyPressure = ((v1GmxBuyPressure + v2GmxBuyPressure) * 365n) / 7n;
 
     return (
       <>
@@ -372,12 +371,12 @@ export function OverviewCard({
         </p>
         <p className="Tooltip-row">
           <span className="label">
-            <Trans>Annualized buy pressure:</Trans>
+            <Trans>Annualized GMX buy pressure:</Trans>
           </span>
-          <span className="numbers">{formatAmountHuman(annualizedTotalBuyingPressure, USD_DECIMALS, true, 2)}</span>
+          <span className="numbers">{formatAmountHuman(annualizedGmxBuyPressure, USD_DECIMALS, true, 2)}</span>
         </p>
-        <p className="Tooltip-row !mt-16">
-          <Trans>Annualized data based on the past 7 days</Trans>
+        <p className="Tooltip-row !mt-16 max-w-[260px] whitespace-normal">
+          <Trans>Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks.</Trans>
         </p>
       </>
     );

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -464,7 +464,9 @@ export function OverviewCard({
                   position="bottom-end"
                   content={
                     <>
-                      <Trans>TVL includes GMX staked, GM pools, and position collateral</Trans>
+                      <Trans>
+                        TVL includes GMX staked, GM pools, and position collateral. Solana contributes GM pools only.
+                      </Trans>
                       <br />
                       <br />
                       {tvlRows.map(({ label, value }) => (

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -7,7 +7,7 @@ import { ARBITRUM, AVALANCHE, MEGAETH } from "config/chains";
 import { USD_DECIMALS } from "config/factors";
 import { useGmxPrice, useTotalGmxStaked } from "domain/legacy";
 import { useProtocolStatsFeesInfo } from "domain/protocolStats/useProtocolStatsFeesInfo";
-import { useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
+import { isProtocolStatsNetworkStale, useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
 import { parseProtocolStatsUsd } from "domain/protocolStats/utils";
 import { useV1FeesInfo, useVolumeInfo } from "domain/stats";
 import { usePositionsTotalMargin } from "domain/synthetics/positions/usePositionsTotalMargin";
@@ -43,6 +43,13 @@ function sortNetworkRows(rows: NetworkRow[]): NetworkRow[] {
   });
 }
 
+// a headline total stays unknown until every contribution is known, so a missing network never reads as zero
+function sumKnown(...parts: (bigint | undefined)[]): bigint | undefined {
+  return parts.some((part) => part === undefined) ? undefined : parts.reduce<bigint>((acc, part) => acc + part!, 0n);
+}
+
+const SOLANA_ENTRY = "Solana";
+
 export function OverviewCard({
   statsArbitrum,
   statsAvalanche,
@@ -56,7 +63,12 @@ export function OverviewCard({
   const v2ArbitrumOverview = useV2Stats(ARBITRUM);
   const v2AvalancheOverview = useV2Stats(AVALANCHE);
   const v2MegaethOverview = useV2Stats(MEGAETH);
-  const gmtradeOverview = useProtocolStatsSummary({ networks: ["solana"] }).data?.byNetwork.solana;
+  const gmtradeSummary = useProtocolStatsSummary({ networks: ["solana"] });
+  const gmtradeOverview = gmtradeSummary.data?.byNetwork.solana;
+  const staleTitles = useMemo(
+    () => (isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : []),
+    [gmtradeSummary.data]
+  );
   const gmtradeFees = useProtocolStatsFeesInfo({ networks: ["solana"] });
 
   const { data: positionStats } = useSWR<
@@ -120,7 +132,7 @@ export function OverviewCard({
   const gmTvlMegaeth = v2MegaethOverview.totalGMLiquidity;
   const gmTvlGmtrade = parseProtocolStatsUsd(gmtradeOverview?.tvl?.pools);
 
-  const totalGmTvl = gmTvlArbitrum + gmTvlAvalanche + gmTvlMegaeth + (gmTvlGmtrade ?? 0n);
+  const totalGmTvl = sumKnown(gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade);
 
   let displayTvlArbitrum: bigint | undefined = undefined;
   let displayTvlAvalanche: bigint | undefined = undefined;
@@ -134,7 +146,10 @@ export function OverviewCard({
     glpMarketCapAvalanche !== undefined &&
     arbitrumPositionsMarginUsd !== undefined &&
     avalanchePositionsMarginUsd !== undefined &&
-    megaethPositionsMarginUsd !== undefined
+    megaethPositionsMarginUsd !== undefined &&
+    gmTvlArbitrum !== undefined &&
+    gmTvlAvalanche !== undefined &&
+    gmTvlMegaeth !== undefined
   ) {
     const stakedGmxUsdArbitrum = bigMath.mulDiv(gmxPrice, stakedGmxArbitrum, expandDecimals(1, GMX_DECIMALS));
     const stakedGmxUsdAvalanche = bigMath.mulDiv(gmxPrice, stakedGmxAvalanche, expandDecimals(1, GMX_DECIMALS));
@@ -143,7 +158,7 @@ export function OverviewCard({
     displayTvlArbitrum = stakedGmxUsdArbitrum + glpMarketCapArbitrum + gmTvlArbitrum + arbitrumPositionsMarginUsd;
     displayTvlAvalanche = stakedGmxUsdAvalanche + glpMarketCapAvalanche + gmTvlAvalanche + avalanchePositionsMarginUsd;
     displayTvlMegaeth = gmTvlMegaeth + megaethPositionsMarginUsd;
-    displayTvl = displayTvlArbitrum + displayTvlAvalanche + displayTvlMegaeth + (gmTvlGmtrade ?? 0n);
+    displayTvl = sumKnown(displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade);
   }
 
   // #endregion TVL and GLP Pool
@@ -266,7 +281,7 @@ export function OverviewCard({
       Arbitrum: sumNetworkParts(v2ArbitrumOverview?.dailyVolume, v1ArbitrumDailyVolume),
       Avalanche: sumNetworkParts(v2AvalancheOverview?.dailyVolume, v1AvalancheDailyVolume),
       MegaETH: v2MegaethOverview?.dailyVolume,
-      Solana: gmtradeDailyVolume,
+      [SOLANA_ENTRY]: gmtradeDailyVolume,
     }),
     [
       gmtradeDailyVolume,
@@ -283,7 +298,7 @@ export function OverviewCard({
       Arbitrum: sumNetworkParts(v2ArbitrumOpenInterest, v1ArbitrumOpenInterest),
       Avalanche: sumNetworkParts(v2AvalancheOpenInterest, v1AvalancheOpenInterest),
       MegaETH: v2MegaethOpenInterest,
-      Solana: gmtradeOpenInterest,
+      [SOLANA_ENTRY]: gmtradeOpenInterest,
     }),
     [
       v1ArbitrumOpenInterest,
@@ -300,7 +315,7 @@ export function OverviewCard({
       Arbitrum: sumNetworkParts(v2ArbitrumLongPositionSizes, v1ArbitrumLongPositionSizes),
       Avalanche: sumNetworkParts(v2AvalancheLongPositionSizes, v1AvalancheLongPositionSizes),
       MegaETH: v2MegaethLongPositionSizes,
-      Solana: gmtradeLongPositionSizes,
+      [SOLANA_ENTRY]: gmtradeLongPositionSizes,
     }),
     [
       v1ArbitrumLongPositionSizes,
@@ -317,7 +332,7 @@ export function OverviewCard({
       Arbitrum: sumNetworkParts(v2ArbitrumShortPositionSizes, v1ArbitrumShortPositionSizes),
       Avalanche: sumNetworkParts(v2AvalancheShortPositionSizes, v1AvalancheShortPositionSizes),
       MegaETH: v2MegaethShortPositionSizes,
-      Solana: gmtradeShortPositionSizes,
+      [SOLANA_ENTRY]: gmtradeShortPositionSizes,
     }),
     [
       v1ArbitrumShortPositionSizes,
@@ -334,7 +349,7 @@ export function OverviewCard({
       Arbitrum: sumNetworkParts(v2ArbitrumEpochFees, v1ArbitrumEpochFees),
       Avalanche: sumNetworkParts(v2AvalancheEpochFees, v1AvalancheEpochFees),
       MegaETH: v2MegaethEpochFees,
-      Solana: gmtradeEpochFees,
+      [SOLANA_ENTRY]: gmtradeEpochFees,
     }),
     [
       v1ArbitrumEpochFees,
@@ -434,7 +449,13 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalEpochFeesUsd, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={epochFeesEntries} subtotal={feesSubtotal} />}
+                  content={
+                    <ChainsStatsTooltipRow
+                      entries={epochFeesEntries}
+                      subtotal={feesSubtotal}
+                      staleTitles={staleTitles}
+                    />
+                  }
                 />
               </div>
             </div>
@@ -518,7 +539,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalDailyVolume, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={dailyVolumeEntries} />}
+                  content={<ChainsStatsTooltipRow entries={dailyVolumeEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>
@@ -532,7 +553,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalOpenInterest, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={openInterestEntries} />}
+                  content={<ChainsStatsTooltipRow entries={openInterestEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>
@@ -546,7 +567,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalLongPositionSizes, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={totalLongPositionSizesEntries} />}
+                  content={<ChainsStatsTooltipRow entries={totalLongPositionSizesEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>
@@ -560,7 +581,7 @@ export function OverviewCard({
                   className="whitespace-nowrap"
                   handle={formatAmountHuman(totalShortPositionSizes, USD_DECIMALS, true, 2)}
                   handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={totalShortPositionSizesEntries} />}
+                  content={<ChainsStatsTooltipRow entries={totalShortPositionSizesEntries} staleTitles={staleTitles} />}
                 />
               </div>
             </div>

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -16,12 +16,12 @@ import { useChainId } from "lib/chains";
 import { arrayURLFetcher } from "lib/fetcher";
 import { GLP_DECIMALS, GMX_DECIMALS } from "lib/legacy";
 import { expandDecimals, formatAmountHuman } from "lib/numbers";
-import { sumBigInts } from "lib/sumBigInts";
+import { sumBigInts, sumKnownBigInts } from "lib/sumBigInts";
 import useWallet from "lib/wallets/useWallet";
 import { bigMath } from "sdk/utils/bigmath";
 
 import { AppCard, AppCardSection, AppCardSplit } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow, { sumNetworkParts } from "components/StatsTooltip/ChainsStatsTooltipRow";
+import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
 import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
 import TooltipComponent from "components/Tooltip/Tooltip";
 
@@ -41,11 +41,6 @@ function sortNetworkRows(rows: NetworkRow[]): NetworkRow[] {
 
     return a.value === b.value ? 0 : a.value > b.value ? -1 : 1;
   });
-}
-
-// a headline total stays unknown until every contribution is known, so a missing network never reads as zero
-function sumKnown(...parts: (bigint | undefined)[]): bigint | undefined {
-  return parts.some((part) => part === undefined) ? undefined : parts.reduce<bigint>((acc, part) => acc + part!, 0n);
 }
 
 const SOLANA_ENTRY = "Solana";
@@ -132,7 +127,7 @@ export function OverviewCard({
   const gmTvlMegaeth = v2MegaethOverview.totalGMLiquidity;
   const gmTvlGmtrade = parseProtocolStatsUsd(gmtradeOverview?.tvl?.pools);
 
-  const totalGmTvl = sumKnown(gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade);
+  const totalGmTvl = sumKnownBigInts(gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade);
 
   let displayTvlArbitrum: bigint | undefined = undefined;
   let displayTvlAvalanche: bigint | undefined = undefined;
@@ -158,7 +153,7 @@ export function OverviewCard({
     displayTvlArbitrum = stakedGmxUsdArbitrum + glpMarketCapArbitrum + gmTvlArbitrum + arbitrumPositionsMarginUsd;
     displayTvlAvalanche = stakedGmxUsdAvalanche + glpMarketCapAvalanche + gmTvlAvalanche + avalanchePositionsMarginUsd;
     displayTvlMegaeth = gmTvlMegaeth + megaethPositionsMarginUsd;
-    displayTvl = sumKnown(displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade);
+    displayTvl = sumKnownBigInts(displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade);
   }
 
   // #endregion TVL and GLP Pool
@@ -278,8 +273,8 @@ export function OverviewCard({
 
   const dailyVolumeEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.dailyVolume, v1ArbitrumDailyVolume),
-      Avalanche: sumNetworkParts(v2AvalancheOverview?.dailyVolume, v1AvalancheDailyVolume),
+      Arbitrum: sumKnownBigInts(v2ArbitrumOverview?.dailyVolume, v1ArbitrumDailyVolume),
+      Avalanche: sumKnownBigInts(v2AvalancheOverview?.dailyVolume, v1AvalancheDailyVolume),
       MegaETH: v2MegaethOverview?.dailyVolume,
       [SOLANA_ENTRY]: gmtradeDailyVolume,
     }),
@@ -295,8 +290,8 @@ export function OverviewCard({
 
   const openInterestEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumOpenInterest, v1ArbitrumOpenInterest),
-      Avalanche: sumNetworkParts(v2AvalancheOpenInterest, v1AvalancheOpenInterest),
+      Arbitrum: sumKnownBigInts(v2ArbitrumOpenInterest, v1ArbitrumOpenInterest),
+      Avalanche: sumKnownBigInts(v2AvalancheOpenInterest, v1AvalancheOpenInterest),
       MegaETH: v2MegaethOpenInterest,
       [SOLANA_ENTRY]: gmtradeOpenInterest,
     }),
@@ -312,8 +307,8 @@ export function OverviewCard({
 
   const totalLongPositionSizesEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumLongPositionSizes, v1ArbitrumLongPositionSizes),
-      Avalanche: sumNetworkParts(v2AvalancheLongPositionSizes, v1AvalancheLongPositionSizes),
+      Arbitrum: sumKnownBigInts(v2ArbitrumLongPositionSizes, v1ArbitrumLongPositionSizes),
+      Avalanche: sumKnownBigInts(v2AvalancheLongPositionSizes, v1AvalancheLongPositionSizes),
       MegaETH: v2MegaethLongPositionSizes,
       [SOLANA_ENTRY]: gmtradeLongPositionSizes,
     }),
@@ -329,8 +324,8 @@ export function OverviewCard({
 
   const totalShortPositionSizesEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumShortPositionSizes, v1ArbitrumShortPositionSizes),
-      Avalanche: sumNetworkParts(v2AvalancheShortPositionSizes, v1AvalancheShortPositionSizes),
+      Arbitrum: sumKnownBigInts(v2ArbitrumShortPositionSizes, v1ArbitrumShortPositionSizes),
+      Avalanche: sumKnownBigInts(v2AvalancheShortPositionSizes, v1AvalancheShortPositionSizes),
       MegaETH: v2MegaethShortPositionSizes,
       [SOLANA_ENTRY]: gmtradeShortPositionSizes,
     }),
@@ -346,8 +341,8 @@ export function OverviewCard({
 
   const epochFeesEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumEpochFees, v1ArbitrumEpochFees),
-      Avalanche: sumNetworkParts(v2AvalancheEpochFees, v1AvalancheEpochFees),
+      Arbitrum: sumKnownBigInts(v2ArbitrumEpochFees, v1ArbitrumEpochFees),
+      Avalanche: sumKnownBigInts(v2AvalancheEpochFees, v1AvalancheEpochFees),
       MegaETH: v2MegaethEpochFees,
       [SOLANA_ENTRY]: gmtradeEpochFees,
     }),
@@ -393,7 +388,7 @@ export function OverviewCard({
   }, []);
 
   const feesSubtotal = useMemo(() => {
-    // only GMX-buyback fee allocations feed this: GMTrade fees buy GT historically and nothing since 2026-01-16
+    // only GMX-buyback fee allocations feed this: solana fees bought GT historically and nothing since 2026-01-16
     const v1GmxBuyPressure = (((v1ArbitrumWeeklyFees ?? 0n) + (v1AvalancheWeeklyFees ?? 0n)) * 30n) / 100n;
     const v2GmxBuyPressure =
       (((v2ArbitrumWeeklyFees ?? 0n) + (v2AvalancheWeeklyFees ?? 0n) + (v2MegaethWeeklyFees ?? 0n)) * 27n) / 100n;
@@ -415,7 +410,7 @@ export function OverviewCard({
           <span className="numbers">{formatAmountHuman(annualizedGmxBuyPressure, USD_DECIMALS, true, 2)}</span>
         </p>
         <p className="Tooltip-row !mt-16 max-w-[260px] whitespace-normal">
-          <Trans>Annualized data based on the past 7 days. GMTrade fees do not contribute to GMX buybacks.</Trans>
+          <Trans>Annualized data based on the past 7 days. Solana fees do not contribute to GMX buybacks.</Trans>
         </p>
       </>
     );

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -21,7 +21,7 @@ import useWallet from "lib/wallets/useWallet";
 import { bigMath } from "sdk/utils/bigmath";
 
 import { AppCard, AppCardSection, AppCardSplit } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
+import ChainsStatsTooltipRow, { sumNetworkParts } from "components/StatsTooltip/ChainsStatsTooltipRow";
 import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
 import TooltipComponent from "components/Tooltip/Tooltip";
 
@@ -29,6 +29,19 @@ import { ACTIVE_CHAIN_IDS } from "./DashboardV2";
 import { getFormattedFeesDuration } from "./getFormattedFeesDuration";
 import { getPositionStats } from "./getPositionStats";
 import type { ChainStats } from "./useDashboardChainStatsMulticall";
+
+type NetworkRow = { label: string; value: bigint | undefined };
+
+// highest first, with a network whose value has not arrived yet kept last rather than ordered as zero
+function sortNetworkRows(rows: NetworkRow[]): NetworkRow[] {
+  return [...rows].sort((a, b) => {
+    if (a.value === undefined || b.value === undefined) {
+      return a.value === b.value ? 0 : a.value === undefined ? 1 : -1;
+    }
+
+    return a.value === b.value ? 0 : a.value > b.value ? -1 : 1;
+  });
+}
 
 export function OverviewCard({
   statsArbitrum,
@@ -250,12 +263,10 @@ export function OverviewCard({
 
   const dailyVolumeEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.dailyVolume,
-      "V2 Avalanche": v2AvalancheOverview?.dailyVolume,
-      "V2 MegaETH": v2MegaethOverview?.dailyVolume,
-      "V1 Arbitrum": v1ArbitrumDailyVolume,
-      "V1 Avalanche": v1AvalancheDailyVolume,
-      "GMTrade Solana": gmtradeDailyVolume,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.dailyVolume, v1ArbitrumDailyVolume),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.dailyVolume, v1AvalancheDailyVolume),
+      MegaETH: v2MegaethOverview?.dailyVolume,
+      Solana: gmtradeDailyVolume,
     }),
     [
       gmtradeDailyVolume,
@@ -269,12 +280,10 @@ export function OverviewCard({
 
   const openInterestEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOpenInterest,
-      "V2 Avalanche": v2AvalancheOpenInterest,
-      "V2 MegaETH": v2MegaethOpenInterest,
-      "V1 Avalanche": v1AvalancheOpenInterest,
-      "V1 Arbitrum": v1ArbitrumOpenInterest,
-      "GMTrade Solana": gmtradeOpenInterest,
+      Arbitrum: sumNetworkParts(v2ArbitrumOpenInterest, v1ArbitrumOpenInterest),
+      Avalanche: sumNetworkParts(v2AvalancheOpenInterest, v1AvalancheOpenInterest),
+      MegaETH: v2MegaethOpenInterest,
+      Solana: gmtradeOpenInterest,
     }),
     [
       v1ArbitrumOpenInterest,
@@ -288,12 +297,10 @@ export function OverviewCard({
 
   const totalLongPositionSizesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumLongPositionSizes,
-      "V2 Avalanche": v2AvalancheLongPositionSizes,
-      "V2 MegaETH": v2MegaethLongPositionSizes,
-      "V1 Arbitrum": v1ArbitrumLongPositionSizes,
-      "V1 Avalanche": v1AvalancheLongPositionSizes,
-      "GMTrade Solana": gmtradeLongPositionSizes,
+      Arbitrum: sumNetworkParts(v2ArbitrumLongPositionSizes, v1ArbitrumLongPositionSizes),
+      Avalanche: sumNetworkParts(v2AvalancheLongPositionSizes, v1AvalancheLongPositionSizes),
+      MegaETH: v2MegaethLongPositionSizes,
+      Solana: gmtradeLongPositionSizes,
     }),
     [
       v1ArbitrumLongPositionSizes,
@@ -307,12 +314,10 @@ export function OverviewCard({
 
   const totalShortPositionSizesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumShortPositionSizes,
-      "V2 Avalanche": v2AvalancheShortPositionSizes,
-      "V2 MegaETH": v2MegaethShortPositionSizes,
-      "V1 Arbitrum": v1ArbitrumShortPositionSizes,
-      "V1 Avalanche": v1AvalancheShortPositionSizes,
-      "GMTrade Solana": gmtradeShortPositionSizes,
+      Arbitrum: sumNetworkParts(v2ArbitrumShortPositionSizes, v1ArbitrumShortPositionSizes),
+      Avalanche: sumNetworkParts(v2AvalancheShortPositionSizes, v1AvalancheShortPositionSizes),
+      MegaETH: v2MegaethShortPositionSizes,
+      Solana: gmtradeShortPositionSizes,
     }),
     [
       v1ArbitrumShortPositionSizes,
@@ -326,12 +331,10 @@ export function OverviewCard({
 
   const epochFeesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumEpochFees,
-      "V2 Avalanche": v2AvalancheEpochFees,
-      "V2 MegaETH": v2MegaethEpochFees,
-      "V1 Arbitrum": v1ArbitrumEpochFees,
-      "V1 Avalanche": v1AvalancheEpochFees,
-      "GMTrade Solana": gmtradeEpochFees,
+      Arbitrum: sumNetworkParts(v2ArbitrumEpochFees, v1ArbitrumEpochFees),
+      Avalanche: sumNetworkParts(v2AvalancheEpochFees, v1AvalancheEpochFees),
+      MegaETH: v2MegaethEpochFees,
+      Solana: gmtradeEpochFees,
     }),
     [
       v1ArbitrumEpochFees,
@@ -341,6 +344,28 @@ export function OverviewCard({
       v2MegaethEpochFees,
       gmtradeEpochFees,
     ]
+  );
+
+  const tvlRows = useMemo(
+    () =>
+      sortNetworkRows([
+        { label: t`Arbitrum`, value: displayTvlArbitrum },
+        { label: t`Avalanche`, value: displayTvlAvalanche },
+        { label: "MegaETH", value: displayTvlMegaeth },
+        { label: "Solana", value: gmTvlGmtrade },
+      ]),
+    [displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, gmTvlGmtrade]
+  );
+
+  const gmPoolRows = useMemo(
+    () =>
+      sortNetworkRows([
+        { label: t`Arbitrum`, value: gmTvlArbitrum },
+        { label: t`Avalanche`, value: gmTvlAvalanche },
+        { label: "MegaETH", value: gmTvlMegaeth },
+        { label: "Solana", value: gmTvlGmtrade },
+      ]),
+    [gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade]
   );
 
   const [formattedDuration, setFormattedDuration] = useState(() => getFormattedFeesDuration());
@@ -427,28 +452,14 @@ export function OverviewCard({
                       <Trans>TVL includes GMX staked, GM pools, and position collateral</Trans>
                       <br />
                       <br />
-                      <StatsTooltipRow
-                        label={t`Arbitrum`}
-                        showDollar={false}
-                        value={formatAmountHuman(displayTvlArbitrum, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label={t`Avalanche`}
-                        showDollar={false}
-                        value={formatAmountHuman(displayTvlAvalanche, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label="MegaETH"
-                        showDollar={false}
-                        value={formatAmountHuman(displayTvlMegaeth, USD_DECIMALS, true, 2)}
-                      />
-                      {gmTvlGmtrade !== undefined && (
+                      {tvlRows.map(({ label, value }) => (
                         <StatsTooltipRow
-                          label="Solana (GMTrade)"
+                          key={label}
+                          label={label}
                           showDollar={false}
-                          value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
+                          value={formatAmountHuman(value, USD_DECIMALS, true, 2)}
                         />
-                      )}
+                      ))}
                       <div className="!my-8 h-1 bg-gray-800" />
                       <StatsTooltipRow
                         label={t`Total`}
@@ -474,28 +485,14 @@ export function OverviewCard({
                       <Trans>Total value of tokens in GM pools</Trans>
                       <br />
                       <br />
-                      <StatsTooltipRow
-                        label={t`Arbitrum`}
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlArbitrum, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label={t`Avalanche`}
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlAvalanche, USD_DECIMALS, true, 2)}
-                      />
-                      <StatsTooltipRow
-                        label="MegaETH"
-                        showDollar={false}
-                        value={formatAmountHuman(gmTvlMegaeth, USD_DECIMALS, true, 2)}
-                      />
-                      {gmTvlGmtrade !== undefined && (
+                      {gmPoolRows.map(({ label, value }) => (
                         <StatsTooltipRow
-                          label="Solana (GMTrade)"
+                          key={label}
+                          label={label}
                           showDollar={false}
-                          value={formatAmountHuman(gmTvlGmtrade, USD_DECIMALS, true, 2)}
+                          value={formatAmountHuman(value, USD_DECIMALS, true, 2)}
                         />
-                      )}
+                      ))}
                       <div className="!my-8 h-1 bg-gray-800" />
                       <StatsTooltipRow
                         label={t`Total`}

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -402,10 +402,9 @@ export function OverviewCard({
 
     return (
       <>
-        <div className="my-5 h-1 bg-gray-800" />
-        <p className="Tooltip-row">
+        <p className="Tooltip-row !mt-12">
           <span className="label">
-            <Trans>Annualized:</Trans>
+            <Trans>Annualized fees:</Trans>
           </span>
           <span className="numbers">{formatAmountHuman(annualizedTotal, USD_DECIMALS, true, 2)}</span>
         </p>

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -35,11 +35,17 @@ type NetworkRow = { label: string; value: bigint | undefined };
 // highest first, with a network whose value has not arrived yet kept last rather than ordered as zero
 function sortNetworkRows(rows: NetworkRow[]): NetworkRow[] {
   return [...rows].sort((a, b) => {
-    if (a.value === undefined || b.value === undefined) {
-      return a.value === b.value ? 0 : a.value === undefined ? 1 : -1;
+    if (a.value === b.value) {
+      return 0;
+    }
+    if (a.value === undefined) {
+      return 1;
+    }
+    if (b.value === undefined) {
+      return -1;
     }
 
-    return a.value === b.value ? 0 : a.value > b.value ? -1 : 1;
+    return a.value > b.value ? -1 : 1;
   });
 }
 
@@ -60,10 +66,7 @@ export function OverviewCard({
   const v2MegaethOverview = useV2Stats(MEGAETH);
   const gmtradeSummary = useProtocolStatsSummary({ networks: ["solana"] });
   const gmtradeOverview = gmtradeSummary.data?.byNetwork.solana;
-  const staleTitles = useMemo(
-    () => (isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : []),
-    [gmtradeSummary.data]
-  );
+  const staleTitles = isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : [];
   const gmtradeFees = useProtocolStatsFeesInfo({ networks: ["solana"] });
 
   const { data: positionStats } = useSWR<

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -42,10 +42,7 @@ export function StatsCard() {
   const v2MegaethOverview = useV2Stats(MEGAETH);
   const gmtradeSummary = useProtocolStatsSummary({ networks: ["solana"] });
   const gmtradeStats = gmtradeSummary.data?.byNetwork.solana;
-  const staleTitles = useMemo(
-    () => (isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : []),
-    [gmtradeSummary.data]
-  );
+  const staleTitles = isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : [];
   const gmtradeTotalFees = parseProtocolStatsUsd(gmtradeStats?.fees.total);
   const gmtradeTotalVolume = parseProtocolStatsUsd(gmtradeStats?.volume.total);
   // users.all counts a wallet on its first action of any kind, the same basis as the V2 totalUsers entries

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -225,11 +225,11 @@ export function StatsCard() {
               content={
                 <div>
                   <StatsTooltipRow
-                    label={<Trans>In other tokens</Trans>}
+                    label={<Trans>In other tokens:</Trans>}
                     value={formatAmountHuman(treasuryWithoutGmxUsd, USD_DECIMALS, false, 2)}
                   />
                   <StatsTooltipRow
-                    label={<Trans>In GMX</Trans>}
+                    label={<Trans>In GMX:</Trans>}
                     value={formatAmountHuman(gmxInTreasuryUsd, USD_DECIMALS, false, 2)}
                   />
                 </div>

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -15,7 +15,7 @@ import { MARKETS } from "sdk/configs/markets";
 import { getTokenBySymbol } from "sdk/configs/tokens";
 
 import { AppCard, AppCardSection } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
+import ChainsStatsTooltipRow, { sumNetworkParts } from "components/StatsTooltip/ChainsStatsTooltipRow";
 import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
 import TooltipComponent from "components/Tooltip/Tooltip";
 import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
@@ -78,12 +78,10 @@ export function StatsCard() {
 
   const totalFeesEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.totalFees,
-      "V2 Avalanche": v2AvalancheOverview?.totalFees,
-      "V2 MegaETH": v2MegaethOverview?.totalFees,
-      "V1 Arbitrum": v1ArbitrumTotalFees?.totalFees,
-      "V1 Avalanche": v1AvalancheTotalFees?.totalFees,
-      "GMTrade Solana": gmtradeTotalFees,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalFees, v1ArbitrumTotalFees?.totalFees),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalFees, v1AvalancheTotalFees?.totalFees),
+      MegaETH: v2MegaethOverview?.totalFees,
+      Solana: gmtradeTotalFees,
     }),
     [
       v1AvalancheTotalFees?.totalFees,
@@ -97,12 +95,10 @@ export function StatsCard() {
 
   const totalVolumeEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.totalVolume,
-      "V2 Avalanche": v2AvalancheOverview?.totalVolume,
-      "V2 MegaETH": v2MegaethOverview?.totalVolume,
-      "V1 Arbitrum": v1TotalVolume?.[ARBITRUM],
-      "V1 Avalanche": v1TotalVolume?.[AVALANCHE],
-      "GMTrade Solana": gmtradeTotalVolume,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalVolume, v1TotalVolume?.[ARBITRUM]),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalVolume, v1TotalVolume?.[AVALANCHE]),
+      MegaETH: v2MegaethOverview?.totalVolume,
+      Solana: gmtradeTotalVolume,
     }),
     [
       v1TotalVolume,
@@ -115,12 +111,10 @@ export function StatsCard() {
 
   const uniqueUsersEntries = useMemo(
     () => ({
-      "V2 Arbitrum": v2ArbitrumOverview?.totalUsers,
-      "V2 Avalanche": v2AvalancheOverview?.totalUsers,
-      "V2 MegaETH": v2MegaethOverview?.totalUsers,
-      "V1 Arbitrum": uniqueUsers?.[ARBITRUM],
-      "V1 Avalanche": uniqueUsers?.[AVALANCHE],
-      "GMTrade Solana": gmtradeUsers,
+      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalUsers, uniqueUsers?.[ARBITRUM]),
+      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalUsers, uniqueUsers?.[AVALANCHE]),
+      MegaETH: v2MegaethOverview?.totalUsers,
+      Solana: gmtradeUsers,
     }),
     [
       gmtradeUsers,

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -10,12 +10,12 @@ import { useTreasuryAllChains } from "domain/stats/treasury/useTreasuryAllChains
 import useUniqueUsers from "domain/stats/useUniqueUsers";
 import useV2Stats from "domain/synthetics/stats/useV2Stats";
 import { formatAmountHuman } from "lib/numbers";
-import { sumBigInts } from "lib/sumBigInts";
+import { sumBigInts, sumKnownBigInts } from "lib/sumBigInts";
 import { MARKETS } from "sdk/configs/markets";
 import { getTokenBySymbol } from "sdk/configs/tokens";
 
 import { AppCard, AppCardSection } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow, { sumNetworkParts } from "components/StatsTooltip/ChainsStatsTooltipRow";
+import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
 import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
 import TooltipComponent from "components/Tooltip/Tooltip";
 import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
@@ -85,8 +85,8 @@ export function StatsCard() {
 
   const totalFeesEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalFees, v1ArbitrumTotalFees?.totalFees),
-      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalFees, v1AvalancheTotalFees?.totalFees),
+      Arbitrum: sumKnownBigInts(v2ArbitrumOverview?.totalFees, v1ArbitrumTotalFees?.totalFees),
+      Avalanche: sumKnownBigInts(v2AvalancheOverview?.totalFees, v1AvalancheTotalFees?.totalFees),
       MegaETH: v2MegaethOverview?.totalFees,
       [SOLANA_ENTRY]: gmtradeTotalFees,
     }),
@@ -102,8 +102,8 @@ export function StatsCard() {
 
   const totalVolumeEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalVolume, v1TotalVolume?.[ARBITRUM]),
-      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalVolume, v1TotalVolume?.[AVALANCHE]),
+      Arbitrum: sumKnownBigInts(v2ArbitrumOverview?.totalVolume, v1TotalVolume?.[ARBITRUM]),
+      Avalanche: sumKnownBigInts(v2AvalancheOverview?.totalVolume, v1TotalVolume?.[AVALANCHE]),
       MegaETH: v2MegaethOverview?.totalVolume,
       [SOLANA_ENTRY]: gmtradeTotalVolume,
     }),
@@ -118,8 +118,8 @@ export function StatsCard() {
 
   const uniqueUsersEntries = useMemo(
     () => ({
-      Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalUsers, uniqueUsers?.[ARBITRUM]),
-      Avalanche: sumNetworkParts(v2AvalancheOverview?.totalUsers, uniqueUsers?.[AVALANCHE]),
+      Arbitrum: sumKnownBigInts(v2ArbitrumOverview?.totalUsers, uniqueUsers?.[ARBITRUM]),
+      Avalanche: sumKnownBigInts(v2AvalancheOverview?.totalUsers, uniqueUsers?.[AVALANCHE]),
       MegaETH: v2MegaethOverview?.totalUsers,
       [SOLANA_ENTRY]: gmtradeUsers,
     }),

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 
 import { ARBITRUM, AVALANCHE, MEGAETH, ContractsChainIdProduction } from "config/chains";
 import { USD_DECIMALS } from "config/factors";
-import { useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
+import { isProtocolStatsNetworkStale, useProtocolStatsSummary } from "domain/protocolStats/useProtocolStatsSummary";
 import { parseProtocolStatsUsd } from "domain/protocolStats/utils";
 import { useTotalVolume, useV1FeesInfo } from "domain/stats";
 import { useTreasuryAllChains } from "domain/stats/treasury/useTreasuryAllChains";
@@ -32,13 +32,20 @@ const gmGmxTokenAddresses = chains.map((chain) =>
 );
 const gmxGmAndTokensAddresses = [...gmxTokenAddresses, ...gmGmxTokenAddresses];
 
+const SOLANA_ENTRY = "Solana";
+
 export function StatsCard() {
   const v1TotalVolume = useTotalVolume();
 
   const v2ArbitrumOverview = useV2Stats(ARBITRUM);
   const v2AvalancheOverview = useV2Stats(AVALANCHE);
   const v2MegaethOverview = useV2Stats(MEGAETH);
-  const gmtradeStats = useProtocolStatsSummary({ networks: ["solana"] }).data?.byNetwork.solana;
+  const gmtradeSummary = useProtocolStatsSummary({ networks: ["solana"] });
+  const gmtradeStats = gmtradeSummary.data?.byNetwork.solana;
+  const staleTitles = useMemo(
+    () => (isProtocolStatsNetworkStale(gmtradeSummary.data, "solana") ? [SOLANA_ENTRY] : []),
+    [gmtradeSummary.data]
+  );
   const gmtradeTotalFees = parseProtocolStatsUsd(gmtradeStats?.fees.total);
   const gmtradeTotalVolume = parseProtocolStatsUsd(gmtradeStats?.volume.total);
   // users.all counts a wallet on its first action of any kind, the same basis as the V2 totalUsers entries
@@ -81,7 +88,7 @@ export function StatsCard() {
       Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalFees, v1ArbitrumTotalFees?.totalFees),
       Avalanche: sumNetworkParts(v2AvalancheOverview?.totalFees, v1AvalancheTotalFees?.totalFees),
       MegaETH: v2MegaethOverview?.totalFees,
-      Solana: gmtradeTotalFees,
+      [SOLANA_ENTRY]: gmtradeTotalFees,
     }),
     [
       v1AvalancheTotalFees?.totalFees,
@@ -98,7 +105,7 @@ export function StatsCard() {
       Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalVolume, v1TotalVolume?.[ARBITRUM]),
       Avalanche: sumNetworkParts(v2AvalancheOverview?.totalVolume, v1TotalVolume?.[AVALANCHE]),
       MegaETH: v2MegaethOverview?.totalVolume,
-      Solana: gmtradeTotalVolume,
+      [SOLANA_ENTRY]: gmtradeTotalVolume,
     }),
     [
       v1TotalVolume,
@@ -114,7 +121,7 @@ export function StatsCard() {
       Arbitrum: sumNetworkParts(v2ArbitrumOverview?.totalUsers, uniqueUsers?.[ARBITRUM]),
       Avalanche: sumNetworkParts(v2AvalancheOverview?.totalUsers, uniqueUsers?.[AVALANCHE]),
       MegaETH: v2MegaethOverview?.totalUsers,
-      Solana: gmtradeUsers,
+      [SOLANA_ENTRY]: gmtradeUsers,
     }),
     [
       gmtradeUsers,
@@ -141,7 +148,7 @@ export function StatsCard() {
               className="whitespace-nowrap"
               handle={formatAmountHuman(totalFeesUsd, USD_DECIMALS, true, 2)}
               handleClassName="numbers"
-              content={<ChainsStatsTooltipRow entries={totalFeesEntries} />}
+              content={<ChainsStatsTooltipRow entries={totalFeesEntries} staleTitles={staleTitles} />}
             />
           </div>
         </div>
@@ -168,7 +175,7 @@ export function StatsCard() {
                 2
               )}
               handleClassName="numbers"
-              content={<ChainsStatsTooltipRow entries={totalVolumeEntries} />}
+              content={<ChainsStatsTooltipRow entries={totalVolumeEntries} staleTitles={staleTitles} />}
             />
           </div>
         </div>
@@ -196,7 +203,12 @@ export function StatsCard() {
               )}
               handleClassName="numbers"
               content={
-                <ChainsStatsTooltipRow showDollar={false} entries={uniqueUsersEntries} decimalsForConversion={0} />
+                <ChainsStatsTooltipRow
+                  showDollar={false}
+                  entries={uniqueUsersEntries}
+                  decimalsForConversion={0}
+                  staleTitles={staleTitles}
+                />
               }
             />
           </div>


### PR DESCRIPTION
FEDEV-4292, FEDEV-4293, FEDEV-4294, FEDEV-4295.

One row per network in the Total stats tooltips, sorted by value, with a source that has not answered or is lagging named instead of being summed as zero. The Solana TVL now comes from the store value gmx-io/gmx-api#186 reports, so it carries position collateral like the other networks.

Supersedes #2840, #2841 and #2842.