### PR TITLE
Keep stats figures consistent when a source is unavailable

### DIFF
--- a/src/components/StatsTooltip/ChainsStatsTooltip.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltip.tsx
@@ -1,0 +1,58 @@
+import cx from "classnames";
+import { ReactNode } from "react";
+
+import { USD_DECIMALS } from "config/factors";
+import { formatAmountHuman } from "lib/numbers";
+
+import TooltipComponent from "components/Tooltip/Tooltip";
+
+import ChainsStatsTooltipRow from "./ChainsStatsTooltipRow";
+import { summarizeChainsStats, type ChainsStatsEntries } from "./summarizeChainsStats";
+
+type Props = {
+  entries: ChainsStatsEntries;
+  staleTitles?: string[];
+  caption?: ReactNode;
+  subtotal?: ReactNode;
+  showDollar?: boolean;
+  decimalsForConversion?: number;
+};
+
+// the figure and its breakdown are drawn from one summary, so they cannot disagree about the total
+export default function ChainsStatsTooltip({
+  entries,
+  staleTitles,
+  caption,
+  subtotal,
+  showDollar = true,
+  decimalsForConversion = USD_DECIMALS,
+}: Props) {
+  const summary = summarizeChainsStats(entries);
+
+  return (
+    <TooltipComponent
+      position="bottom-end"
+      className={caption ? undefined : "whitespace-nowrap"}
+      handle={formatAmountHuman(summary.total, decimalsForConversion, showDollar, 2)}
+      handleClassName={cx("numbers", { "text-yellow-300": summary.missingTitles.length > 0 })}
+      content={
+        <>
+          {caption && (
+            <>
+              {caption}
+              <br />
+              <br />
+            </>
+          )}
+          <ChainsStatsTooltipRow
+            summary={summary}
+            staleTitles={staleTitles}
+            subtotal={subtotal}
+            showDollar={showDollar}
+            decimalsForConversion={decimalsForConversion}
+          />
+        </>
+      }
+    />
+  );
+}

--- a/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
+++ b/src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
@@ -4,81 +4,49 @@ import { ReactNode } from "react";
 import { USD_DECIMALS } from "config/factors";
 import { formatAmountHuman } from "lib/numbers";
 
+import type { ChainsStatsSummary } from "./summarizeChainsStats";
+
 import "./StatsTooltip.css";
