### PR TITLE
Show a loading state instead of Connect wallet while the session is restored FEDEV-4253

### DIFF
--- a/src/components/AppHeader/AppHeaderUser.tsx
+++ b/src/components/AppHeader/AppHeaderUser.tsx
@@ -4,12 +4,14 @@ import { NETWORK_OPTIONS } from "config/networkOptions";
 import { useConnectModal } from "context/ConnectModalContext/ConnectModalContext";
 import { useChainId } from "lib/chains";
 import { sendUserAnalyticsConnectWalletClickEvent } from "lib/userAnalytics";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 import useWallet from "lib/wallets/useWallet";
 
 import { SettingsButton } from "components/SettingsButton/SettingsButton";
 
 import { AddressDropdown } from "../AddressDropdown/AddressDropdown";
 import ConnectWalletButton from "../ConnectWalletButton/ConnectWalletButton";
+import ConnectWalletPlaceholder from "../ConnectWalletButton/ConnectWalletPlaceholder";
 import NetworkDropdown from "../NetworkDropdown/NetworkDropdown";
 
 type Props = {
@@ -20,6 +22,7 @@ type Props = {
 export function AppHeaderUser({ openSettings, menuToggle }: Props) {
   const { chainId: settlementChainId, srcChainId } = useChainId();
   const { active, account } = useWallet();
+  const isWalletInitializing = useIsWalletInitializing();
   const { openConnectModal } = useConnectModal();
 
   const visualChainId = srcChainId ?? settlementChainId;
@@ -27,14 +30,18 @@ export function AppHeaderUser({ openSettings, menuToggle }: Props) {
   if (!active || !account) {
     return (
       <div className="flex items-center gap-8">
-        <ConnectWalletButton
-          onClick={() => {
-            sendUserAnalyticsConnectWalletClickEvent("Header");
-            openConnectModal?.();
-          }}
-        >
-          <Trans>Connect wallet</Trans>
-        </ConnectWalletButton>
+        {isWalletInitializing ? (
+          <ConnectWalletPlaceholder />
+        ) : (
+          <ConnectWalletButton
+            onClick={() => {
+              sendUserAnalyticsConnectWalletClickEvent("Header");
+              openConnectModal?.();
+            }}
+          >
+            <Trans>Connect wallet</Trans>
+          </ConnectWalletButton>
+        )}
         <SettingsButton openSettings={openSettings} />
         <NetworkDropdown chainId={visualChainId} networkOptions={NETWORK_OPTIONS} />
         {menuToggle ? menuToggle : null}

--- a/src/components/ConnectWalletButton/ConnectWalletPlaceholder.tsx
+++ b/src/components/ConnectWalletButton/ConnectWalletPlaceholder.tsx
@@ -1,0 +1,24 @@
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
+
+import "react-loading-skeleton/dist/skeleton.css";
+import "components/Skeleton/Skeleton.scss";
+
+export default function ConnectWalletPlaceholder() {
+  return (
+    <SkeletonTheme baseColor="#B4BBFF0D" highlightColor="#B4BBFF0D">
+      <span
+        data-qa="wallet-initializing"
+        className="flex h-40 items-center gap-8 rounded-8 bg-button-secondary px-12 max-md:h-32 max-md:px-10"
+      >
+        <Skeleton circle inline width="100%" height="100%" containerClassName="flex size-24 max-md:size-16" />
+        <Skeleton
+          inline
+          width="100%"
+          height="100%"
+          borderRadius={4}
+          containerClassName="flex h-14 w-[88px] max-md:w-[56px] max-smallMobile:hidden"
+        />
+      </span>
+    </SkeletonTheme>
+  );
+}

--- a/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
@@ -55,6 +55,7 @@ import { isCustomError } from "lib/errors";
 import { adjustForDecimals, formatBalanceAmount } from "lib/numbers";
 import { getByKey } from "lib/objects";
 import { useHasOutdatedUi } from "lib/useHasOutdatedUi";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 import useWallet from "lib/wallets/useWallet";
 import { bigMath } from "sdk/utils/bigmath";
 import { GmSwapFees } from "sdk/utils/trade/types";
@@ -133,6 +134,7 @@ export const useGmSwapSubmitState = ({
   const multipleWalletExtensionsChainError = useMultipleWalletExtensionsChainError();
   const { openConnectModal } = useConnectModal();
   const { account } = useWallet();
+  const isWalletInitializing = useIsWalletInitializing();
 
   const {
     glvTokenAmount = 0n,
@@ -393,6 +395,13 @@ export const useGmSwapSubmitState = ({
 
   return useMemo((): SubmitButtonState => {
     if (!account) {
+      if (isWalletInitializing) {
+        return {
+          text: t`Connecting wallet...`,
+          disabled: true,
+        };
+      }
+
       return {
         text: t`Connect wallet`,
         onSubmit: onConnectAccount,
@@ -516,6 +525,7 @@ export const useGmSwapSubmitState = ({
     };
   }, [
     account,
+    isWalletInitializing,
     isAvalancheGmxAccountWarning,
     multipleWalletExtensionsChainError,
     isAllowanceLoading,

--- a/src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+++ b/src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
@@ -14,6 +14,7 @@ import { useMultipleWalletExtensionsChainError } from "lib/chains/getMultipleWal
 import { useHasOutdatedUi } from "lib/useHasOutdatedUi";
 import { userAnalytics } from "lib/userAnalytics";
 import type { TokenApproveClickEvent, TokenApproveResultEvent } from "lib/userAnalytics/types";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 import type { GmSwapFees } from "sdk/utils/trade/types";
 
 import SpinnerIcon from "img/ic_spinner.svg?react";
@@ -50,6 +51,7 @@ export function useShiftSubmitState({
 }) {
   const chainId = useSelector(selectChainId);
   const account = useSelector(selectAccount);
+  const isWalletInitializing = useIsWalletInitializing();
   const hasOutdatedUi = useHasOutdatedUi();
   const multipleWalletExtensionsChainError = useMultipleWalletExtensionsChainError();
 
@@ -104,6 +106,13 @@ export function useShiftSubmitState({
     }
 
     if (!account) {
+      if (isWalletInitializing) {
+        return {
+          text: t`Connecting wallet...`,
+          disabled: true,
+        };
+      }
+
       return {
         text: t`Connect wallet`,
         onSubmit: () => openConnectModal?.(),
@@ -188,6 +197,7 @@ export function useShiftSubmitState({
     isSubmitting,
     isAllowanceLoading,
     account,
+    isWalletInitializing,
     chainId,
     hasOutdatedUi,
     selectedMarketInfo,

--- a/src/components/Referrals/affiliates/ReferralsAffiliatesTab.tsx
+++ b/src/components/Referrals/affiliates/ReferralsAffiliatesTab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { registerReferralCode, TotalReferralsStats, useTiers } from "domain/referrals";
 import { getSharePercentage } from "domain/referrals/utils/referralsHelper";
 import { useChainId } from "lib/chains";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 import useWallet from "lib/wallets/useWallet";
 
 import { Faq } from "components/Faq/Faq";
@@ -51,8 +52,9 @@ export function ReferralsAffiliatesTab({
   const hasRecentCode = recentCodes.length > 0;
   const isSomeReferralCodeAvailable = ownsSomeChainCode || hasRecentCode;
   const handleGoToAffiliateDashboard = useCallback(() => setForceDashboard(true), []);
+  const isWalletInitializing = useIsWalletInitializing();
 
-  if (isLoading) return <Loader />;
+  if (isLoading || isWalletInitializing) return <Loader />;
 
   const isWizard = !forceDashboard && !hasAddressInUrl && (!account || !isSomeReferralCodeAvailable);
 

--- a/src/components/Referrals/distributions/ReferralsDistributionsTab.tsx
+++ b/src/components/Referrals/distributions/ReferralsDistributionsTab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { ContractsChainId } from "config/chains";
 import { TotalReferralsStats } from "domain/referrals";
 import { useChainId } from "lib/chains";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 
 import Loader from "components/Loader/Loader";
 import usePagination from "components/Pagination/usePagination";
@@ -40,8 +41,9 @@ export function ReferralsDistributionsTab({ isLoading, account, referralsData }:
   }, []);
 
   const currentRebateData = getCurrentRebateData();
+  const isWalletInitializing = useIsWalletInitializing();
 
-  if (isLoading) return <Loader />;
+  if (isLoading || isWalletInitializing) return <Loader />;
 
   if (!account) {
     return (

--- a/src/components/Referrals/traders/ReferralsTradersTab.tsx
+++ b/src/components/Referrals/traders/ReferralsTradersTab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { useUserReferralCode } from "domain/referrals";
 import { useChainId } from "lib/chains";
 import { isHashZero } from "lib/legacy";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 
 import { Faq } from "components/Faq/Faq";
 import Loader from "components/Loader/Loader";
@@ -22,9 +23,10 @@ export function ReferralsTradersTab({ isLoading, account, hasAddressInUrl = fals
   const [forceDashboard, setForceDashboard] = useState(false);
   const { chainId } = useChainId();
   const { userReferralCode, isLoading: isUserReferralCodeLoading } = useUserReferralCode(chainId, account);
+  const isWalletInitializing = useIsWalletInitializing();
   const handleGoToTraderDashboard = useCallback(() => setForceDashboard(true), []);
 
-  if (isLoading || isUserReferralCodeLoading) {
+  if (isLoading || isUserReferralCodeLoading || isWalletInitializing) {
     return <Loader />;
   }
 

--- a/src/components/TradeBox/hooks/useTradeButtonState.tsx
+++ b/src/components/TradeBox/hooks/useTradeButtonState.tsx
@@ -87,6 +87,7 @@ import { useHasOutdatedUi } from "lib/useHasOutdatedUi";
 import { sendUserAnalyticsConnectWalletClickEvent, userAnalytics } from "lib/userAnalytics";
 import type { TokenApproveClickEvent, TokenApproveResultEvent } from "lib/userAnalytics/types";
 import { useEthersSigner } from "lib/wallets/useEthersSigner";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 import { getContract } from "sdk/configs/contracts";
 import { getToken, getTokenBySymbol } from "sdk/configs/tokens";
 import { ExecutionFee } from "sdk/utils/fees/types";
@@ -166,6 +167,7 @@ export function useTradeboxButtonState({
 
   const { setPendingTxns } = usePendingTxns();
   const { openConnectModal } = useConnectModal();
+  const isWalletInitializing = useIsWalletInitializing();
 
   const {
     onSubmitWrapOrUnwrap,
@@ -507,6 +509,14 @@ export function useTradeboxButtonState({
       isExpressLoading,
     };
 
+    if (!account && isWalletInitializing) {
+      return {
+        ...commonState,
+        text: t`Connecting wallet...`,
+        disabled: true,
+      };
+    }
+
     if (!account && buttonErrorText) {
       return {
         ...commonState,
@@ -666,6 +676,7 @@ export function useTradeboxButtonState({
     isMultichainSubmitDisabled,
     isWaitingForExternalSwapQuote,
     account,
+    isWalletInitializing,
     buttonErrorText,
     shouldShowDepositButton,
     stopLoss.error?.percentage,

--- a/src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+++ b/src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -23,6 +23,7 @@ import { GM_DECIMALS } from "lib/legacy";
 import { expandDecimals, formatBalanceAmount, formatUsd } from "lib/numbers";
 import { useBreakpoints } from "lib/useBreakpoints";
 import { shortenAddressOrEns } from "lib/wallets";
+import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
 import useWallet from "lib/wallets/useWallet";
 import { getPublicClientWithRpc } from "lib/wallets/walletConfig";
 import { getTokens } from "sdk/configs/tokens";
@@ -97,6 +98,7 @@ function getNormalizedIncentive(
 
 export default function UserIncentiveDistribution() {
   const { account, active } = useWallet();
+  const isWalletInitializing = useIsWalletInitializing();
   const { openConnectModal } = useConnectModal();
   const { chainId, srcChainId } = useChainId();
   const tokens = getTokens(chainId);
@@ -149,7 +151,7 @@ export default function UserIncentiveDistribution() {
                     handle={t`No distribution history`}
                     content={t`Incentives, airdrops, and prizes will appear here`}
                   />
-                  {!active ? (
+                  {!active && !isWalletInitializing ? (
                     <div className="mt-15">
                       <Button variant="primary" onClick={openConnectModal}>
                         <WalletIcon className="size-16" />

--- a/src/lib/wallets/WalletProvider.tsx
+++ b/src/lib/wallets/WalletProvider.tsx
@@ -13,6 +13,7 @@ import { watchInjectedProviderAnnouncements } from "./announceInjectedProviders"
 import { PRIVY_STYLIS_PLUGINS } from "./privyUiCompat";
 import {
   getWagmiConfig,
+  getWagmiInitialState,
   getSupportedChains,
   PRIVY_APP_ID,
   PRIVY_LOGIN_METHODS,
@@ -60,7 +61,9 @@ export default function WalletProvider({ children }: { children: React.ReactNode
     <StyleSheetManager stylisPlugins={PRIVY_STYLIS_PLUGINS}>
       <PrivyProvider appId={PRIVY_APP_ID} config={privyConfig}>
         <QueryClientProvider client={queryClient}>
-          <WagmiProvider config={getWagmiConfig()}>{children}</WagmiProvider>
+          <WagmiProvider config={getWagmiConfig()} initialState={getWagmiInitialState()}>
+            {children}
+          </WagmiProvider>
         </QueryClientProvider>
       </PrivyProvider>
     </StyleSheetManager>

--- a/src/lib/wallets/useIsWalletInitializing.ts
+++ b/src/lib/wallets/useIsWalletInitializing.ts
@@ -1,12 +1,22 @@
 import { usePrivy, useWallets } from "@privy-io/react-auth";
-import { useAccount } from "wagmi";
+import { useCallback, useSyncExternalStore } from "react";
+import { useAccount, useConfig } from "wagmi";
 
-// @privy-io/wagmi forces reconnectOnMount: false, so while Privy restores the session on page load
-// wagmi reports plain "disconnected" (never "reconnecting")
 export function useIsWalletInitializing(): boolean {
-  const { address: account, isConnecting, isReconnecting } = useAccount();
+  const config = useConfig();
+  const { address: account } = useAccount();
   const { ready: isPrivyReady } = usePrivy();
   const { ready: isWalletsReady, wallets } = useWallets();
 
-  return !isPrivyReady || !isWalletsReady || (wallets.length > 0 && !account) || isConnecting || isReconnecting;
+  const subscribe = useCallback(
+    (onChange: () => void) => config.subscribe((state) => state.current, onChange),
+    [config]
+  );
+  const hasRememberedConnection = useSyncExternalStore(subscribe, () => config.state.current !== null);
+
+  if (account || !hasRememberedConnection) {
+    return false;
+  }
+
+  return !isPrivyReady || !isWalletsReady || wallets.length > 0;
 }

--- a/src/lib/wallets/walletConfig.spec.ts
+++ b/src/lib/wallets/walletConfig.spec.ts
@@ -1,8 +1,9 @@
+import { serialize } from "@wagmi/core";
 import { describe, expect, it } from "vitest";
 
 import { ARBITRUM, DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
 
-import { getSupportedChains } from "./walletConfig";
+import { getSupportedChains, getWagmiInitialState } from "./walletConfig";
 
 describe("getSupportedChains", () => {
   it("uses Arbitrum as the default settlement chain", () => {
@@ -19,5 +20,29 @@ describe("getSupportedChains", () => {
     const chainIds = getSupportedChains().map((chain) => chain.id);
 
     expect(new Set(chainIds).size).toBe(chainIds.length);
+  });
+});
+
+describe("getWagmiInitialState", () => {
+  // wagmi 2.19 runs store.setState(getInitialState()) inside createConfig, and with the ssr: true that
+  // @privy-io/wagmi forces (skipHydration) the persist middleware writes that empty state back before
+  // hydration, wiping `current` — wagmi's own marker of a restorable session. Reading the store before
+  // createConfig and handing it to WagmiProvider as initialState keeps it. Drop this once createConfig
+  // stops persisting its initial state or Privy stops forcing ssr.
+  it("hands the persisted connection to wagmi as initialState", () => {
+    localStorage.setItem(
+      "wagmi.store",
+      serialize({
+        state: {
+          connections: new Map([["connector-uid", { accounts: ["0x1"], chainId: 42161 }]]),
+          chainId: 42161,
+          current: "connector-uid",
+        },
+        version: 2,
+      })
+    );
+
+    expect(getWagmiInitialState()?.current).toBe("connector-uid");
+    expect(getWagmiInitialState()?.chainId).toBe(42161);
   });
 });

--- a/src/lib/wallets/walletConfig.ts
+++ b/src/lib/wallets/walletConfig.ts
@@ -1,4 +1,5 @@
 import { createConfig } from "@privy-io/wagmi";
+import { deserialize } from "@wagmi/core";
 import once from "lodash/once";
 import {
   Chain,
@@ -10,6 +11,7 @@ import {
   webSocket,
   WebSocketTransport,
 } from "viem";
+import type { State } from "wagmi";
 
 import { DEFAULT_SETTLEMENT_CHAIN_ID, getViemChain, isTestnetChain } from "config/chains";
 import { isDevelopment } from "config/env";
@@ -55,6 +57,10 @@ export function getSupportedChains(): [Chain, ...Chain[]] {
   return [defaultChain, ...chains.filter((chain) => chain.id !== defaultChain.id)] as [Chain, ...Chain[]];
 }
 
+const WAGMI_STORE_KEY = "wagmi.store";
+
+let persistedWagmiState: State | undefined;
+
 export const getWagmiConfig = once(() => {
   const chains = getSupportedChains();
 
@@ -67,11 +73,37 @@ export const getWagmiConfig = once(() => {
     {} as Record<number, Transport>
   );
 
+  persistedWagmiState = readPersistedWagmiState();
+
   return createConfig({
     chains,
     transports,
   });
 });
+
+export function getWagmiInitialState(): State | undefined {
+  getWagmiConfig();
+
+  return persistedWagmiState;
+}
+
+function readPersistedWagmiState(): State | undefined {
+  if (typeof localStorage === "undefined") {
+    return undefined;
+  }
+
+  const persisted = localStorage.getItem(WAGMI_STORE_KEY);
+
+  if (persisted === null) {
+    return undefined;
+  }
+
+  try {
+    return (deserialize(persisted) as { state?: State }).state;
+  } catch {
+    return undefined;
+  }
+}
 
 const TRANSPORTS_CACHE = new LRUCache<Transport>(100);
 const PUBLIC_CLIENTS_CACHE = new LRUCache<PublicClient>(100);

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -482,6 +482,12 @@ msgstr "Prozentsatz"
 msgid "Swap UI fee"
 msgstr "Swap-UI-Gebühr"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "Wallet wird verbunden..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "Keine TP-Orders"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -482,6 +482,12 @@ msgstr "Percentage"
 msgid "Swap UI fee"
 msgstr "Swap UI fee"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "Connecting wallet..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "No TP orders"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -482,6 +482,12 @@ msgstr "Porcentaje"
 msgid "Swap UI fee"
 msgstr "Comisión de interfaz de intercambio"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "Conectando billetera..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "Sin órdenes de Take-Profit"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -482,6 +482,12 @@ msgstr "Pourcentage"
 msgid "Swap UI fee"
 msgstr "Frais d'interface de swap"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "Connexion du portefeuille..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "Aucun ordre Take-Profit"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -482,6 +482,12 @@ msgstr "割合"
 msgid "Swap UI fee"
 msgstr "スワップUI手数料"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "ウォレットを接続中..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "テイクプロフィット注文はありません"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -482,6 +482,12 @@ msgstr "비율"
 msgid "Swap UI fee"
 msgstr "스왑 UI 수수료"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "지갑 연결 중..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "익절매 주문 없음"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -482,6 +482,12 @@ msgstr ""
 msgid "Swap UI fee"
 msgstr ""
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr ""
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -482,6 +482,12 @@ msgstr "Процент"
 msgid "Swap UI fee"
 msgstr "Комиссия UI за своп"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "Подключение кошелька..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "Нет ордеров тейк-профит"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -482,6 +482,12 @@ msgstr "百分比"
 msgid "Swap UI fee"
 msgstr "兌換介面費用"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "正在連接錢包..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "無 TP 訂單"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -482,6 +482,12 @@ msgstr "百分比"
 msgid "Swap UI fee"
 msgstr "兑换界面费用"
 
+#: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+#: src/components/GmSwap/GmSwapBox/GmShiftBox/useShiftSubmitState.tsx
+#: src/components/TradeBox/hooks/useTradeButtonState.tsx
+msgid "Connecting wallet..."
+msgstr "正在连接钱包..."
+
 #: src/components/OrdersModal/TPSLOrdersList.tsx
 msgid "No TP orders"
 msgstr "无止盈订单"


### PR DESCRIPTION
## Summary
- On reload the app rendered "Connect wallet" in the header and in the forms until Privy finished restoring the session. wagmi does remember the last connection (`wagmi.store.current`), but wagmi 2.19 `createConfig` persists its empty initial state before hydration, and with the `ssr: true` that `@privy-io/wagmi` forces this wiped the marker on every load. `getWagmiConfig` now reads the persisted store before `createConfig` and `WalletProvider` hands it back through wagmi's own `initialState`; the spec covers it and notes when the workaround can be dropped.
- `useIsWalletInitializing` is true only while a remembered connection exists, wagmi has no account yet and Privy has not resolved its wallets. Visitors without a session still get "Connect wallet" on the first frame, and in-app Disconnect clears the marker, so nothing stays stuck in the loading state.
- Header: while the session is restored the button slot shows a skeleton shaped like the account button (same box, avatar circle and address bar, app skeleton shimmer), so the address replaces it without a layout shift.
- Trade, GM/GLV and shift submit buttons show a disabled "Connecting wallet..." during that window instead of a clickable "Connect wallet" (new string translated in all locales). Referrals tabs show their loader and Earn distributions hide the connect CTA meanwhile; Earn Portfolio already used the hook.

Linear: https://linear.app/gmx-io/issue/FEDEV-4253/bug-connect-wallet-flashes-while-restoring-a-connected-session-on

## CI
Audit is red on the vitest 3.2.6 advisory (GHSA-82fw-gwwq-j7x9, `yarn npm audit`). This PR changes no dependencies, and the same job fails on the other release-based PRs today. The bump to vitest 4.1.11 (#2844) landed on `master`, not on `release` yet, so the check stays red here until that reaches `release`.
