### PR TITLE
Hotfix: send an unconditional Environment property to Intercom FEDEV-4289

### DIFF
--- a/src/domain/supportChat/useSupportChat.ts
+++ b/src/domain/supportChat/useSupportChat.ts
@@ -115,6 +115,7 @@ export function useSupportChat() {
       hide_default_launcher: true,
       hide_notifications: false,
       user_id: supportChatUserId,
+      Environment: "EVM",
       // theme goes into the boot settings: update({ theme_mode }) during the boot window
       // suppresses the initial unread count delivery in the Intercom widget
       theme_mode: themeToIntercomTheme(themeModeRef.current),


### PR DESCRIPTION
## Why

FEDEV-4289 is Urgent and already merged into `release` (#2834), but the next UI release is days away. Support requests from the GMX app and from GM Trade land in the same Intercom inbox with nothing on the conversation saying which app the person was using — agents infer it from context and risk answering with the wrong chain's mechanics. GM Trade already sends `Environment: SOLANA` on their side, so until this ships to production the EVM half of the inbox stays untagged.

## What

Cherry-pick of `74603fb` from #2834, one line, no adaptation:

- `Environment: "EVM"` in the Intercom boot settings in `useSupportChat` (the object passed to `Intercom()` on first init and to `boot()` after `shutdown()`). It goes out in the very first `ping` for every user who has the messenger at all: wallet connected or not (`?openChat=1` / "opened without wallet" flag), before volumes, portfolio and wallet type have loaded.
- The wallet-dependent attributes (Tier, volumes, Active Network, Wallet Type, Trading Mode) keep going through the existing `update()` call, which is untouched; `update()` merges attributes on the user, so `Environment` is not cleared.
- Deliberately not sent as a separate `update({ Environment })` after boot: an `update()` inside the boot window suppresses the initial unread-count delivery (documented in the same hook).

## No merge conflict with release

`src/domain/supportChat/` has not been touched on `master` since the branches diverged, so after this hotfix the file is byte-identical on both branches. Both future merges were simulated locally with `git merge-tree`: `release -> master` and `master -> release` each apply cleanly and produce the same tree (`ef4f642`) — git sees one identical change on both sides, not two competing ones. The open support-chat PR on `release` (#2847) touches `constants.ts` / `useShowSupportChat.ts` / `localStorage.ts`, not this file.

## Verification

Verified on #2834 with headed Chromium on a fresh profile without a wallet: the outgoing `POST /messenger/web/ping` carries `user_data={"user_id":"…","Environment":"EVM"}`, `source=apiBoot`. The commit here is identical to the one that passed review and merged into `release`.

Linear: https://linear.app/gmx-io/issue/FEDEV-4289/send-an-unconditional-environment-property-to-intercom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwZLjqxssqqSCAkBeJ1Uop