-
-type EntryValue = bigint | number | string | undefined;
-
-function isKnown(value: EntryValue) {
-  return value !== undefined && value !== null;
-}
-
-function amountOf(value: EntryValue): bigint {
-  return BigInt(value || 0);
-}
 
 function Notice({ children }: { children: ReactNode }) {
   return <p className="Tooltip-row !mt-8 max-w-[260px] whitespace-normal text-yellow-300">{children}</p>;
 }
 
 type Props = {
-  entries: { [key: string]: EntryValue };
+  summary: ChainsStatsSummary;
   showDollar?: boolean;
   decimalsForConversion?: number;
-  symbol?: string;
   subtotal?: ReactNode;
   staleTitles?: string[];
 };
 
 export default function ChainsStatsTooltipRow({
-  entries,
+  summary: { knownEntries, missingTitles, total },
   showDollar = true,
   decimalsForConversion = USD_DECIMALS,
-  symbol,
   subtotal,
   staleTitles = [],
 }: Props) {
-  const allEntries = Object.entries(entries);
-
-  // an entry that has not answered yet is named below the total rather than summed as zero
-  const knownEntries = allEntries
-    .filter(([, value]) => isKnown(value))
-    .sort(([, left], [, right]) => {
-      const a = amountOf(left);
-      const b = amountOf(right);
-
-      return a === b ? 0 : a > b ? -1 : 1;
-    });
-  const missingTitles = allEntries.filter(([, value]) => !isKnown(value)).map(([title]) => title);
-  const total = knownEntries.reduce((acc, [, value]) => acc + amountOf(value), 0n);
-
   if (knownEntries.length === 0) {
     return null;
   }
 
   return (
     <>
-      {knownEntries.map(([title, value]) => {
-        return (
-          <p key={title} className="Tooltip-row">
-            <span className="label">
-              <Trans>{title}</Trans>:{" "}
-            </span>
-            <span className="amount">
-              {formatAmountHuman(value, decimalsForConversion, showDollar, 2)}
-              {!showDollar && symbol && " " + symbol}
-            </span>
-          </p>
-        );
-      })}
+      {knownEntries.map(([title, value]) => (
+        <p key={title} className="Tooltip-row">
+          <span className="label">
+            <Trans>{title}</Trans>:{" "}
+          </span>
+          <span className="amount">{formatAmountHuman(value, decimalsForConversion, showDollar, 2)}</span>
+        </p>
+      ))}
       <div className="my-5 h-1 bg-gray-800" />
       <p className="Tooltip-row">
         <span className="label">
           <Trans>Total</Trans>:{" "}
         </span>
-        <span className="amount">
-          {formatAmountHuman(total, decimalsForConversion, showDollar, 2)}
-          {!showDollar && symbol && " " + symbol}
-        </span>
+        <span className="amount">{formatAmountHuman(total, decimalsForConversion, showDollar, 2)}</span>
       </p>
       {missingTitles.length > 0 && (
         <Notice>

--- a/src/components/StatsTooltip/summarizeChainsStats.spec.ts
+++ b/src/components/StatsTooltip/summarizeChainsStats.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeChainsStats } from "./summarizeChainsStats";
+
+describe("summarizeChainsStats", () => {
+  it("sums every known network and orders them highest first", () => {
+    expect(summarizeChainsStats({ Arbitrum: 5n, Avalanche: 9n, Solana: 1n })).toEqual({
+      knownEntries: [
+        ["Avalanche", 9n],
+        ["Arbitrum", 5n],
+        ["Solana", 1n],
+      ],
+      missingTitles: [],
+      total: 15n,
+    });
+  });
+
+  it("names a network that has not answered and leaves it out of the total", () => {
+    const summary = summarizeChainsStats({ Arbitrum: undefined, Avalanche: 9n, Solana: 1n });
+
+    expect(summary.total).toBe(10n);
+    expect(summary.missingTitles).toEqual(["Arbitrum"]);
+  });
+
+  it("keeps a real zero as a known value", () => {
+    const summary = summarizeChainsStats({ MegaETH: 0n, Solana: 1n });
+
+    expect(summary.missingTitles).toEqual([]);
+    expect(summary.knownEntries).toContainEqual(["MegaETH", 0n]);
+  });
+
+  it("reports no total until at least one network has answered", () => {
+    expect(summarizeChainsStats({ Arbitrum: undefined, Solana: undefined }).total).toBeUndefined();
+  });
+});

--- a/src/components/StatsTooltip/summarizeChainsStats.ts
+++ b/src/components/StatsTooltip/summarizeChainsStats.ts
@@ -1,0 +1,36 @@
+export type ChainsStatsValue = bigint | number | string | undefined;
+
+export type ChainsStatsEntries = { [title: string]: ChainsStatsValue };
+
+export type ChainsStatsSummary = {
+  knownEntries: [string, ChainsStatsValue][];
+  missingTitles: string[];
+  total: bigint | undefined;
+};
+
+function isKnown(value: ChainsStatsValue) {
+  return value !== undefined && value !== null;
+}
+
+function amountOf(value: ChainsStatsValue): bigint {
+  return BigInt(value || 0);
+}
+
+// a network that has not answered is named below the total rather than summed as zero
+export function summarizeChainsStats(entries: ChainsStatsEntries): ChainsStatsSummary {
+  const allEntries = Object.entries(entries);
+
+  const knownEntries = allEntries
+    .filter(([, value]) => isKnown(value))
+    .sort(([, left], [, right]) => {
+      const a = amountOf(left);
+      const b = amountOf(right);
+
+      return a === b ? 0 : a > b ? -1 : 1;
+    });
+  const missingTitles = allEntries.filter(([, value]) => !isKnown(value)).map(([title]) => title);
+  const total =
+    knownEntries.length === 0 ? undefined : knownEntries.reduce((acc, [, value]) => acc + amountOf(value), 0n);
+
+  return { knownEntries, missingTitles, total };
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -194,11 +194,6 @@ msgstr "GMX Account-Swaps können kein natives {0} verwenden. Wählen Sie {1} od
 msgid "Include rPnL in leverage display"
 msgstr "rPnL in Hebelanzeige einbeziehen"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "Orders ({0})"
@@ -2002,8 +1997,6 @@ msgstr "Affiliate-Adresse:"
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "Frist:"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "Verbunden mit {sourceChainName}"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -194,11 +194,6 @@ msgstr "GMX Account swaps cannot use native {0}. Select {1} or withdraw to walle
 msgid "Include rPnL in leverage display"
 msgstr "Include rPnL in leverage display"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "Orders ({0})"
@@ -2002,8 +1997,6 @@ msgstr "Affiliate address:"
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "Deadline:"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "Connected to {sourceChainName}"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -194,11 +194,6 @@ msgstr "Los swaps de GMX Account no pueden usar {0} nativo. Seleccione {1} o ret
 msgid "Include rPnL in leverage display"
 msgstr "Incluir rPnL en la visualización de apalancamiento"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "Órdenes ({0})"
@@ -2002,8 +1997,6 @@ msgstr "Dirección del afiliado:"
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "Fecha límite:"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "Conectado a {sourceChainName}"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -194,11 +194,6 @@ msgstr "Les swaps GMX Account ne peuvent pas utiliser le {0} natif. Sélectionne
 msgid "Include rPnL in leverage display"
 msgstr "Inclure le rPnL dans l'affichage de l'effet de levier"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "Ordres ({0})"
@@ -2002,8 +1997,6 @@ msgstr "Adresse de l'affilié :"
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "Date limite :"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "Connecté à {sourceChainName}"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -194,11 +194,6 @@ msgstr "GMX Accountのスワップではネイティブの{0}を使用できま�
 msgid "Include rPnL in leverage display"
 msgstr "レバレッジ表示にrPnLを含める"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "注文 ({0})"
@@ -2002,8 +1997,6 @@ msgstr "アフィリエイトアドレス:"
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "有効期限:"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "{sourceChainName}に接続済み"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -194,11 +194,6 @@ msgstr "GMX Account 스왑에서는 네이티브 {0}을(를) 사용할 수 없�
 msgid "Include rPnL in leverage display"
 msgstr "레버리지 표시에 실현 PnL 포함"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "주문 ({0})"
@@ -2002,8 +1997,6 @@ msgstr "추천인 주소:"
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "마감 기한:"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "{sourceChainName}에 연결됨"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -194,11 +194,6 @@ msgstr ""
 msgid "Include rPnL in leverage display"
 msgstr ""
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr ""
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr ""
@@ -2002,8 +1997,6 @@ msgstr ""
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4366,11 +4359,6 @@ msgstr ""
 
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
-msgstr ""
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
 msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -194,11 +194,6 @@ msgstr "Свопы GMX Account не могут использовать нати
 msgid "Include rPnL in leverage display"
 msgstr "Включить rPnL в отображение кредитного плеча"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "Ордера ({0})"
@@ -2002,8 +1997,6 @@ msgstr "Адрес аффилиата:"
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "Срок действия:"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "Подключено к {sourceChainName}"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -194,11 +194,6 @@ msgstr "GMX Account 交換無法使用原生 {0}。請選擇 {1}，或先提取�
 msgid "Include rPnL in leverage display"
 msgstr "在槓桿顯示中包含已實現盈虧"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "訂單 ({0})"
@@ -2002,8 +1997,6 @@ msgstr "推廣夥伴地址："
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "截止時間："
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "已連接至 {sourceChainName}"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -194,11 +194,6 @@ msgstr "GMX Account 交换无法使用原生 {0}。请选择 {1}，或先提取�
 msgid "Include rPnL in leverage display"
 msgstr "在杠杆显示中包含已实现 PnL"
 
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Arbitrum"
-msgstr "Arbitrum"
-
 #: src/components/PositionItem/PositionItemOrders.tsx
 msgid "Orders ({0})"
 msgstr "订单 ({0})"
@@ -2002,8 +1997,6 @@ msgstr "推广者地址："
 #: src/components/Referrals/shared/TimeRangeFilter.tsx
 #: src/components/StatsTooltip/ChainsStatsTooltipRow.tsx
 #: src/pages/Dashboard/GmxCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4367,11 +4360,6 @@ msgstr "截止时间："
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Connected to {sourceChainName}"
 msgstr "已连接到 {sourceChainName}"
-
-#: src/pages/Dashboard/OverviewCard.tsx
-#: src/pages/Dashboard/OverviewCard.tsx
-msgid "Avalanche"
-msgstr "Avalanche"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"

--- a/src/pages/Dashboard/OverviewCard.tsx
+++ b/src/pages/Dashboard/OverviewCard.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 
@@ -21,33 +21,12 @@ import useWallet from "lib/wallets/useWallet";
 import { bigMath } from "sdk/utils/bigmath";
 
 import { AppCard, AppCardSection, AppCardSplit } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
-import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
-import TooltipComponent from "components/Tooltip/Tooltip";
+import ChainsStatsTooltip from "components/StatsTooltip/ChainsStatsTooltip";
 
 import { ACTIVE_CHAIN_IDS } from "./DashboardV2";
 import { getFormattedFeesDuration } from "./getFormattedFeesDuration";
 import { getPositionStats } from "./getPositionStats";
 import type { ChainStats } from "./useDashboardChainStatsMulticall";
-
-type NetworkRow = { label: string; value: bigint | undefined };
-
-// highest first, with a network whose value has not arrived yet kept last rather than ordered as zero
-function sortNetworkRows(rows: NetworkRow[]): NetworkRow[] {
-  return [...rows].sort((a, b) => {
-    if (a.value === b.value) {
-      return 0;
-    }
-    if (a.value === undefined) {
-      return 1;
-    }
-    if (b.value === undefined) {
-      return -1;
-    }
-
-    return a.value > b.value ? -1 : 1;
-  });
-}
 
 const SOLANA_ENTRY = "Solana";
 
@@ -132,34 +111,25 @@ export function OverviewCard({
   // the store carries position collateral the way the EVM figures do, which the pool value on its own leaves out
   const displayTvlGmtrade = parseProtocolStatsUsd(gmtradeOverview?.tvl?.store) ?? gmTvlGmtrade;
 
-  const totalGmTvl = sumKnownBigInts(gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade);
+  const getStakedGmxUsd = (stakedGmx: bigint | undefined) =>
+    gmxPrice !== undefined && stakedGmx !== undefined
+      ? bigMath.mulDiv(gmxPrice, stakedGmx, expandDecimals(1, GMX_DECIMALS))
+      : undefined;
 
-  let displayTvlArbitrum: bigint | undefined = undefined;
-  let displayTvlAvalanche: bigint | undefined = undefined;
-  let displayTvlMegaeth: bigint | undefined = undefined;
-  let displayTvl: bigint | undefined = undefined;
-  if (
-    gmxPrice !== undefined &&
-    stakedGmxArbitrum !== undefined &&
-    stakedGmxAvalanche !== undefined &&
-    glpMarketCapArbitrum !== undefined &&
-    glpMarketCapAvalanche !== undefined &&
-    arbitrumPositionsMarginUsd !== undefined &&
-    avalanchePositionsMarginUsd !== undefined &&
-    megaethPositionsMarginUsd !== undefined &&
-    gmTvlArbitrum !== undefined &&
-    gmTvlAvalanche !== undefined &&
-    gmTvlMegaeth !== undefined
-  ) {
-    const stakedGmxUsdArbitrum = bigMath.mulDiv(gmxPrice, stakedGmxArbitrum, expandDecimals(1, GMX_DECIMALS));
-    const stakedGmxUsdAvalanche = bigMath.mulDiv(gmxPrice, stakedGmxAvalanche, expandDecimals(1, GMX_DECIMALS));
-
-    // GMX Staked + GLP Pools + GM Pools
-    displayTvlArbitrum = stakedGmxUsdArbitrum + glpMarketCapArbitrum + gmTvlArbitrum + arbitrumPositionsMarginUsd;
-    displayTvlAvalanche = stakedGmxUsdAvalanche + glpMarketCapAvalanche + gmTvlAvalanche + avalanchePositionsMarginUsd;
-    displayTvlMegaeth = gmTvlMegaeth + megaethPositionsMarginUsd;
-    displayTvl = sumKnownBigInts(displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, displayTvlGmtrade);
-  }
+  // GMX staked + GLP pools + GM pools + position collateral, each network from its own inputs only
+  const displayTvlArbitrum = sumKnownBigInts(
+    getStakedGmxUsd(stakedGmxArbitrum),
+    glpMarketCapArbitrum,
+    gmTvlArbitrum,
+    arbitrumPositionsMarginUsd
+  );
+  const displayTvlAvalanche = sumKnownBigInts(
+    getStakedGmxUsd(stakedGmxAvalanche),
+    glpMarketCapAvalanche,
+    gmTvlAvalanche,
+    avalanchePositionsMarginUsd
+  );
+  const displayTvlMegaeth = sumKnownBigInts(gmTvlMegaeth, megaethPositionsMarginUsd);
 
   // #endregion TVL and GLP Pool
 
@@ -168,19 +138,8 @@ export function OverviewCard({
   const v1ArbitrumDailyVolume = v1DailyVolumeInfo?.[ARBITRUM];
   const v1AvalancheDailyVolume = v1DailyVolumeInfo?.[AVALANCHE];
 
-  const v2ArbitrumDailyVolume = v2ArbitrumOverview.dailyVolume;
-  const v2AvalancheDailyVolume = v2AvalancheOverview.dailyVolume;
-  const v2MegaethDailyVolume = v2MegaethOverview.dailyVolume;
   const gmtradeDailyVolume = parseProtocolStatsUsd(gmtradeOverview?.volume24h?.total);
 
-  const totalDailyVolume = sumBigInts(
-    v1ArbitrumDailyVolume,
-    v1AvalancheDailyVolume,
-    v2ArbitrumDailyVolume,
-    v2AvalancheDailyVolume,
-    v2MegaethDailyVolume,
-    gmtradeDailyVolume
-  );
   // #endregion Daily Volume
 
   // #region Open Interest
@@ -191,14 +150,6 @@ export function OverviewCard({
   const v2MegaethOpenInterest = v2MegaethOverview.openInterest;
   const gmtradeOpenInterest = parseProtocolStatsUsd(gmtradeOverview?.openInterest?.total);
 
-  const totalOpenInterest = sumBigInts(
-    v1ArbitrumOpenInterest,
-    v1AvalancheOpenInterest,
-    v2ArbitrumOpenInterest,
-    v2AvalancheOpenInterest,
-    v2MegaethOpenInterest,
-    gmtradeOpenInterest
-  );
   // #endregion Open Interest
 
   // #region Long Position Sizes
@@ -210,14 +161,6 @@ export function OverviewCard({
   const v2MegaethLongPositionSizes = v2MegaethOverview.totalLongPositionSizes;
   const gmtradeLongPositionSizes = parseProtocolStatsUsd(gmtradeOverview?.openInterest?.long);
 
-  const totalLongPositionSizes = sumBigInts(
-    v1ArbitrumLongPositionSizes,
-    v1AvalancheLongPositionSizes,
-    v2ArbitrumLongPositionSizes,
-    v2AvalancheLongPositionSizes,
-    v2MegaethLongPositionSizes,
-    gmtradeLongPositionSizes
-  );
   // #endregion Long Position Sizes
 
   // #region Short Position Sizes
@@ -229,14 +172,6 @@ export function OverviewCard({
   const v2MegaethShortPositionSizes = v2MegaethOverview.totalShortPositionSizes;
   const gmtradeShortPositionSizes = parseProtocolStatsUsd(gmtradeOverview?.openInterest?.short);
 
-  const totalShortPositionSizes = sumBigInts(
-    v1ArbitrumShortPositionSizes,
-    v1AvalancheShortPositionSizes,
-    v2ArbitrumShortPositionSizes,
-    v2AvalancheShortPositionSizes,
-    v2MegaethShortPositionSizes,
-    gmtradeShortPositionSizes
-  );
   // #endregion Short Position Sizes
 
   // #region Fees
@@ -247,15 +182,6 @@ export function OverviewCard({
   const v2AvalancheEpochFees = v2AvalancheOverview?.epochFees;
   const v2MegaethEpochFees = v2MegaethOverview?.epochFees;
   const gmtradeEpochFees = gmtradeFees?.epochFees;
-
-  const totalEpochFeesUsd = sumBigInts(
-    v1ArbitrumEpochFees,
-    v1AvalancheEpochFees,
-    v2ArbitrumEpochFees,
-    v2AvalancheEpochFees,
-    v2MegaethEpochFees,
-    gmtradeEpochFees
-  );
 
   const v1ArbitrumWeeklyFees = v1ArbitrumFees?.weeklyFees;
   const v1AvalancheWeeklyFees = v1AvalancheFees?.weeklyFees;
@@ -361,25 +287,23 @@ export function OverviewCard({
     ]
   );
 
-  const tvlRows = useMemo(
-    () =>
-      sortNetworkRows([
-        { label: t`Arbitrum`, value: displayTvlArbitrum },
-        { label: t`Avalanche`, value: displayTvlAvalanche },
-        { label: "MegaETH", value: displayTvlMegaeth },
-        { label: "Solana", value: displayTvlGmtrade },
-      ]),
+  const tvlEntries = useMemo(
+    () => ({
+      Arbitrum: displayTvlArbitrum,
+      Avalanche: displayTvlAvalanche,
+      MegaETH: displayTvlMegaeth,
+      [SOLANA_ENTRY]: displayTvlGmtrade,
+    }),
     [displayTvlArbitrum, displayTvlAvalanche, displayTvlMegaeth, displayTvlGmtrade]
   );
 
-  const gmPoolRows = useMemo(
-    () =>
-      sortNetworkRows([
-        { label: t`Arbitrum`, value: gmTvlArbitrum },
-        { label: t`Avalanche`, value: gmTvlAvalanche },
-        { label: "MegaETH", value: gmTvlMegaeth },
-        { label: "Solana", value: gmTvlGmtrade },
-      ]),
+  const gmPoolEntries = useMemo(
+    () => ({
+      Arbitrum: gmTvlArbitrum,
+      Avalanche: gmTvlAvalanche,
+      MegaETH: gmTvlMegaeth,
+      [SOLANA_ENTRY]: gmTvlGmtrade,
+    }),
     [gmTvlArbitrum, gmTvlAvalanche, gmTvlMegaeth, gmTvlGmtrade]
   );
 
@@ -443,19 +367,7 @@ export function OverviewCard({
                 <Trans>Fees for the past</Trans> {formattedDuration}
               </div>
               <div>
-                <TooltipComponent
-                  position="bottom-end"
-                  className="whitespace-nowrap"
-                  handle={formatAmountHuman(totalEpochFeesUsd, USD_DECIMALS, true, 2)}
-                  handleClassName="numbers"
-                  content={
-                    <ChainsStatsTooltipRow
-                      entries={epochFeesEntries}
-                      subtotal={feesSubtotal}
-                      staleTitles={staleTitles}
-                    />
-                  }
-                />
+                <ChainsStatsTooltip entries={epochFeesEntries} subtotal={feesSubtotal} staleTitles={staleTitles} />
               </div>
             </div>
             <div className="App-card-row">
@@ -463,31 +375,10 @@ export function OverviewCard({
                 <Trans>TVL</Trans>
               </div>
               <div>
-                <TooltipComponent
-                  handle={formatAmountHuman(displayTvl, USD_DECIMALS, true, 2)}
-                  handleClassName="numbers"
-                  position="bottom-end"
-                  content={
-                    <>
-                      <Trans>TVL includes GMX staked, GM pools, and position collateral</Trans>
-                      <br />
-                      <br />
-                      {tvlRows.map(({ label, value }) => (
-                        <StatsTooltipRow
-                          key={label}
-                          label={label}
-                          showDollar={false}
-                          value={formatAmountHuman(value, USD_DECIMALS, true, 2)}
-                        />
-                      ))}
-                      <div className="!my-8 h-1 bg-gray-800" />
-                      <StatsTooltipRow
-                        label={t`Total`}
-                        showDollar={false}
-                        value={formatAmountHuman(displayTvl, USD_DECIMALS, true, 2)}
-                      />
-                    </>
-                  }
+                <ChainsStatsTooltip
+                  entries={tvlEntries}
+                  staleTitles={staleTitles}
+                  caption={<Trans>TVL includes GMX staked, GM pools, and position collateral</Trans>}
                 />
               </div>
             </div>
@@ -496,31 +387,10 @@ export function OverviewCard({
                 <Trans>GM pools</Trans>
               </div>
               <div>
-                <TooltipComponent
-                  handle={formatAmountHuman(totalGmTvl, USD_DECIMALS, true, 2)}
-                  handleClassName="numbers"
-                  position="bottom-end"
-                  content={
-                    <>
-                      <Trans>Total value of tokens in GM pools</Trans>
-                      <br />
-                      <br />
-                      {gmPoolRows.map(({ label, value }) => (
-                        <StatsTooltipRow
-                          key={label}
-                          label={label}
-                          showDollar={false}
-                          value={formatAmountHuman(value, USD_DECIMALS, true, 2)}
-                        />
-                      ))}
-                      <div className="!my-8 h-1 bg-gray-800" />
-                      <StatsTooltipRow
-                        label={t`Total`}
-                        showDollar={false}
-                        value={formatAmountHuman(totalGmTvl, USD_DECIMALS, true, 2)}
-                      />
-                    </>
-                  }
+                <ChainsStatsTooltip
+                  entries={gmPoolEntries}
+                  staleTitles={staleTitles}
+                  caption={<Trans>Total value of tokens in GM pools</Trans>}
                 />
               </div>
             </div>
@@ -533,13 +403,7 @@ export function OverviewCard({
                 <Trans>24h volume</Trans>
               </div>
               <div>
-                <TooltipComponent
-                  position="bottom-end"
-                  className="whitespace-nowrap"
-                  handle={formatAmountHuman(totalDailyVolume, USD_DECIMALS, true, 2)}
-                  handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={dailyVolumeEntries} staleTitles={staleTitles} />}
-                />
+                <ChainsStatsTooltip entries={dailyVolumeEntries} staleTitles={staleTitles} />
               </div>
             </div>
             <div className="App-card-row">
@@ -547,13 +411,7 @@ export function OverviewCard({
                 <Trans>Open interest</Trans>
               </div>
               <div>
-                <TooltipComponent
-                  position="bottom-end"
-                  className="whitespace-nowrap"
-                  handle={formatAmountHuman(totalOpenInterest, USD_DECIMALS, true, 2)}
-                  handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={openInterestEntries} staleTitles={staleTitles} />}
-                />
+                <ChainsStatsTooltip entries={openInterestEntries} staleTitles={staleTitles} />
               </div>
             </div>
             <div className="App-card-row">
@@ -561,13 +419,7 @@ export function OverviewCard({
                 <Trans>Long positions</Trans>
               </div>
               <div>
-                <TooltipComponent
-                  position="bottom-end"
-                  className="whitespace-nowrap"
-                  handle={formatAmountHuman(totalLongPositionSizes, USD_DECIMALS, true, 2)}
-                  handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={totalLongPositionSizesEntries} staleTitles={staleTitles} />}
-                />
+                <ChainsStatsTooltip entries={totalLongPositionSizesEntries} staleTitles={staleTitles} />
               </div>
             </div>
             <div className="App-card-row">
@@ -575,13 +427,7 @@ export function OverviewCard({
                 <Trans>Short positions</Trans>
               </div>
               <div>
-                <TooltipComponent
-                  position="bottom-end"
-                  className="whitespace-nowrap"
-                  handle={formatAmountHuman(totalShortPositionSizes, USD_DECIMALS, true, 2)}
-                  handleClassName="numbers"
-                  content={<ChainsStatsTooltipRow entries={totalShortPositionSizesEntries} staleTitles={staleTitles} />}
-                />
+                <ChainsStatsTooltip entries={totalShortPositionSizesEntries} staleTitles={staleTitles} />
               </div>
             </div>
           </AppCardSection>

--- a/src/pages/Dashboard/StatsCard.tsx
+++ b/src/pages/Dashboard/StatsCard.tsx
@@ -10,14 +10,13 @@ import { useTreasuryAllChains } from "domain/stats/treasury/useTreasuryAllChains
 import useUniqueUsers from "domain/stats/useUniqueUsers";
 import useV2Stats from "domain/synthetics/stats/useV2Stats";
 import { formatAmountHuman } from "lib/numbers";
-import { sumBigInts, sumKnownBigInts } from "lib/sumBigInts";
+import { sumKnownBigInts } from "lib/sumBigInts";
 import { MARKETS } from "sdk/configs/markets";
 import { getTokenBySymbol } from "sdk/configs/tokens";
 
 import { AppCard, AppCardSection } from "components/AppCard/AppCard";
-import ChainsStatsTooltipRow from "components/StatsTooltip/ChainsStatsTooltipRow";
+import ChainsStatsTooltip from "components/StatsTooltip/ChainsStatsTooltip";
 import StatsTooltipRow from "components/StatsTooltip/StatsTooltipRow";
-import TooltipComponent from "components/Tooltip/Tooltip";
 import TooltipWithPortal from "components/Tooltip/TooltipWithPortal";
 
 const chains: ContractsChainIdProduction[] = [ARBITRUM, AVALANCHE, MEGAETH];
@@ -52,14 +51,6 @@ export function StatsCard() {
 
   const v1ArbitrumTotalFees = useV1FeesInfo(ARBITRUM);
   const v1AvalancheTotalFees = useV1FeesInfo(AVALANCHE);
-  const totalFeesUsd = sumBigInts(
-    v1ArbitrumTotalFees?.totalFees,
-    v1AvalancheTotalFees?.totalFees,
-    v2ArbitrumOverview.totalFees,
-    v2AvalancheOverview.totalFees,
-    v2MegaethOverview.totalFees,
-    gmtradeTotalFees
-  );
 
   // #endregion Fees
 
@@ -140,13 +131,7 @@ export function StatsCard() {
             <Trans>Fees</Trans>
           </div>
           <div>
-            <TooltipComponent
-              position="bottom-end"
-              className="whitespace-nowrap"
-              handle={formatAmountHuman(totalFeesUsd, USD_DECIMALS, true, 2)}
-              handleClassName="numbers"
-              content={<ChainsStatsTooltipRow entries={totalFeesEntries} staleTitles={staleTitles} />}
-            />
+            <ChainsStatsTooltip entries={totalFeesEntries} staleTitles={staleTitles} />
           </div>
         </div>
         <div className="App-card-row">
@@ -154,26 +139,7 @@ export function StatsCard() {
             <Trans>Volume</Trans>
           </div>
           <div>
-            <TooltipComponent
-              position="bottom-end"
-              className="whitespace-nowrap"
-              handle={formatAmountHuman(
-                sumBigInts(
-                  v1TotalVolume?.[ARBITRUM],
-                  v1TotalVolume?.[AVALANCHE],
-                  v1TotalVolume?.[MEGAETH],
-                  v2ArbitrumOverview?.totalVolume,
-                  v2AvalancheOverview?.totalVolume,
-                  v2MegaethOverview?.totalVolume,
-                  gmtradeTotalVolume
-                ),
-                USD_DECIMALS,
-                true,
-                2
-              )}
-              handleClassName="numbers"
-              content={<ChainsStatsTooltipRow entries={totalVolumeEntries} staleTitles={staleTitles} />}
-            />
+            <ChainsStatsTooltip entries={totalVolumeEntries} staleTitles={staleTitles} />
           </div>
         </div>
         <div className="App-card-row">
@@ -181,32 +147,11 @@ export function StatsCard() {
             <Trans>Users</Trans>
           </div>
           <div>
-            <TooltipComponent
-              position="bottom-end"
-              className="whitespace-nowrap"
-              handle={formatAmountHuman(
-                sumBigInts(
-                  uniqueUsers?.[ARBITRUM],
-                  uniqueUsers?.[AVALANCHE],
-                  uniqueUsers?.[MEGAETH],
-                  v2ArbitrumOverview?.totalUsers,
-                  v2AvalancheOverview?.totalUsers,
-                  v2MegaethOverview?.totalUsers,
-                  gmtradeUsers
-                ),
-                0,
-                false,
-                2
-              )}
-              handleClassName="numbers"
-              content={
-                <ChainsStatsTooltipRow
-                  showDollar={false}
-                  entries={uniqueUsersEntries}
-                  decimalsForConversion={0}
-                  staleTitles={staleTitles}
-                />
-              }
+            <ChainsStatsTooltip
+              entries={uniqueUsersEntries}
+              staleTitles={staleTitles}
+              showDollar={false}
+              decimalsForConversion={0}
             />
           </div>
         </div>


### PR DESCRIPTION
FEDEV-4312.

A figure and its hover breakdown were summed from different inputs, so they disagreed when a source was missing, and one network's missing position collateral blanked the TVL of three. Each figure now comes from the same summary as its breakdown and turns yellow while a network is missing.