### PR TITLE
Limit the walletless support chat to the visit that opened it FEDEV-4291

### DIFF
--- a/src/config/localStorage.ts
+++ b/src/config/localStorage.ts
@@ -68,7 +68,6 @@ export const SUPPORT_CHAT_WAS_EVER_SHOWN_KEY = "support-chat-was-ever-shown";
 export const SUPPORT_CHAT_WAS_EVER_CLICKED_KEY = "support-chat-was-ever-clicked";
 export const SUPPORT_CHAT_USER_ID_KEY = "support-chat-user-id";
 export const SUPPORT_CHAT_LAST_CONNECTED_STATE_KEY = "support-chat-last-connected-state";
-export const SUPPORT_CHAT_WAS_OPENED_WITHOUT_WALLET_KEY = "support-chat-was-opened-without-wallet";
 
 export const METRICS_PENDING_EVENTS_KEY = "metrics-pending-events";
 export const METRICS_TIMERS_KEY = "metrics-timers-key";

--- a/src/domain/supportChat/constants.ts
+++ b/src/domain/supportChat/constants.ts
@@ -1,1 +1,2 @@
 export const INTERCOM_APP_ID = "blsw8a15";
+export const SUPPORT_CHAT_OPENED_WITHOUT_WALLET_SESSION_KEY = "support-chat-opened-without-wallet";

--- a/src/domain/supportChat/useShowSupportChat.ts
+++ b/src/domain/supportChat/useShowSupportChat.ts
@@ -1,10 +1,13 @@
 import { useEffect, useRef } from "react";
+import { useSessionStorage } from "react-use";
 import { useAccount } from "wagmi";
 
-import { SUPPORT_CHAT_LAST_CONNECTED_STATE_KEY, SUPPORT_CHAT_WAS_OPENED_WITHOUT_WALLET_KEY } from "config/localStorage";
+import { SUPPORT_CHAT_LAST_CONNECTED_STATE_KEY } from "config/localStorage";
 import { useLocalStorageSerializeKey } from "lib/localStorage";
 import useSearchParams from "lib/useSearchParams";
 import { useIsWalletInitializing } from "lib/wallets/useIsWalletInitializing";
+
+import { SUPPORT_CHAT_OPENED_WITHOUT_WALLET_SESSION_KEY } from "./constants";
 
 export function useShowSupportChat() {
   const { isConnected } = useAccount();
@@ -13,23 +16,29 @@ export function useShowSupportChat() {
     SUPPORT_CHAT_LAST_CONNECTED_STATE_KEY,
     false
   );
-  const [wasOpenedWithoutWallet, setWasOpenedWithoutWallet] = useLocalStorageSerializeKey<boolean>(
-    SUPPORT_CHAT_WAS_OPENED_WITHOUT_WALLET_KEY,
-    false
-  );
 
   const { openChat } = useSearchParams<{ openChat?: string }>();
   const shouldOpenChatOnBoot = useRef(Boolean(openChat)).current;
+  const [wasOpenedWithoutWallet, setWasOpenedWithoutWallet] = useSessionStorage<boolean>(
+    SUPPORT_CHAT_OPENED_WITHOUT_WALLET_SESSION_KEY,
+    shouldOpenChatOnBoot
+  );
 
   const showWhileConnecting = isWalletInitializing && lastConnectedState;
 
-  const shouldShowSupportChat = isConnected || showWhileConnecting || shouldOpenChatOnBoot || wasOpenedWithoutWallet;
+  const shouldShowSupportChat = isConnected || showWhileConnecting || wasOpenedWithoutWallet;
 
   useEffect(() => {
     if (shouldOpenChatOnBoot) {
       setWasOpenedWithoutWallet(true);
     }
   }, [shouldOpenChatOnBoot, setWasOpenedWithoutWallet]);
+
+  useEffect(() => {
+    if (isConnected) {
+      setWasOpenedWithoutWallet(false);
+    }
+  }, [isConnected, setWasOpenedWithoutWallet]);
 
   useEffect(() => {
     if (!isWalletInitializing) {


### PR DESCRIPTION
## Summary
- The sidebar Support button is meant for connected wallets, with one exception: a wallet-less visitor who arrives from "Contact us" on the Trader & Affiliate landing (`?openChat=1`). `8363601f` latched that exception in `localStorage` so it would survive a reload, but the latch never expired — after a single visit from the landing the button was shown to that browser profile forever, on every page, with no wallet connected.
- The latch now lives in `sessionStorage` (`support-chat-opened-without-wallet`): it survives SPA navigation and a full reload of the same tab, and it is gone in a new browser session. The old `localStorage` key is no longer read; the stale entry in existing profiles is simply ignored, so those users are fixed without clearing storage.
- The exception also ends the moment a wallet connects. It exists for visitors who have not connected yet; once they have, they are on the same footing as everyone else, so after connect → disconnect the button hides instead of lingering for the rest of the session.
- `shouldOpenChatOnBoot` is no longer a separate term in `shouldShowSupportChat` — it would have kept the button alive through connect → disconnect inside the same page load. It seeds the latch instead, so the button is present on the first painted frame of the arrival.

Linear: https://linear.app/gmx-io/issue/FEDEV-4291/support-button-stays-visible-without-a-wallet-after-one-visit-from-the

## Testing
Playwright stand against a local build, injected EIP-1193 wallet with SIWE signing, wallet-less unless stated:

| scenario | Support |
| -- | -- |
| first visit `?openChat=1` (latch is `"true"` in sessionStorage) | shown |
| SPA navigation afterwards | shown |
| full reload of the same tab | shown |
| tab closed and reopened (new session) | hidden |
| profile carrying the stale `localStorage` flag | hidden |
| after connecting a wallet (latch drops to `"false"`) | shown |
| wallet disconnected in the same tab | hidden |
| disconnected, then reloaded | hidden |

The in-app Disconnect button was exercised at the wallet level (`accountsChanged: []`), because on `release` it also runs into FEDEV-4253, where `showWhileConnecting` keeps the button after an in-app disconnect; that one is fixed separately in #2845.

## CI
Audit is red on the vitest 3.2.6 advisory (GHSA-82fw-gwwq-j7x9, `yarn npm audit`), the same failure the other release-based PRs see today. This PR touches three source files and no dependencies. The bump to vitest 4.1.11 (#2844) is on `master`, not on `release`, so the check stays red here until that reaches `release`. Everything else is green: lint/types/tests, component tests, SDK build, both Cloudflare Pages builds.
